### PR TITLE
Registration sets a password, and that is how you sign in

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -29,13 +29,26 @@ PASSKEY_RP_ID="localhost"
 PASSKEY_RP_NAME="Pretty Please Print"
 
 # --- the one admin, created on first start and kept in step after that ---
+#
+# There is no ADMIN_PASSWORD, deliberately. A password here would also be in
+# `docker inspect`, in the shell history that wrote this file, and in every
+# backup of the host — still valid months later. Instead the migrator prints a
+# one-use link on first start:
+#
+#   docker compose -f docker-compose.prod.yml logs migrate
+#
+# Open it within 30 minutes to choose a username and a password. Lost it?
+# Re-run the migrator and it prints a fresh one, as long as no password has
+# been set yet.
 ADMIN_EMAIL="you@example.org"
 ADMIN_NAME="Your Name"
 
-# --- mail (optional) ---
-# Leave BOTH unset and the app still works: invitations and recovery links are
-# shown to the admin to hand over instead of being emailed. Mail is only ever
-# used for authentication here — notifications are in-app.
+# --- mail (genuinely optional) ---
+# Nothing in the running system needs it. People sign in with a username and
+# a password, and notifications are in-app. Mail only ever carries a link —
+# an invitation, or a password reset — and with no transport configured the
+# admin is shown that link on screen to hand over instead. Same token, same
+# single use, same expiry either way.
 #
 # With --profile mailcatcher, SMTP_URL points at Mailpit and nothing leaves
 # the box. Deployed: a real SMTP server, or set RESEND_API_KEY instead.
@@ -48,6 +61,13 @@ SMTP_URL="smtp://mailpit:1025"
 # control (docker-compose.truenas.yml arranges exactly that). Otherwise the
 # audit trail would record a client-supplied X-Forwarded-For as fact.
 TRUST_PROXY_HEADERS=false
+
+# --- password breach check ---
+# Passwords are checked against api.pwnedpasswords.com when they are set, by
+# k-anonymity: five characters of a SHA-1 prefix leave the box, never the
+# password. The check fails closed, so set this to "true" ONLY if the host has
+# no outbound internet at all — otherwise nobody would be able to register.
+HIBP_DISABLED=false
 
 # --- storage ---
 S3_BUCKET="ppp-models"

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,9 @@ DATABASE_URL="postgresql://ppp:dev-only-not-a-secret@localhost:5432/ppp?schema=p
 # ---------------------------------------------------------------------------
 # Auth
 # ---------------------------------------------------------------------------
-# Public origin of the app. Cookies, magic links and the WebAuthn relying
-# party are all derived from this — it MUST match what the browser sees.
+# Public origin of the app. Cookies, invitation links, set-password links and
+# the WebAuthn relying party are all derived from this — it MUST match what
+# the browser sees.
 BETTER_AUTH_URL="http://localhost:3000"
 
 # 32+ random bytes. Generate with: openssl rand -base64 32
@@ -19,18 +20,33 @@ PASSKEY_RP_ID="localhost"
 PASSKEY_RP_NAME="Pretty Please Print"
 
 # ---------------------------------------------------------------------------
-# The single admin (printer owner). Seeded by `npm run db:seed`.
+# The single admin (printer owner). Seeded by `npm run db:seed`, which prints
+# a one-use link for setting their username and password. There is
+# deliberately no ADMIN_PASSWORD: it would sit in this file, in the shell
+# history that wrote it, and in every backup of the host, still valid months
+# later.
 # ---------------------------------------------------------------------------
 ADMIN_EMAIL="ruben@example.org"
 ADMIN_NAME="Ruben Haas"
 
 # ---------------------------------------------------------------------------
-# Email. Picks a transport in this order: RESEND_API_KEY, then SMTP_URL,
-# then falls back to logging the message to the console (dev only).
+# Email — OPTIONAL. Picks a transport in this order: RESEND_API_KEY, then
+# SMTP_URL, then none at all, which is a supported mode.
+#
+# Nobody needs mail to sign in: people use a username and a password. Mail
+# only ever carries a link — an invitation, or a password reset — and with no
+# transport configured the admin is shown that link on screen to hand over
+# instead.
 # ---------------------------------------------------------------------------
 MAIL_FROM="Pretty Please Print <printer@example.org>"
 # RESEND_API_KEY=""
 SMTP_URL="smtp://localhost:1025"
+
+# Refuse a password that is in a known breach corpus (api.pwnedpasswords.com,
+# checked by k-anonymity — the password never leaves the machine). Set this to
+# "true" ONLY on a deployment with no outbound internet at all: the check
+# fails closed, so without it nobody could register.
+# HIBP_DISABLED="false"
 
 # ---------------------------------------------------------------------------
 # Object storage for model files (docker compose brings up MinIO)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ is unchanged in `Print That for Me/`; everything in the app reads
 
 Built from `Print That for Me/design_handoff_print_that_for_me/`. Built so far:
 
-- **Authentication and invitation-link registration** — magic link, passkeys,
-  invite-only with no public sign-up.
+- **Authentication and invitation-link registration** — username and password,
+  passkeys, invite-only with no public sign-up.
 - **Upload → board → story detail** — real file validation, object storage,
   mesh measurement, the kanban board, and the read half of story detail.
 - **An audit trail** covering access and story events, readable at
@@ -24,7 +24,7 @@ the 3D viewer, the profile screen, and notification delivery by email.
 | | |
 | --- | --- |
 | Framework | Next.js 15 (App Router), React 19, TypeScript |
-| Auth | [Better Auth](https://better-auth.com) 1.7 — magic link, passkeys, admin plugin |
+| Auth | [Better Auth](https://better-auth.com) 1.7 — username/password, passkeys, breach check, admin plugin |
 | Data | Prisma 6 → PostgreSQL 17 |
 | Styling | Tailwind v4, design tokens from the handoff as CSS variables |
 | Local infra | Docker Compose: Postgres, MinIO (model files), Mailpit (mail) |
@@ -43,65 +43,87 @@ npm run db:seed               # creates the one admin from ADMIN_EMAIL/ADMIN_NAM
 npm run dev
 ```
 
-Sign in at `/signin` as `ADMIN_EMAIL`. In development every outgoing email is
-caught by **Mailpit at http://localhost:8025** — the sign-in link is there.
-Then invite people from `/admin/invites`.
+`npm run db:seed` prints a one-use link for the admin to choose a username and
+a password — open it, then invite people from `/admin/invites`. In development
+every outgoing email is caught by **Mailpit at http://localhost:8025**, so
+invitation and reset links are clickable there.
 
 ```bash
 npm run verify:models         # upload validator vs. hostile fixtures (no server needed)
-npm run verify:auth           # invite + sign-in flow, end to end
+npm run verify:auth           # registration, sign-in and password reset, end to end
 npm run verify:upload         # upload -> board -> story, end to end
 npm run verify:queue          # the admin queue, status flow and conversation
 npm run verify:passkey        # WebAuthn ceremonies in a real browser
-npm run probe:security        # 56 OWASP-mapped security probes
+npm run probe:security        # 62 OWASP-mapped security probes
 ```
 
 ## How authentication works
 
-**There are no passwords anywhere.** Nothing to phish, reuse, or leak. Two ways
-in, both bound to something the person actually holds:
+**An invitation link registers you; after that you sign in with a username and
+a password.** No inbox round trip, and nothing in the running system depends on
+a mail server.
 
-- **Passkey** (WebAuthn) — the primary path once enrolled. Offered through
-  browser conditional UI, so it can sign someone in from the email field with
-  no click at all.
-- **Magic link** — 10 minutes, single use, token stored as a digest
-  (`storeToken: "hashed"`), so a database reader cannot replay one.
+Two ways in:
 
-### Getting people off the inbox round trip
+- **Username and password** — the way in, and the one that always works. At
+  least 10 characters, capped at 128, and refused outright if the password
+  already appears in a known breach corpus.
+- **Passkey** (WebAuthn) — optional, stronger, and faster. Offered through
+  browser conditional UI, so it can sign someone in from the username field
+  with no click at all.
 
-Magic links are the way *in*; they are not meant to be the everyday
-experience. A passkey signs someone in from the email field with no click at
-all (browser conditional UI), and `npm run verify:passkey` proves that path
-works end to end in a real browser.
+The passkey is an accelerator, not the way in. That is the correction this
+model makes over the one before it: an emailed link was doing the job of a
+password while being harder to use and impossible to use at all when mail was
+down.
 
-The thing that decides whether people actually get there is not the technology,
-it is whether anyone ever asks them twice. Accepting an invite offers a passkey
-once; the first version let people tap "Skip for now" and then never mentioned
-it again, which left them on an emailed link for every sign-in, forever,
-without having chosen that.
+### Why ten characters, and why a breach check
 
-So there are three prompts now, and two tests holding them in place:
+Length is the control that does the work. Composition rules — a digit, a
+symbol, a capital — mostly move people to `Password1!`, which is in every
+corpus there is. So the rules here are: ten characters minimum, and
+[Have I Been Pwned](https://haveibeenpwned.com) says no.
+
+The breach lookup is k-anonymity: five characters of a SHA-1 prefix go to
+`api.pwnedpasswords.com`, and the password itself never leaves the machine. It
+**fails closed** — if that service cannot be reached, setting a password fails
+rather than quietly skipping the check. Only registration and reset set a
+password, so an outage cannot lock out anybody who already has one.
+
+`HIBP_DISABLED=true` turns it off, and exists for exactly one case: a
+deployment with no outbound internet at all, where failing closed would mean
+nobody could ever register.
+
+### Getting people onto passkeys
+
+The thing that decides whether people get there is not the technology, it is
+whether anyone ever asks them twice. Registration offers a passkey once; the
+first version let people tap "Skip for now" and then never mentioned it again,
+which left them typing a password every time without having chosen that.
+
+So there are three prompts, and two tests holding them in place:
 
 - A banner for anyone with zero passkeys, dismissible **for the session only** —
   closing it means "not right now", not "never".
 - A line in the account menu saying how you currently sign in, with a way to
   change it.
-- Honest copy on the skip: "Not now — keep using emailed links", rather than
+- Honest copy on the skip: "Not now — keep typing my password", rather than
   implying it is a postponement.
 
 All three disappear the moment a passkey exists.
 
-### Mail is optional
+### Mail is optional — genuinely
 
-**SMTP is used only for authentication, and not at all for notifications** —
-those are in-app, written by `notify()` and read by the Activity panel. Mail
-is called in exactly three places: sending an invitation, resending one, and
-the magic sign-in link.
+**Nothing in the running system needs a mail server.** People sign in with a
+password, and notifications are in-app, written by `notify()` and read by the
+Activity panel. Mail is called in exactly three places, and every one of them
+is delivering a *link*: sending an invitation, resending one, and sending a
+password reset.
 
-So the app runs without a mail server. With `SMTP_URL` or `RESEND_API_KEY`
-set, invitations are emailed as usual. With neither, the admin gets the link
-on screen to hand over directly, and the app boots normally rather than
-refusing to start. Same token, same single use, same expiry either way.
+With `SMTP_URL` or `RESEND_API_KEY` set, those links are emailed. With neither,
+the admin gets the link on screen to hand over directly, and the app boots
+normally rather than refusing to start. Same token, same single use, same
+expiry either way.
 
 For a group that shares an office, handing a link over is arguably the safer
 channel: a token in an inbox sits there indefinitely and can be forwarded,
@@ -109,16 +131,49 @@ where one passed over in person cannot. When mail *is* configured the raw
 token is still withheld from the admin — it exists only inside the message —
 because that property is worth keeping wherever it can be kept.
 
-There is also **"Lost access?"** against each member on the guest list: it
-mints a single-use ten-minute sign-in link for someone who wiped the device
-their passkey lived on, and hands it to the admin. That is the answer when
-mail is down, which is exactly when you cannot email a link.
+### Forgotten passwords
 
-It is impersonation-shaped — whoever holds the link is signed in as that
-person — and it is allowed because it grants the printer owner nothing they
-did not already have, owning the machine and the database. It is recorded
-loudly (`access.reissued`) for the same reason: an audited action beats a
-quiet `UPDATE`.
+**"Forgotten password?"** sits against each member on the guest list. The admin
+presses it; a single-use, thirty-minute token is minted, emailed if there is a
+transport and shown to the admin to hand over if there is not.
+
+The link opens a set-password form. It does **not** sign anyone in — that is
+the whole difference from the sign-in link it replaces, which signed whoever
+held it in *as* that person. Here they choose a password and then have to use
+it, and setting it revokes every session the old password opened. Both halves
+are audited: `password.reset_requested` names the admin, `password.reset_completed`
+names the member.
+
+There is no self-service "forgot password" form. With no `sendResetPassword`
+configured, Better Auth's `/request-password-reset` refuses outright — resets
+are admin-minted so the flow cannot depend on a mail server that may not exist.
+
+One detail worth knowing, because it is a deliberate deviation: Better Auth
+consumes the reset token *before* it hashes the new password, so a password
+refused by the breach check would burn the link on its way out and send someone
+back to the admin over a password they were about to correct. `setPassword`
+puts the row back — with its original expiry — when the failure happened after
+consumption. The link is spent when a password is actually set, which is what
+"single use" was ever meant to mean.
+
+### Bootstrapping the admin
+
+The printer owner is the one account nobody invites, so `prisma/seed.ts` writes
+the row directly. A row cannot sign in on its own, so when the admin has no
+password the seed mints a set-password link and **prints it**:
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
+```
+
+Open it within thirty minutes to choose a username and a password. Lost it?
+Re-run the migrator and it prints a fresh one — but only while no password has
+been set. Re-seeding never resets an existing one.
+
+There is deliberately no `ADMIN_PASSWORD`. It would sit in `.env.docker`, in
+`docker inspect`, in the shell history that wrote the file and in every backup
+of the host, still valid months later. A link that expires in half an hour is a
+smaller thing to leak.
 
 ### Invite-only, enforced in one place
 
@@ -134,9 +189,12 @@ async validateUserInfo({ user, source }) {
 }
 ```
 
-Better Auth calls it before provisioning an identity **by any method** — magic
-link, passkey, and whatever gets added later. There is no second copy of this
-rule in a route handler to drift out of sync.
+Better Auth calls it before provisioning an identity **by any method**, from
+`internalAdapter.createUser`. Password sign-up goes through that path with
+`{ method: "email-password" }` exactly as passkey enrolment does, so adding
+passwords neither moved this rule nor added a second copy of it in a route
+handler to drift out of sync. `verify:auth` asserts it directly: registering an
+address with no pending invite is answered 403 and leaves no row.
 
 ### The invitation link
 
@@ -145,32 +203,50 @@ rule in a route handler to drift out of sync.
    digest**, and emails the raw token inside the link. The raw token is never
    returned to the admin either — it exists in the email and nowhere else.
 3. The invitee opens `/invite/<token>`, sees who invited them and which
-   address the invite is bound to, and picks the name they want to be known by.
-4. Claiming redeems the invite and drops them into the app, signed in.
+   address the invite is bound to, and picks a display name, a **username** and
+   a **password**.
+4. Submitting calls Better Auth's sign-up, which runs the invite gate and the
+   stamping hook, creates the account and returns a session. They land on
+   `/welcome`, which offers a passkey.
 5. `databaseHooks.user.create.after` burns every open invite for that address,
    so the link cannot mint a second account.
 
 Invites expire after 7 days, can be withdrawn, and can be re-sent — re-sending
 **rotates the token**, so a previously leaked email stops working.
 
-#### Why claiming does not send a second email
+#### Why registering does not send a second email
 
 The invite token was delivered to that mailbox and nowhere else, so following
 the link already proves control of it. Making someone read a *second* email to
-finish registering adds a hop without adding assurance.
+finish registering adds a hop without adding assurance — and it would put a
+mail server back on the critical path for getting in, which is precisely what
+this model exists to remove.
 
-So `issueInviteSignInUrl` runs Better Auth's normal magic-link issuance inside
-an `AsyncLocalStorage` scope; the `sendMagicLink` callback sees the scope and
-returns the URL in-process instead of mailing it. Every check Better Auth
-performs on a magic link still runs — the link is simply redeemed immediately
-rather than days later, and it never leaves the server.
+So registration creates the session directly. There is no in-process link to
+redeem and no `AsyncLocalStorage` machinery holding one; the previous version
+had both, and they existed only to work around the absence of a password.
+
+#### Usernames
+
+3–32 characters of letters, digits, `-` and `_`. Case is accepted but not kept:
+the value is folded to lower case on write and looked up folded, so `Ayla_B` is
+stored as `ayla_b`, signs in as either, and cannot be registered twice in
+different clothes. `displayUsername` keeps whatever was typed.
+
+Matching case-insensitively rather than refusing capitals is the friendlier
+half of that: somebody whose phone capitalises the first letter should be told
+the username is taken, not that it is malformed.
 
 ### Privileged fields cannot be set over the wire
 
-`role`, `initials` and `invitedById` are declared `input: false`, so they are
-stripped from any request body. They are written server-side in
-`databaseHooks.user.create.before`, read out of the invite row. Posting
-`{"role":"admin"}` at sign-up does nothing — there is a test for exactly that.
+`role`, `initials` and `invitedById` are declared `input: false`. Better Auth
+does not quietly strip them — it **refuses the whole request** with
+`FIELD_NOT_ALLOWED`, which is the better failure: a sign-up that half-worked
+would be harder to notice than one that did not. They are written server-side
+in `databaseHooks.user.create.before`, read out of the invite row.
+
+Fields that are not declared at all — a chosen `id`, a posted `emailVerified` —
+reach the endpoint and are simply overruled. There are tests for both halves.
 
 ### Exactly one admin
 
@@ -216,14 +292,23 @@ and every server action.
 - **CSP carries a per-request nonce** minted in `src/middleware.ts`, so
   `script-src` needs no `'unsafe-inline'`. Every script tag on a rendered page
   carries it.
-- **Rate limiting** is on, in Postgres. Magic links are capped at 10 per minute
-  per IP rather than a tighter number *because an office sits behind one NAT
-  address* — a limit of 3 would refuse the fourth colleague to claim an invite
-  in the same minute.
-- **No user enumeration**: `/signin` answers identically whether or not the
-  address is known, and always says "if that address belongs to someone here".
+- **Rate limiting** is on, in Postgres, with the password paths capped well
+  below the blanket rule: `/sign-in/username`, `/sign-up/email` and
+  `/reset-password` get 10 a minute per IP. Ten rather than three *because an
+  office sits behind one NAT address* — a tighter limit would lock out the
+  colleague at the next desk. Ten a minute still puts online guessing several
+  thousand years away from a ten-character password, which is the number that
+  matters.
+- **No user enumeration**: a wrong password and an invented username get
+  byte-identical responses, and an unknown username still pays for a password
+  hash so the wall clock does not answer either. Both are probed.
 - `SameSite=Lax`, not `Strict`, because `Strict` would drop the cookie on the
-  magic-link landing and the sign-in would appear to silently fail.
+  hop from a set-password link and the sign-in would appear to silently fail.
+- **Reset tokens are hashed at rest.** `verification.storeIdentifier: "hashed"`
+  means the table holds a digest, not a link anyone could paste into a URL.
+  `prisma/reset-token.ts` reproduces that digest for the two places that mint a
+  row directly — the admin control and the seed — and is the single definition
+  of the format, because the migrator image ships `prisma/` and nothing else.
 
 ## The viewer
 
@@ -485,8 +570,8 @@ Two independent reasons:
 
 1. **WebAuthn requires a secure context.** Browsers refuse to create or use a
    passkey over plain HTTP, with the single exception of `localhost`. On
-   `http://nas.local:3000`, passkeys simply do not work — the app falls back to
-   magic links, which still function.
+   `http://nas.local:3000`, passkeys simply do not work — everyone falls back
+   to a username and a password, which still function.
 2. **The app refuses to start.** `src/lib/auth.ts` throws in production when
    `BETTER_AUTH_URL` is not `https://`, unless it is loopback. Session cookies
    carry `Secure`, and a cookie the browser discards is an app nobody can sign
@@ -501,16 +586,22 @@ records that address.
 It is the registrable domain with no scheme and no port
 (`print.example.org`, not `https://print.example.org:443`). Passkeys are bound
 to it cryptographically. **Change it later and every passkey already
-registered stops working**, with no migration path — everyone re-enrols from a
-magic link. Pick the hostname you intend to keep.
+registered stops working**, with no migration path — everyone signs in with
+their password and re-enrols. Pick the hostname you intend to keep.
 
 ### First run
 
-`migrate` seeds exactly one admin from `ADMIN_EMAIL` / `ADMIN_NAME`. Sign in at
-`/signin`, then invite the office from `/admin/invites`. The seed is an upsert,
-so it is safe on every start and keeps the admin's name in step with the
-environment — but it will refuse to create a *second* admin, and so will the
-database.
+`migrate` seeds exactly one admin from `ADMIN_EMAIL` / `ADMIN_NAME` and prints
+a one-use link for setting a username and a password:
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
+```
+
+Open it within thirty minutes, then invite the office from `/admin/invites`.
+The seed is an upsert, so it is safe on every start and keeps the admin's name
+in step with the environment — but it will refuse to create a *second* admin,
+and so will the database, and it never resets a password that already exists.
 
 ### What to back up
 
@@ -566,17 +657,21 @@ framework versions, and drop any that upstream has caught up with.
 ```
 prisma/
   schema.prisma          auth tables (Better Auth's shapes) + domain models
-  seed.ts                bootstraps the single admin
+  seed.ts                bootstraps the single admin, prints its setup link
+  reset-token.ts         set-password token format, shared with the app
 src/lib/
   auth.ts                Better Auth config — the invite gate lives here
-  auth-client.ts         browser client (magic link, passkey, admin)
+  auth-client.ts         browser client (username, passkey, admin)
+  auth-rules.ts          username and password rules, shared with the forms
+  password-reset.ts      minting, reading and restoring set-password links
   authz.ts               requireUser/requireAdmin/storyScope + status flow
   invites.ts             invite lifecycle: mint, resend, revoke, consume
   email.ts               Resend → SMTP → console, plus templates
   tokens.ts              CSPRNG tokens, digests, initials
 src/app/
-  signin/                passkey-first, magic-link fallback
-  invite/[token]/        the claim page and its server action
+  signin/                passkey button over a username/password form
+  invite/[token]/        the registration page and its server action
+  set-password/          where a reset link lands; sets no session
   welcome/               passkey enrolment after registration
   admin/invites/         the guest list (admin only)
   scope.ts               pure authorisation predicates (no server-only)
@@ -592,7 +687,7 @@ src/app/
   api/upload/            validation, storage, story creation
 scripts/
   verify-models.ts       validator vs. hostile fixtures
-  verify-auth.ts         invite + sign-in flow
+  verify-auth.ts         registration, sign-in and password reset
   verify-upload.ts       upload -> board -> story
   verify-passkey.ts      WebAuthn in a real browser
   security-probe.ts      OWASP-mapped security probes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,16 @@
 
 Scope: Pretty Please Print (formerly Print That For Me), assessed against the **OWASP Top 10 (2021)** with
 SAST, SCA and DAST. Everything below was run against the production build
-(`npm run build && npm start`) on 2026-08-22.
+(`npm run build && npm start`) on 2026-08-23.
 
 Covers the authentication and invitation slice and the upload → board → story
 slice. Re-run after every slice; the numbers below are current.
+
+**Re-run on 2026-08-23** after authentication changed shape: invitation links
+now *register* an account with a username and a password, and people sign in
+with those. A07 is the category that moves — see
+[A07 with passwords in the picture](#a07-with-passwords-in-the-picture) below,
+which is the honest accounting of what got better and what got worse.
 
 Reproduce with:
 
@@ -16,7 +22,7 @@ docker run --rm -v "$PWD:/src:ro" semgrep/semgrep semgrep scan \
   --config=p/owasp-top-ten --config=p/security-audit --config=p/nextjs /src/src
 docker run --rm --network host ghcr.io/zaproxy/zaproxy:stable \
   zap-baseline.py -t http://localhost:3000        # DAST
-npm run probe:security                     # DAST, app-specific (50 probes)
+npm run probe:security                     # DAST, app-specific (62 probes)
 ```
 
 ## Result
@@ -28,9 +34,9 @@ npm run probe:security                     # DAST, app-specific (50 probes)
 | Syft + Grype | SBOM, binary contents | **92 (2 crit, 46 high)** | 0 |
 | Semgrep | 153 rules, 37 files | 1 (false positive) | 0 |
 | OWASP ZAP baseline | passive DAST | **1 medium, 3 low** | 0 fail / 63 pass |
-| `probe:security` | 56 app-specific probes | **2 real, 4 artifacts** | 56 pass |
+| `probe:security` | 62 app-specific probes | **2 real, 4 artifacts** | 62 pass |
 | `verify:models` | 29 upload-validator checks | — | 29 pass |
-| `verify:passkey` | WebAuthn in a real browser | *unverified* | 11 pass |
+| `verify:passkey` | WebAuthn in a real browser | *unverified* | 13 pass |
 
 A generic scanner cannot reason about *this* app's authority model, so the
 probe suite in [`scripts/security-probe.ts`](scripts/security-probe.ts) covers
@@ -147,15 +153,103 @@ hit was a false positive *inside* that generated file.
 | | Category | Verdict |
 | --- | --- | --- |
 | **A01** | Broken Access Control | **Pass.** Client refused on the admin page (404, not 403 — a 403 confirms existence) and on all six admin-plugin endpoints (`list-users`, `set-role`, `create-user`, `impersonate-user`, `remove-user`, `list-user-sessions`). Role unchanged after escalation attempts; no back-door account. `storyScope` hides another client's story. A forged session cookie reaches nothing. |
-| **A02** | Cryptographic Failures | **Pass.** Session cookie `HttpOnly`, `SameSite=Lax`, `Secure`, `__Secure-` prefixed. Invite tokens stored as SHA-256 only; magic-link tokens hashed at rest — both verified against the live database. No passwords exist to mishandle. |
-| **A03** | Injection | **Pass.** SQL metacharacters handled (Prisma parameterises); no 5xx, table intact. Stored XSS via display name escaped in both DOM and flight payload. Reflected XSS via `?error=` and via the invite-token path segment both escaped. CRLF in the email field does not reach the mailer. Uploads are validated against their bytes, not their filename — a PDF, an ELF binary and an HTML page renamed `.stl` are all refused, as is an STL that lies about its triangle count. |
-| **A04** | Insecure Design | **Pass.** No public registration route. Invite-only enforced in one hook across every auth method. Invites single-use, expiring, revocable, rotated on resend. Rate limiting active and confirmed firing. |
+| **A02** | Cryptographic Failures | **Pass.** Session cookie `HttpOnly`, `SameSite=Lax`, `Secure`, `__Secure-` prefixed. Invite tokens stored as SHA-256 only; set-password tokens hashed at rest (`verification.storeIdentifier: "hashed"`) — both verified against the live database. Passwords are stored as Better Auth's scrypt digest, asserted against the live `account` row rather than assumed. |
+| **A03** | Injection | **Pass.** SQL metacharacters in the username field handled (Prisma parameterises); no 5xx, table intact. Stored XSS via display name escaped in both DOM and flight payload. Reflected XSS via `?error=` and via the invite-token path segment both escaped. CRLF in the email field does not reach the mailer. Uploads are validated against their bytes, not their filename — a PDF, an ELF binary and an HTML page renamed `.stl` are all refused, as is an STL that lies about its triangle count. |
+| **A04** | Insecure Design | **Pass.** No public registration route: `/signup` and `/register` do not exist, and the sign-up endpoint that *does* exist — the one an invitation link posts to — answers 403 to anybody without a pending invite, leaving no row. Invite-only enforced in one hook across every auth method. Invites single-use, expiring, revocable, rotated on resend. Password guessing rate-limited and confirmed firing. |
 | **A05** | Security Misconfiguration | **Pass, after fixes 2 and 3.** Full header set; `X-Powered-By` suppressed; `.env`, `.git/config`, `package.json` and the Prisma schema all unreachable; malformed input returns no stack trace. |
 | **A06** | Vulnerable Components | **Pass, after fixes 4 and 5.** Zero across three independent scanners. |
-| **A07** | Auth Failures | **Pass, after fix 1.** No user enumeration (identical responses). Magic links single-use, 10-minute TTL. Off-site and protocol-relative redirect targets refused, both via `?next=` and via the API's `callbackURL`. Sign-out kills the session server-side. |
-| **A08** | Integrity Failures | **Pass.** `role`, `initials`, `invitedById` and `id` cannot be set from the request body — declared `input: false` and written server-side from the invite. On upload, `uploaderId` comes from the session and a posted `status` is ignored, both probed. Storage keys are generated, never derived from the filename. Lockfile committed. |
-| **A09** | Logging & Monitoring | **Pass.** An append-only `AuditEvent` table records invitations sent, resent, revoked, accepted and *rejected*; sign-in and sign-out; story creation and refused uploads. Rows are denormalised (`actorEmail`, `subject`) so the trail still reads correctly after the user or story it refers to is deleted, and a probe asserts no token or secret reaches `detail`. |
+| **A07** | Auth Failures | **Pass, after fix 1.** Passwords: ≥10 characters, breach-checked against HIBP by k-anonymity, guessing capped at 10/min per IP. No user enumeration — a wrong password and an invented username give byte-identical responses, and an unknown username still pays for a hash so the wall clock does not answer either. Set-password links single-use, 30-minute TTL, hashed at rest, and they establish **no session**. Setting a password revokes the sessions the old one opened. Off-site and protocol-relative redirect targets refused, both via `?next=` and via the API's `callbackURL`. Sign-out kills the session server-side. See the section below. |
+| **A08** | Integrity Failures | **Pass.** `role`, `initials` and `invitedById` cannot be set from the request body: declared `input: false`, and Better Auth refuses the whole sign-up with `FIELD_NOT_ALLOWED` rather than silently trimming it. A chosen `id` and a posted `emailVerified` reach the endpoint undeclared and are overruled server-side from the invite. Both halves probed. On upload, `uploaderId` comes from the session and a posted `status` is ignored, both probed. Storage keys are generated, never derived from the filename. Lockfile committed. |
+| **A09** | Logging & Monitoring | **Pass.** An append-only `AuditEvent` table records invitations sent, resent, revoked, accepted and *rejected*; password resets requested and completed; sign-in and sign-out; story creation and refused uploads. Rows are denormalised (`actorEmail`, `subject`) so the trail still reads correctly after the user or story it refers to is deleted, and a probe asserts no token or secret reaches `detail`. |
 | **A10** | SSRF | **Pass (low exposure).** The app makes no outbound request from user input. A link-local `callbackURL` (`169.254.169.254`) is refused. |
+
+## A07 with passwords in the picture
+
+The previous version of this report leaned on a sentence that is no longer
+true: *"No passwords exist to mishandle."* That was a real property and it is
+worth being honest about giving it up, so here is what actually changed.
+
+**What got worse.** There is now a secret people choose, which means there is
+something to guess, something to reuse across sites, and something to phish.
+None of those existed before. Specifically:
+
+- **Online guessing** is a live attack surface where it was not. Mitigated by a
+  10-character floor, a breach-corpus refusal, and a 10/min per-IP cap on
+  `/sign-in/username` — probed by `A04-ratelimit`. Ten a minute against ten
+  characters is not a threat; ten a minute against `hunter2` would be, which is
+  why the breach check matters more than the rate limit does.
+- **Reuse.** A password chosen here may already be a password somewhere else.
+  The HIBP check catches the ones already published; it cannot catch a fresh
+  reuse. The passkey nudge is the real answer, and it is why enrolment is
+  pushed at three separate points.
+- **Phishing.** A password can be typed into a fake page; a magic link could
+  also be forwarded to one, so this is less of a regression than it looks, but
+  it is not nothing. Passkeys are unphishable and remain one click away.
+- **Storage.** There is now a credential at rest. scrypt, `N=16384, r=16, p=1,
+  dkLen=64`, per-password salt, stored `salt:hash` — Better Auth's default via
+  `node:crypto`. `A02-password-hash` asserts against the live row that what is
+  stored is not the password.
+
+**What got better.** Not a consolation prize — these are real:
+
+- **Recovery no longer means impersonation.** The old "Lost access?" minted a
+  link that signed its holder in *as* that person. The replacement mints a link
+  that lets them *set a password*, which they then have to use. An admin who
+  keeps the link is locking someone out, not quietly becoming them. `A07-reset-nosession`
+  asserts the link establishes no session.
+- **The mail server left the critical path.** Sign-in used to depend on message
+  delivery. A mail outage is now a nuisance for invitations, not a lockout for
+  the whole office — and a token that sits in an inbox indefinitely is a
+  standing key that no longer exists.
+- **The enumeration oracle got narrower.** The old form had to answer
+  identically whether or not an address existed *and still send mail*, which
+  made "did a message arrive" the oracle. Now a wrong password and an invented
+  username produce byte-identical responses (`A07-enum`), and the unknown
+  username still pays for a scrypt hash so the wall clock does not answer
+  either (`A07-enum-timing`).
+- **Session revocation on reset.** Setting a password kills every session the
+  old one opened (`A07-reset-revokes`). The old model had no equivalent —
+  a compromised account stayed compromised until someone deleted rows by hand.
+- **One less piece of machinery.** The `AsyncLocalStorage` trick that redeemed
+  a magic link in-process at invite acceptance is gone. It was sound but it
+  existed only to paper over the absence of a password, and code that does not
+  exist cannot be got wrong.
+
+**Net.** A07 stays a pass, on a broader base of evidence: 11 probes where there
+were 7, plus the registration, login, duplicate-username, breached-password,
+rate-limit and full reset cycle checks in `verify:auth`.
+
+### Reset tokens, and one deliberate deviation
+
+Reset tokens live in `verification` under a **digest** of their identifier
+(`verification.storeIdentifier: "hashed"`), so a database reader gets no link
+they can paste into a URL — `A02-reset-hash` checks that against the live
+table. They last 30 minutes and work once.
+
+The deviation: Better Auth consumes the token *before* it hashes the new
+password, so a password rejected by the breach check would spend the link on
+its way out. `setPassword` puts the row back — same identifier, same original
+expiry — when the failure happened after consumption. This extends nothing and
+weakens nothing: whoever is retrying already held the token. It makes the link
+spent when a password is actually set, which is what "single use" is for.
+`verify:auth` asserts both halves: a refused password leaves the link working,
+and a successful one kills it.
+
+### Residual risk accepted
+
+- **The breach check is an outbound dependency.** It fails closed, so if
+  `api.pwnedpasswords.com` is unreachable, nobody can *set* a password —
+  registration and reset stop, sign-in does not. `HIBP_DISABLED=true` exists
+  for an air-gapped deployment and is off by default. This is a deliberate
+  availability-for-integrity trade at this size; a cached local corpus would be
+  the answer if it ever bit.
+- **No second factor.** A password plus an optional passkey is the whole set.
+  TOTP would be the next thing to add if this were ever exposed beyond an
+  office, and Better Auth's `twoFactor` plugin is the path.
+- **No password-change screen for a signed-in user.** Today changing a password
+  means asking the admin for a reset link. That is a gap in convenience rather
+  than in security, and `/api/auth/change-password` is already served by the
+  catch-all if it is ever wired to a form.
 
 ## Closed since the first pass
 
@@ -167,10 +261,16 @@ hit was a false positive *inside* that generated file.
   learn to ignore. Two probes assert a client gets 404 there and that no audit
   rows leak.
 - **The WebAuthn ceremonies are verified.** `npm run verify:passkey` drives a
-  real Chromium with a CDP virtual authenticator: it registers a passkey,
-  confirms the credential persists with a public key and no private material,
-  signs out, and signs back in. Conditional UI signs the returning user in
-  with no click at all, which is the intended experience.
+  real Chromium with a CDP virtual authenticator: it signs in with a username
+  and a password, registers a passkey, confirms the credential persists with a
+  public key and no private material, signs out, and signs back in. Conditional
+  UI signs the returning user in with no click at all, which is the intended
+  experience. Passwords and passkeys are verified working side by side, which
+  is the whole point of keeping both.
+- **Recovery stopped being impersonation.** `access.reissued` — a link that
+  signed its holder in as somebody else — is gone, replaced by
+  `password.reset_requested` / `password.reset_completed` and a link that sets
+  a password and nothing more.
 
 ## Open items
 
@@ -179,7 +279,7 @@ hit was a false positive *inside* that generated file.
   oversight — revisit if the group grows or the app is ever exposed beyond
   the office.
 - **No authenticated active scan.** ZAP ran a passive baseline against the
-  unauthenticated surface. The authenticated surface is covered by the 50
+  unauthenticated surface. The authenticated surface is covered by the 62
   custom probes instead, which is better for authorisation logic and worse for
   generic injection classes. Once the board and upload screens land, an
   authenticated ZAP active scan is worth configuring.
@@ -202,3 +302,5 @@ hit was a false positive *inside* that generated file.
   Auth's model and is sound for this threat profile. There are no
   per-form tokens; if the app ever needs to accept cross-site POSTs, that
   changes.
+- **No second factor, and no self-service password change.** Both are in
+  [Residual risk accepted](#residual-risk-accepted) above with the reasoning.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,12 +41,19 @@ x-restart: &restart
 services:
   # Applies migrations and upserts the admin, then exits. The app waits for it
   # to finish, so a deploy can never serve against an unmigrated schema.
+  #
+  # On a first deploy it also prints a one-use link for the admin to set a
+  # username and a password — that link is the whole bootstrap, so read the
+  # logs:  docker compose -f docker-compose.prod.yml logs migrate
   migrate:
     image: ${PPP_REGISTRY:-ghcr.io/danileau}/ppp-migrate:${PPP_TAG:-latest}
     container_name: ppp-migrate
     env_file: [.env.docker]
     environment:
       DATABASE_URL: postgresql://ppp:${DB_PASSWORD:?set DB_PASSWORD}@db:5432/ppp?schema=public
+      # The set-password link it prints has to point at the hostname the
+      # browser uses, not at the container's idea of localhost.
+      BETTER_AUTH_URL: ${APP_URL:-http://localhost:3000}
     depends_on:
       db:
         condition: service_healthy
@@ -60,8 +67,8 @@ services:
     environment:
       DATABASE_URL: postgresql://ppp:${DB_PASSWORD:?set DB_PASSWORD}@db:5432/ppp?schema=public
       S3_ENDPOINT: http://minio:9000
-      # Better Auth derives cookie scope, magic-link URLs and the WebAuthn
-      # relying party from this. It must match what the browser actually sees,
+      # Better Auth derives cookie scope, invitation and set-password link
+      # URLs, and the WebAuthn relying party from this. It must match what the browser actually sees,
       # including scheme and port.
       BETTER_AUTH_URL: ${APP_URL:-http://localhost:3000}
       # Forwarded client addresses are only believed when a proxy is genuinely
@@ -118,8 +125,8 @@ services:
       timeout: 5s
       retries: 10
 
-  # Development and staging only. Catches every outgoing email so invitations
-  # and sign-in links can be clicked without a real mail server.
+  # Development and staging only. Catches every outgoing email so invitation
+  # and password-reset links can be clicked without a real mail server.
   # Enable with:  --profile mailcatcher
   mailpit:
     image: axllent/mailpit:latest

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,7 +21,7 @@ services:
       - "${MINIO_CONSOLE_PORT:-9001}:9001"
   mailpit:
     ports:
-      # 8025 is the web UI where invitations and sign-in links show up;
+      # 8025 is the web UI where invitation and reset links show up;
       # 1025 is SMTP, which the host-side suites post to directly.
       - "${MAILPIT_UI_PORT:-8025}:8025"
       - "1025:1025"

--- a/prisma/migrations/20260823153000_username_and_password_login/migration.sql
+++ b/prisma/migrations/20260823153000_username_and_password_login/migration.sql
@@ -1,0 +1,13 @@
+-- Username + password login.
+--
+-- Both columns belong to Better Auth's username plugin. `username` is
+-- nullable because an account can exist before it has one: the seeded admin
+-- is written straight through Prisma and picks a username on the
+-- set-password link the seed prints.
+--
+-- The unique index is what makes the login identifier unambiguous. Values are
+-- folded to lower case on write, so it is case-insensitive in practice.
+ALTER TABLE "user" ADD COLUMN "username" TEXT;
+ALTER TABLE "user" ADD COLUMN "displayUsername" TEXT;
+
+CREATE UNIQUE INDEX "user_username_key" ON "user"("username");

--- a/prisma/migrations/20260823154500_account_issuer/migration.sql
+++ b/prisma/migrations/20260823154500_account_issuer/migration.sql
@@ -1,0 +1,16 @@
+-- `account.issuer`, which Better Auth requires and this app never needed
+-- until it had passwords.
+--
+-- Nothing had ever written an account row: passkeys live in their own table
+-- and there is no OAuth provider, so the column and its uniqueness rule were
+-- dead weight right up until a `credential` account had to exist. Backfilled
+-- rather than added bare, so the migration is correct against a database that
+-- somehow does hold rows.
+ALTER TABLE "account" ADD COLUMN "issuer" TEXT;
+UPDATE "account" SET "issuer" = 'local:' || "providerId" WHERE "issuer" IS NULL;
+ALTER TABLE "account" ALTER COLUMN "issuer" SET NOT NULL;
+
+-- Uniqueness moves to (issuer, accountId): the issuer is the namespace, so it
+-- is the half that makes an account id unambiguous.
+DROP INDEX IF EXISTS "account_providerId_accountId_key";
+CREATE UNIQUE INDEX "account_issuer_accountId_key" ON "account"("issuer", "accountId");

--- a/prisma/reset-token.ts
+++ b/prisma/reset-token.ts
@@ -1,0 +1,47 @@
+/**
+ * Password-setup tokens: minting, and the identifier they are stored under.
+ *
+ * This file sits beside the schema rather than in `src/lib` because two very
+ * different things need it and only one of them can see the app:
+ *
+ *   - `prisma/seed.ts`, which mints the printer owner's first set-password
+ *     link. The migrator image ships `prisma/` and three npm packages, so
+ *     anything under `src/` is simply not there (see the Dockerfile).
+ *   - `src/lib/password-reset.ts`, which mints one when the admin resets a
+ *     member's password.
+ *
+ * Both write a row Better Auth will later consume through its own
+ * `/reset-password` endpoint, so the identifier format below is not ours to
+ * choose — it is Better Auth's, and the two constants encode it in one place
+ * instead of two.
+ */
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Short enough that a link left in a chat window is not a standing key to the
+ * account, long enough to survive being walked over to somebody's desk.
+ */
+export const RESET_TTL_MINUTES = 30;
+
+/** 32 bytes of CSPRNG output, URL-safe. Guessing one is not a threat model. */
+export function newResetToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * The `verification.identifier` a reset token is filed under.
+ *
+ * Two layers, both Better Auth's:
+ *   - the `reset-password:` prefix its `/reset-password` endpoint looks up
+ *   - the digest applied by `verification.storeIdentifier: "hashed"`, which
+ *     is SHA-256 over the identifier, base64url without padding
+ *
+ * Hashing is what keeps a database reader from replaying a live link. Keep
+ * this in step with `storeIdentifier` in src/lib/auth.ts: change one and the
+ * links silently stop resolving.
+ */
+export function resetIdentifier(token: string): string {
+  return createHash("sha256")
+    .update(`reset-password:${token}`, "utf8")
+    .digest("base64url");
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,18 @@ model User {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
+  /// --- username plugin ---
+  ///
+  /// The login identifier. Folded to lower case on write, which is what makes
+  /// the unique index case-insensitive; `displayUsername` keeps whatever was
+  /// typed so the profile can show it back.
+  ///
+  /// Nullable because an account can exist before it has one: the seeded admin
+  /// is a row written straight through Prisma, and picks a username and a
+  /// password from the set-password link the seed prints.
+  username        String? @unique
+  displayUsername String?
+
   /// Avatar fallback, e.g. "AY". Derived from `name` on create. The default is
   /// a safety net only — `databaseHooks.user.create.before` always sets it.
   initials String @default("??")
@@ -84,9 +96,15 @@ model Session {
 }
 
 model Account {
-  id                    String    @id @default(cuid())
-  accountId             String
-  providerId            String
+  id        String @id @default(cuid())
+  accountId String
+
+  /// Namespace for `accountId`, so a provider id can never collide with an
+  /// internal method. Better Auth writes `local:credential` for a password
+  /// account; an OAuth provider would get its own issuer. Required by the
+  /// library, and the left half of the uniqueness rule below.
+  issuer     String
+  providerId String
   userId                String
   user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   accessToken           String?
@@ -95,18 +113,21 @@ model Account {
   accessTokenExpiresAt  DateTime?
   refreshTokenExpiresAt DateTime?
   scope                 String?
-  /// Unused: this app has no password login at all.
+  /// scrypt digest as `salt:hash`, written by Better Auth. Only
+  /// `providerId: "credential"` rows carry one; a passkey has no password.
   password              String?
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
-  @@unique([providerId, accountId])
+  @@unique([issuer, accountId])
   @@index([userId])
   @@map("account")
 }
 
-/// Better Auth's generic token store. Backs magic links, which are configured
-/// with `storeToken: "hashed"` — a database reader cannot replay them.
+/// Better Auth's generic token store. Backs password-reset links and the
+/// WebAuthn challenges. `verification.storeIdentifier: "hashed"` in
+/// src/lib/auth.ts means `identifier` holds a digest, not the token — a
+/// database reader cannot replay a live reset link.
 model Verification {
   id         String   @id @default(cuid())
   identifier String

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,13 +3,26 @@
  *
  * This is the one account that is not created by an invitation, because
  * somebody has to be able to send the first one. It is written straight
- * through Prisma rather than Better Auth: there is no credential to
- * establish, only a row. The admin signs in with a magic link like everyone
- * else, and registers a passkey on first sign-in.
+ * through Prisma rather than Better Auth: there is no invite to validate
+ * against, only a row.
  *
- * Idempotent: re-running it updates the name and leaves everything else be.
+ * The row alone cannot sign in — it has no password and no username. So when
+ * the admin has no credential yet, the seed mints a single-use set-password
+ * link and prints it. That link is the whole handover: whoever runs the deploy
+ * reads it out of the container logs and uses it once.
+ *
+ * The password deliberately does NOT come from the environment. A password in
+ * `.env.docker` is a password in `docker inspect`, in the shell history that
+ * wrote the file, and in every backup of the host — and it would still be
+ * sitting there, valid, months later. A link that expires in half an hour is
+ * a smaller thing to leak.
+ *
+ * Idempotent: re-running it updates the name, and mints a new link only while
+ * the admin still has no password. It never resets an existing one.
  */
 import { PrismaClient } from "@prisma/client";
+
+import { RESET_TTL_MINUTES, newResetToken, resetIdentifier } from "./reset-token";
 
 const db = new PrismaClient();
 
@@ -20,6 +33,9 @@ function initialsFor(name: string): string {
   if (!first) return "??";
   return [...first].slice(0, 2).join("").toUpperCase();
 }
+
+const appUrl = (path: string) =>
+  new URL(path, process.env.BETTER_AUTH_URL ?? "http://localhost:3000").toString();
 
 async function main() {
   const email = (process.env.ADMIN_EMAIL ?? "").trim().toLowerCase();
@@ -54,10 +70,46 @@ async function main() {
     },
   });
 
+  console.info(`Printer owner ready: ${admin.name} <${admin.email}>`);
+
+  // A `credential` account with a password is the thing that makes signing in
+  // possible. A passkey creates no such row, so somebody who enrolled one and
+  // never set a password still counts as needing this — which is correct: the
+  // passkey is the accelerator, the password is the way back.
+  const credential = await db.account.findFirst({
+    where: { userId: admin.id, providerId: "credential", password: { not: null } },
+    select: { id: true },
+  });
+
+  if (credential) {
+    console.info(
+      "A password is already set. Re-seeding never resets it — use " +
+        "\"Forgotten password?\" on the guest list if it has been lost.",
+    );
+    return;
+  }
+
+  // Any link an earlier run printed goes first, so "re-run it and a fresh link
+  // appears" is true rather than "and now there are two". Reset rows are the
+  // only ones whose value is a bare user id; WebAuthn challenges store JSON.
+  await db.verification.deleteMany({ where: { value: admin.id } });
+
+  const token = newResetToken();
+  await db.verification.create({
+    data: {
+      identifier: resetIdentifier(token),
+      value: admin.id,
+      expiresAt: new Date(Date.now() + RESET_TTL_MINUTES * 60_000),
+    },
+  });
+
+  const url = appUrl(`/set-password?token=${encodeURIComponent(token)}`);
+
   console.info(
-    `Printer owner ready: ${admin.name} <${admin.email}>\n` +
-      `Sign in at ${process.env.BETTER_AUTH_URL ?? "http://localhost:3000"}/signin ` +
-      `and invite the rest of the office from /admin/invites.`,
+    `\nNo password set yet. Open this once, within ${RESET_TTL_MINUTES} minutes,\n` +
+      `to choose a username and a password:\n\n  ${url}\n\n` +
+      "Then invite the rest of the office from /admin/invites.\n" +
+      "Lost it? Re-run the seed and a fresh link is printed.",
   );
 }
 

--- a/scripts/_accounts.ts
+++ b/scripts/_accounts.ts
@@ -1,0 +1,82 @@
+/**
+ * Test-account plumbing shared by the verification suites.
+ *
+ * Every suite except `verify:auth` needs a signed-in browser before it can
+ * test the thing it is actually about. `verify:auth` owns the real path —
+ * invite, register, sign in — and proves it works; the rest take the short
+ * way round: a user row, a password set through Better Auth's own reset
+ * endpoint, and a username/password sign-in over real HTTP.
+ *
+ * The password is still set through the app rather than written into the
+ * database, so the hashing is the app's and a suite cannot pass against a
+ * credential the app would not accept.
+ */
+import { db } from "../src/lib/db";
+import { issuePasswordSetupUrl } from "../src/lib/password-reset";
+
+/**
+ * The password every suite uses.
+ *
+ * Long, and deliberately nonsense: `haveIBeenPwned` refuses anything in a
+ * breach corpus, and "correct horse battery staple" is very much in one.
+ */
+export const TEST_PASSWORD = "ppp-suite-3d-printer-parked-outside";
+
+/** Anything with a `raw()` — every suite's cookie-jar Browser qualifies. */
+export type HttpClient = {
+  raw(url: string, init?: RequestInit): Promise<Response>;
+};
+
+/**
+ * Give an account a username and a password, whatever state it is in.
+ *
+ * The set-password link is minted server-side and redeemed over HTTP, which
+ * is exactly what the admin's "Forgotten password?" control does — so this
+ * exercises the mechanism rather than working around it.
+ */
+export async function ensureCredentials(
+  app: string,
+  userId: string,
+  username: string,
+  password: string = TEST_PASSWORD,
+): Promise<void> {
+  // The username is not part of the reset endpoint's job; the set-password
+  // form writes it the same way for an account that has none.
+  await db.user.update({
+    where: { id: userId },
+    data: { username: username.toLowerCase(), displayUsername: username },
+  });
+
+  const url = await issuePasswordSetupUrl(userId);
+  const token = new URL(url).searchParams.get("token")!;
+
+  const res = await fetch(`${app}/api/auth/reset-password`, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: app },
+    body: JSON.stringify({ token, newPassword: password }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `could not set a password for ${userId}: ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
+/** Sign a browser in. Returns the raw response so a suite can assert on it. */
+export function signInWithPassword(
+  client: HttpClient,
+  app: string,
+  username: string,
+  password: string = TEST_PASSWORD,
+): Promise<Response> {
+  return client.raw(`${app}/api/auth/sign-in/username`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ username: username.toLowerCase(), password }),
+  });
+}
+
+/** A username from an address: `ayla@office.example` -> `ayla`. */
+export function usernameFor(email: string): string {
+  return email.split("@")[0]!.toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+}

--- a/scripts/screenshot.ts
+++ b/scripts/screenshot.ts
@@ -12,11 +12,11 @@
  */
 import "./_env";
 import { existsSync, mkdirSync } from "node:fs";
-import puppeteer from "puppeteer-core";
+import puppeteer, { type Page } from "puppeteer-core";
 import { db } from "../src/lib/db";
+import { TEST_PASSWORD, ensureCredentials, usernameFor } from "./_accounts";
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
-const MAILPIT = process.env.MAILPIT_URL ?? "http://localhost:8025";
 const OUT = process.env.SHOT_DIR ?? "shots";
 
 const CHROME =
@@ -27,21 +27,39 @@ const CHROME =
     "/usr/bin/chromium",
   ].find((p) => existsSync(p));
 
-async function magicLink(email: string): Promise<string | null> {
+/**
+ * Sign a page in through the real form. The screenshots are of the app a
+ * person uses, so the way into it should be too.
+ */
+async function signIn(page: Page, user: { id: string; email: string }): Promise<void> {
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
-  await fetch(`${APP}/api/auth/sign-in/magic-link`, {
+  await ensureCredentials(APP, user.id, usernameFor(user.email));
+  await page.goto(`${APP}/signin`, { waitUntil: "networkidle2" });
+  await page.type("#username", usernameFor(user.email));
+  await page.type("#password", TEST_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForFunction(() => location.pathname !== "/signin", { timeout: 15_000 });
+}
+
+/** A cookie jar for the one thing that is not driven through the browser. */
+async function sessionCookie(user: { id: string; email: string }): Promise<string> {
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  await ensureCredentials(APP, user.id, usernameFor(user.email));
+  const res = await fetch(`${APP}/api/auth/sign-in/username`, {
     method: "POST",
     headers: { "content-type": "application/json", origin: APP },
-    body: JSON.stringify({ email, callbackURL: "/board" }),
+    body: JSON.stringify({
+      username: usernameFor(user.email),
+      password: TEST_PASSWORD,
+    }),
   });
-  const list = await (await fetch(`${MAILPIT}/api/v1/messages?limit=20`)).json();
-  for (const m of list.messages ?? []) {
-    const body = await (await fetch(`${MAILPIT}/api/v1/message/${m.ID}`)).json();
-    const hit = /http:\/\/[^\s"'<]+\/api\/auth\/magic-link\/verify[^\s"'<]*/.exec(body.Text ?? "");
-    if (hit) return hit[0].replace(/[.,]$/, "");
+  const jar = new Map<string, string>();
+  for (const line of res.headers.getSetCookie()) {
+    const [pair] = line.split(";");
+    const eq = pair!.indexOf("=");
+    jar.set(pair!.slice(0, eq), pair!.slice(eq + 1));
   }
-  return null;
+  return [...jar].map(([k, v]) => `${k}=${v}`).join("; ");
 }
 
 /**
@@ -121,17 +139,7 @@ async function main() {
   // through the same validation and storage every real file does.
   const printingForUpload = await db.story.findFirst({ where: { status: "Printing" } });
   if (printingForUpload) {
-    const jar = new Map<string, string>();
-    const link0 = await magicLink(ayla.email);
-    if (link0) {
-      const r = await fetch(link0, { redirect: "manual", headers: { origin: APP } });
-      for (const line of r.headers.getSetCookie()) {
-        const [pair] = line.split(";");
-        const i = pair!.indexOf("=");
-        jar.set(pair!.slice(0, i), pair!.slice(i + 1));
-      }
-    }
-    const cookie = [...jar].map(([k, v]) => `${k}=${v}`).join("; ");
+    const cookie = await sessionCookie(ayla);
     const form = new FormData();
     form.set("file", new File([stlBox(78, 40, 22) as BlobPart], "monitor-hook-v3.stl"));
     form.set("title", "Replacement knob, grinder");
@@ -177,9 +185,7 @@ async function main() {
   await page.goto(`${APP}/signin`, { waitUntil: "networkidle2" });
   await page.screenshot({ path: `${OUT}/signin.png` });
 
-  const link = await magicLink(ayla.email);
-  if (!link) throw new Error("no magic link delivered");
-  await page.goto(link, { waitUntil: "networkidle2" });
+  await signIn(page, ayla);
 
   const printing = await db.story.findFirst({ where: { status: "Printing" } });
   const pages: Array<[string, string]> = [
@@ -198,9 +204,8 @@ async function main() {
   const adminCtx = await browser.createBrowserContext();
   const adminPage = await adminCtx.newPage();
   await adminPage.setViewport({ width: 1280, height: 980, deviceScaleFactor: 1 });
-  const adminLink = await magicLink(admin.email);
-  if (adminLink) {
-    await adminPage.goto(adminLink, { waitUntil: "networkidle2" });
+  await signIn(adminPage, admin);
+  {
     for (const [name, url] of [
       ["queue", `${APP}/queue`],
       ["books", `${APP}/me`],

--- a/scripts/security-probe.ts
+++ b/scripts/security-probe.ts
@@ -14,6 +14,8 @@
  */
 import "./_env";
 import { db } from "../src/lib/db";
+import { issuePasswordSetupUrl } from "../src/lib/password-reset";
+import { TEST_PASSWORD, ensureCredentials, signInWithPassword, usernameFor } from "./_accounts";
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
 const MAILPIT = process.env.MAILPIT_URL ?? "http://localhost:8025";
@@ -116,16 +118,20 @@ async function mailLink(to: string, re: RegExp) {
   }
   return null;
 }
-const VERIFY = /http:\/\/[^\s"'<]+\/api\/auth\/magic-link\/verify[^\s"'<]*/;
+const CLAIM = /http:\/\/[^\s"'<]+\/invite\/[^\s"'<]+/;
 
-async function signIn(email: string): Promise<Browser> {
+/** A signed-in browser for an existing row, the way the sign-in form does it. */
+async function signIn(user: { id: string; email: string }): Promise<Browser> {
   const b = new Browser();
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
-  await b.json("/api/auth/sign-in/magic-link", { email, callbackURL: "/" });
-  const link = await mailLink(email, VERIFY);
-  if (link) await b.go(link);
+  await ensureCredentials(APP, user.id, usernameFor(user.email));
+  await signInWithPassword(b, APP, usernameFor(user.email));
   return b;
+}
+
+/** Post to the sign-in endpoint directly, for the probes that need the reply. */
+function attemptSignIn(b: Browser, username: string, password: string, extra = {}) {
+  return b.json("/api/auth/sign-in/username", { username, password, ...extra });
 }
 
 async function main() {
@@ -155,8 +161,8 @@ async function main() {
   });
   console.info(`  admin=${admin.email}  client=${ayla.email}  attacker=${mallory.email}`);
 
-  const client = await signIn(ayla.email);
-  const attacker = await signIn(mallory.email);
+  const client = await signIn(ayla);
+  const attacker = await signIn(mallory);
   const anon = new Browser();
   console.info(`  sessions established: ${client.jar.size > 0 && attacker.jar.size > 0}`);
 
@@ -283,9 +289,7 @@ async function main() {
 
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
   const cookieProbe = new Browser();
-  await cookieProbe.json("/api/auth/sign-in/magic-link", { email: ayla.email, callbackURL: "/" });
-  const link = await mailLink(ayla.email, VERIFY);
-  const setRes = await cookieProbe.raw(link!);
+  const setRes = await attemptSignIn(cookieProbe, usernameFor(ayla.email), TEST_PASSWORD);
   const cookieLines = setRes.headers.getSetCookie();
   const sessionCookie = cookieLines.find((c) => c.includes("session_token")) ?? "";
   probe("A02-httponly", "session cookie is HttpOnly", /HttpOnly/i.test(sessionCookie), sessionCookie.slice(0, 80));
@@ -302,17 +306,30 @@ async function main() {
   const { createInvite } = await import("../src/lib/invites");
   await createInvite({ email: "crypto@office.example", invitedById: admin.id });
   const inviteRow = await db.invite.findFirst({ where: { email: "crypto@office.example" } });
-  const inviteLinkUrl = await mailLink("crypto@office.example", /http:\/\/[^\s"'<]+\/invite\/[^\s"'<]+/);
+  const inviteLinkUrl = await mailLink("crypto@office.example", CLAIM);
   const rawInviteToken = inviteLinkUrl?.split("/invite/")[1] ?? "";
   probe("A02-invite-hash", "invite token is stored hashed, not in the clear",
         !!inviteRow && inviteRow.tokenHash !== rawInviteToken && /^[a-f0-9]{64}$/.test(inviteRow.tokenHash),
         `stored=${inviteRow?.tokenHash?.slice(0, 20)}…`);
 
+  // Reset tokens must be unusable straight out of the database too.
+  const resetUrl = await issuePasswordSetupUrl(ayla.id);
+  const rawResetToken = new URL(resetUrl).searchParams.get("token") ?? "";
   const verifications = await db.verification.findMany();
-  const magicRawInUrl = /token=([^&]+)/.exec(link ?? "")?.[1] ?? "";
-  probe("A02-magic-hash", "magic-link token is stored hashed, not in the clear",
-        verifications.every((v) => v.value !== magicRawInUrl && v.identifier !== magicRawInUrl),
-        "a raw magic-link token was found in the verification table");
+  probe("A02-reset-hash", "set-password token is stored hashed, not in the clear",
+        rawResetToken.length > 20 &&
+        verifications.every(
+          (v) => !v.identifier.includes(rawResetToken) && !v.value.includes(rawResetToken),
+        ),
+        "a raw set-password token was found in the verification table");
+
+  const storedPassword = (await db.account.findFirst({
+    where: { userId: ayla.id, providerId: "credential" },
+    select: { password: true },
+  }))?.password ?? "";
+  probe("A02-password-hash", "the account password is stored as a digest, never in the clear",
+        storedPassword.length > 20 && !storedPassword.includes(TEST_PASSWORD),
+        "the password, or something very like it, is readable in the account row");
 
   // =====================================================================
   section("A03 Injection");
@@ -320,10 +337,10 @@ async function main() {
   const sqlPayloads = ["' OR '1'='1", "'; DROP TABLE \"user\"; --", "\\'; SELECT pg_sleep(3); --"];
   let sqlOk = true;
   for (const p of sqlPayloads) {
-    const r = await anon.json("/api/auth/sign-in/magic-link", { email: `${p}@x.test`, callbackURL: "/" });
+    const r = await attemptSignIn(anon, p, "does-not-matter-at-all");
     if (r.status >= 500) sqlOk = false;
   }
-  probe("A03-sqli", "SQL metacharacters in the email field are handled", sqlOk,
+  probe("A03-sqli", "SQL metacharacters in the username field are handled", sqlOk,
         "a payload produced a 5xx, suggesting it reached the driver");
   probe("A03-sqli-intact", "user table still exists after injection attempts",
         (await db.user.count()) > 0);
@@ -357,9 +374,17 @@ async function main() {
   probe("A03-path-xss", "a hostile invite token is not reflected as markup",
         !badToken.includes("<script>alert(1)</script>"));
 
-  const crlf = await anon.json("/api/auth/sign-in/magic-link",
-    { email: "a@x.test\r\nBcc: victim@evil.test", callbackURL: "/" });
-  probe("A03-crlf", "CRLF in the email field does not reach the mailer", crlf.status < 500,
+  // Sign-up is the one public endpoint that takes an address at all, and the
+  // address it takes is the one an invitation would later be matched against.
+  const crlf = await anon.json("/api/auth/sign-up/email", {
+    email: "a@x.test\r\nBcc: victim@evil.test",
+    name: "Header Splitter",
+    username: "splitter",
+    password: TEST_PASSWORD,
+  });
+  probe("A03-crlf", "CRLF in the email field is refused, and never reaches the mailer",
+        crlf.status >= 400 && crlf.status < 500 &&
+        (await db.user.count({ where: { email: { contains: "\n" } } })) === 0,
         `status ${crlf.status}`);
 
   // =====================================================================
@@ -368,7 +393,7 @@ async function main() {
   // raw(), not go(): middleware redirects unknown paths to /signin, and
   // following that redirect would report the sign-in page's 200 as if a
   // signup route existed.
-  for (const path of ["/signup", "/register", "/api/auth/sign-up/email"]) {
+  for (const path of ["/signup", "/register"]) {
     const r = await anon.raw(APP + path);
     const landsOnSignin = (r.headers.get("location") ?? "").includes("/signin");
     probe(`A04-nosignup ${path}`, `${path} offers no public registration`,
@@ -376,14 +401,30 @@ async function main() {
           `status ${r.status} -> ${r.headers.get("location") ?? ""}`);
   }
 
+  // The sign-up endpoint does exist now — it is what an invitation link posts
+  // to. What must hold is that it refuses anybody without a pending invite,
+  // which is the invite-only rule and not a missing route.
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  const gatecrash = await anon.json("/api/auth/sign-up/email", {
+    email: "gatecrasher@nowhere.test",
+    name: "Gate Crasher",
+    username: "gatecrasher",
+    password: TEST_PASSWORD,
+  });
+  probe("A04-invitegate", "registration without a pending invite is refused",
+        gatecrash.status === 403 &&
+        (await db.user.count({ where: { email: "gatecrasher@nowhere.test" } })) === 0,
+        `status ${gatecrash.status}`);
+
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
   let limited = false;
-  for (let i = 0; i < 15; i++) {
-    const r = await anon.json("/api/auth/sign-in/magic-link", { email: ayla.email, callbackURL: "/" });
+  for (let i = 0; i < 25; i++) {
+    const r = await attemptSignIn(anon, usernameFor(ayla.email), `guess-${i}-nope`);
     if (r.status === 429) { limited = true; break; }
   }
-  probe("A04-ratelimit", "magic-link requests are rate limited", limited,
-        "15 requests in a row were all accepted");
+  probe("A04-ratelimit", "password guessing is rate limited", limited,
+        "25 wrong passwords in a row were all answered normally");
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
 
   // =====================================================================
   section("A05 Security Misconfiguration");
@@ -405,7 +446,7 @@ async function main() {
           `status ${r.status}`);
   }
 
-  const errRes = await anon.raw(`${APP}/api/auth/sign-in/magic-link`, {
+  const errRes = await anon.raw(`${APP}/api/auth/sign-in/username`, {
     method: "POST", headers: { "content-type": "application/json" }, body: "{not json",
   });
   const errBody = await errRes.text();
@@ -416,41 +457,68 @@ async function main() {
   section("A07 Identification and Authentication Failures");
 
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
-  const known = await anon.json("/api/auth/sign-in/magic-link", { email: ayla.email, callbackURL: "/" });
-  const unknown = await anon.json("/api/auth/sign-in/magic-link", { email: "nobody@nowhere.test", callbackURL: "/" });
-  probe("A07-enum", "known and unknown addresses are answered identically",
-        known.status === unknown.status,
-        `known=${known.status} unknown=${unknown.status}`);
+  const known = await attemptSignIn(anon, usernameFor(ayla.email), "wrong-password-entirely");
+  const unknown = await attemptSignIn(anon, "nobody-at-all", "wrong-password-entirely");
+  const knownBody = await known.clone().text();
+  const unknownBody = await unknown.clone().text();
+  probe("A07-enum", "a real username and an invented one are answered identically",
+        known.status === unknown.status && knownBody === unknownBody,
+        `known=${known.status} ${knownBody} unknown=${unknown.status} ${unknownBody}`);
 
-  // Magic links must not be replayable.
+  // The wall clock is the other half of the oracle: an unknown username must
+  // still pay for a password hash, or the timing says who exists.
+  const time = async (fn: () => Promise<unknown>) => {
+    const t0 = performance.now();
+    await fn();
+    return performance.now() - t0;
+  };
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
-  const replayer = new Browser();
-  await replayer.json("/api/auth/sign-in/magic-link", { email: ayla.email, callbackURL: "/" });
-  const once = await mailLink(ayla.email, VERIFY);
-  await replayer.go(once!);
-  const second = new Browser();
-  await second.go(once!);
-  const secondBody = await (await second.go(`${APP}/`)).text();
-  probe("A07-replay", "a magic link cannot be redeemed twice",
-        !isAuthenticated(secondBody),
-        "the same link minted a second session");
+  const knownMs = await time(() => attemptSignIn(anon, usernameFor(ayla.email), "wrong-password-entirely"));
+  const unknownMs = await time(() => attemptSignIn(anon, "nobody-at-all", "wrong-password-entirely"));
+  probe("A07-enum-timing", "an unknown username costs about as much as a wrong password",
+        Math.min(knownMs, unknownMs) / Math.max(knownMs, unknownMs) > 0.25,
+        `known=${knownMs.toFixed(0)}ms unknown=${unknownMs.toFixed(0)}ms`);
+
+  // A set-password link must not sign anybody in, and must not work twice.
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  const linkOnly = new Browser();
+  const setUrl = await issuePasswordSetupUrl(ayla.id);
+  const setToken = new URL(setUrl).searchParams.get("token")!;
+  const opened = await linkOnly.go(setUrl);
+  probe("A07-reset-nosession", "opening a set-password link does not sign anybody in",
+        !isAuthenticated(await opened.text()) && linkOnly.jar.size === 0,
+        "following a reset link established a session");
+
+  const RESET_TO = "ppp-probe-new-key-parked-outside";
+  const firstUse = await new Browser().json("/api/auth/reset-password",
+    { token: setToken, newPassword: RESET_TO });
+  const secondUse = await new Browser().json("/api/auth/reset-password",
+    { token: setToken, newPassword: "ppp-probe-third-key-parked-outside" });
+  probe("A07-replay", "a set-password link cannot be redeemed twice",
+        firstUse.status === 200 && secondUse.status >= 400,
+        `first=${firstUse.status} second=${secondUse.status}`);
+
+  // Setting a password revokes what the old one opened. `attacker` is left
+  // alone; only Ayla's sessions should be gone.
+  probe("A07-reset-revokes", "setting a new password ends the sessions the old one opened",
+        (await db.session.count({ where: { userId: ayla.id } })) === 0 &&
+        (await db.session.count({ where: { userId: mallory.id } })) > 0,
+        "a session outlived the password that opened it");
+
+  // Put the suite's own password back, so the probes after this still work.
+  await ensureCredentials(APP, ayla.id, usernameFor(ayla.email));
+  const client2 = await signIn(ayla);
 
   // Open redirect through the API's callbackURL.
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  const evil = await anon.json("/api/auth/sign-in/magic-link",
-    { email: ayla.email, callbackURL: "https://evil.example/steal" });
-  let redirectedOffsite = false;
-  if (evil.status < 400) {
-    const evilLink = await mailLink(ayla.email, VERIFY);
-    if (evilLink) {
-      const r = await new Browser().raw(evilLink);
-      redirectedOffsite = (r.headers.get("location") ?? "").startsWith("https://evil.example");
-    }
-  }
-  probe("A07-openredirect", "an off-site callbackURL is refused", !redirectedOffsite,
-        "the magic link redirected to an attacker-controlled origin");
+  const evil = await attemptSignIn(
+    new Browser(), usernameFor(ayla.email), TEST_PASSWORD,
+    { callbackURL: "https://evil.example/steal" },
+  );
+  const evilLocation = evil.headers.get("location") ?? "";
+  probe("A07-openredirect", "an off-site callbackURL is refused",
+        evil.status >= 400 && !evilLocation.startsWith("https://evil.example"),
+        `status ${evil.status} -> ${evilLocation}`);
 
   // The raw value does appear in the RSC flight payload as a page prop, which
   // is inert. What matters is whether anything *navigable* points off-site,
@@ -467,7 +535,7 @@ async function main() {
         protoRel.headers.get("location") ?? "");
 
   // Sign-out must kill the session server-side, not just drop the cookie.
-  const leaver = await signIn(ayla.email);
+  const leaver = client2;
   const stolen = new Map(leaver.jar);
   const signedOut = await leaver.raw(`${APP}/api/auth/sign-out`, {
     method: "POST",
@@ -499,18 +567,36 @@ async function main() {
 
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
   await createInvite({ email: "integrity@office.example", invitedById: admin.id });
-  const massAssign = new Browser();
-  await massAssign.json("/api/auth/sign-in/magic-link", {
-    email: "integrity@office.example", callbackURL: "/",
-    role: "admin", initials: "ZZ", emailVerified: true, banned: false,
-    invitedById: null, id: "chosen-by-attacker",
+
+  // Declared `input: false`, so the request is refused rather than trimmed.
+  const privileged = await new Browser().json("/api/auth/sign-up/email", {
+    email: "integrity@office.example",
+    name: "Ines Tegrity",
+    username: "integrity",
+    password: TEST_PASSWORD,
+    role: "admin", initials: "ZZ", invitedById: null,
   });
-  const ml = await mailLink("integrity@office.example", VERIFY);
-  if (ml) await massAssign.go(ml);
+  probe("A08-massassign-refused", "a sign-up carrying privileged fields is refused",
+        privileged.status === 400 &&
+        (await db.user.count({ where: { email: "integrity@office.example" } })) === 0,
+        `status ${privileged.status} ${(await privileged.clone().text()).slice(0, 90)}`);
+
+  // The rest reach the endpoint undeclared, and are overruled server-side.
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  await new Browser().json("/api/auth/sign-up/email", {
+    email: "integrity@office.example",
+    name: "Ines Tegrity",
+    username: "integrity",
+    password: TEST_PASSWORD,
+    emailVerified: false, banned: true, id: "chosen-by-attacker",
+  });
   const created = await db.user.findUnique({ where: { email: "integrity@office.example" } });
   probe("A08-massassign", "privileged fields cannot be set from the request body",
-        created?.role === "client" && created.initials !== "ZZ" && created.id !== "chosen-by-attacker",
-        JSON.stringify({ role: created?.role, initials: created?.initials, id: created?.id }));
+        created?.role === "client" && created.initials !== "ZZ" &&
+        created.id !== "chosen-by-attacker" && created.invitedById === admin.id &&
+        created.banned !== true,
+        JSON.stringify({ role: created?.role, initials: created?.initials,
+                         id: created?.id, banned: created?.banned }));
 
   probe("A08-lockfile", "a dependency lockfile is committed",
         await Bun_exists("package-lock.json"));
@@ -518,16 +604,13 @@ async function main() {
   // =====================================================================
   section("A10 Server-Side Request Forgery");
 
-  const ssrf = await anon.json("/api/auth/sign-in/magic-link",
-    { email: ayla.email, callbackURL: "http://169.254.169.254/latest/meta-data/" });
-  let hitMetadata = false;
-  if (ssrf.status < 400) {
-    const l = await mailLink(ayla.email, VERIFY);
-    if (l) {
-      const r = await new Browser().raw(l);
-      hitMetadata = (r.headers.get("location") ?? "").includes("169.254.169.254");
-    }
-  }
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  const ssrf = await attemptSignIn(
+    new Browser(), usernameFor(ayla.email), TEST_PASSWORD,
+    { callbackURL: "http://169.254.169.254/latest/meta-data/" },
+  );
+  const hitMetadata =
+    ssrf.status < 400 && (ssrf.headers.get("location") ?? "").includes("169.254.169.254");
   probe("A10-metadata", "a link-local callbackURL is refused", !hitMetadata,
         "the app would redirect a browser at the cloud metadata service");
 

--- a/scripts/verify-auth.ts
+++ b/scripts/verify-auth.ts
@@ -1,5 +1,5 @@
 /**
- * End-to-end check of the invite-only authentication flow.
+ * End-to-end check of invite-only registration and username/password sign-in.
  *
  *   docker compose up -d db mailpit
  *   npm run build && npm start          # or npm run dev
@@ -10,13 +10,15 @@
  * delivered mail out of Mailpit. Nothing is stubbed, so a pass means the
  * whole path works, not that the units agree with each other.
  *
- * DESTRUCTIVE: it wipes users, invites and verification tokens first. Point it
- * at a development database only.
+ * DESTRUCTIVE: it wipes users, invites, tokens and the audit trail first.
+ * Point it at a development database only.
  */
 import "./_env";
 import { PrismaClient } from "@prisma/client";
 import { db } from "../src/lib/db";
 import { createInvite, mailConfigured } from "../src/lib/invites";
+import { issuePasswordSetupUrl } from "../src/lib/password-reset";
+import { TEST_PASSWORD, ensureCredentials, signInWithPassword } from "./_accounts";
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
 const MAILPIT = process.env.MAILPIT_URL ?? "http://localhost:8025";
@@ -28,6 +30,9 @@ function check(name: string, ok: boolean, detail = "") {
   if (!ok) failures.push(name);
 }
 const section = (t: string) => console.info(`\n== ${t} ==`);
+
+/** Counters are per IP and every suite shares one; clear before each burst. */
+const clearRateLimit = () => db.$executeRawUnsafe('DELETE FROM "rateLimit"');
 
 // --- a cookie jar over fetch, so a "browser" persists between requests -----
 
@@ -108,6 +113,8 @@ const unescapeHtml = (s: string) =>
   s.replace(/&quot;/g, '"').replace(/&#x27;|&#39;/g, "'")
    .replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
 
+const signedIn = (b: Browser) => b.cookieNames.some((c) => c.includes("session_token"));
+
 // --- mailpit ---------------------------------------------------------------
 
 async function mailLink(to: string, pattern: RegExp): Promise<string | null> {
@@ -124,15 +131,27 @@ async function mailLink(to: string, pattern: RegExp): Promise<string | null> {
   return null;
 }
 
-const VERIFY_LINK = /http:\/\/[^\s"'<]+\/api\/auth\/magic-link\/verify[^\s"'<]*/;
 const CLAIM_LINK = /http:\/\/[^\s"'<]+\/invite\/[^\s"'<]+/;
+const SET_PASSWORD_LINK = /http:\/\/[^\s"'<]+\/set-password\?token=[^\s"'<]+/;
+
+/** Registration, as the sign-up endpoint sees it. */
+function signUp(browser: Browser, body: Record<string, unknown>) {
+  return browser.raw(`${APP}/api/auth/sign-up/email`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
 
 // --- the run ---------------------------------------------------------------
 
 async function main() {
   section("reset");
-  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  await clearRateLimit();
   await db.verification.deleteMany();
+  // The trail is append-only in the app, so a suite that asserts "exactly one
+  // of these happened" has to start from an empty one.
+  await db.auditEvent.deleteMany();
   await db.invite.deleteMany();
   await db.user.deleteMany({ where: { role: "client" } });
   await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
@@ -142,43 +161,35 @@ async function main() {
   console.info(`  admin: ${admin.name} <${admin.email}>`);
 
   // ------------------------------------------------------------------------
-  section("1. an uninvited stranger cannot get in");
+  section("1. an uninvited stranger cannot register");
   const STRANGER = "stranger@nowhere.test";
   const anon = new Browser();
 
-  const req = await anon.raw(`${APP}/api/auth/sign-in/magic-link`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ email: STRANGER, callbackURL: "/" }),
+  const uninvited = await signUp(anon, {
+    email: STRANGER,
+    name: "A Stranger",
+    username: "stranger",
+    password: TEST_PASSWORD,
   });
-  check("the request is answered identically for an unknown address", req.status === 200,
-        `status ${req.status}`);
-
-  const strangerLink = await mailLink(STRANGER, VERIFY_LINK);
-  check("a link is still sent, so the form is not a membership oracle",
-        strangerLink !== null);
-
-  if (strangerLink) {
-    const res = await anon.raw(strangerLink);
-    const loc = res.headers.get("location") ?? "";
-    check("following it does not sign the stranger in",
-          loc.includes("invite_required") || loc.includes("error"), `-> ${loc}`);
-  }
+  check("sign-up with no pending invite is refused", uninvited.status === 403,
+        `status ${uninvited.status}`);
+  check("and it says why, without hinting at a way round it",
+        (await uninvited.clone().text()).includes("invite"), "");
   check("no account was created",
         (await db.user.count({ where: { email: STRANGER } })) === 0);
+  check("no session came back", !signedIn(anon));
+  check("the refusal is in the audit trail",
+        (await db.auditEvent.count({
+          where: { action: "invite.rejected", subject: STRANGER },
+        })) > 0);
 
   // ------------------------------------------------------------------------
   section("2. the admin invites someone through the UI");
+  await ensureCredentials(APP, admin.id, "ruben");
   const ruben = new Browser();
-  await ruben.raw(`${APP}/api/auth/sign-in/magic-link`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ email: admin.email, callbackURL: "/" }),
-  });
-  const rubenLink = await mailLink(admin.email, VERIFY_LINK);
-  if (rubenLink) await ruben.go(rubenLink);
-  check("the admin has a session",
-        ruben.cookieNames.some((c) => c.includes("session_token")));
+  await clearRateLimit();
+  await signInWithPassword(ruben, APP, "ruben");
+  check("the admin has a session", signedIn(ruben));
 
   const AYLA = "ayla@office.example";
   const invitePage = await (await ruben.go(`${APP}/admin/invites`)).text();
@@ -192,7 +203,7 @@ async function main() {
   check("an invite row exists", (await db.invite.count({ where: { email: AYLA } })) === 1);
 
   // ------------------------------------------------------------------------
-  section("3. the invited person registers through the link");
+  section("3. the invitation link registers the account");
   const claimUrl = await mailLink(AYLA, CLAIM_LINK);
   check("an invitation email with a claim link arrived", claimUrl !== null, `${claimUrl}`);
   if (!claimUrl) throw new Error("no claim link; cannot continue");
@@ -201,15 +212,20 @@ async function main() {
   const claimPage = await (await ayla.go(claimUrl)).text();
   check("the claim page renders", claimPage.includes("will print things for you"));
   check("it shows the address the invite is bound to", claimPage.includes(AYLA));
+  check("it asks for a username and a password",
+        claimPage.includes('name="username"') && claimPage.includes('name="password"'));
 
-  const claimed = await ayla.submit(claimUrl, claimPage, { name: "Ayla Berg" });
-  const grant = claimed.headers.get("location") ?? "";
-  check("claiming issues a sign-in grant", grant.includes("magic-link/verify"),
-        `status ${claimed.status} -> ${grant.slice(0, 70)}`);
-
-  await ayla.go(new URL(grant, APP).toString());
-  check("a session cookie is set",
-        ayla.cookieNames.some((c) => c.includes("session_token")));
+  // Typed with a capital, on purpose: it should be accepted, folded for the
+  // identifier and kept as typed for display.
+  const claimed = await ayla.submit(claimUrl, claimPage, {
+    name: "Ayla Berg",
+    username: "Ayla",
+    password: TEST_PASSWORD,
+  });
+  check("registering redirects onward", claimed.status >= 300 && claimed.status < 400,
+        `status ${claimed.status}`);
+  check("and signs her in there and then", signedIn(ayla),
+        "registration did not establish a session");
 
   // `/` redirects to the board, which is the client's home per the handoff.
   const home = await (await ayla.go(`${APP}/`)).text();
@@ -229,10 +245,16 @@ async function main() {
         account.invitedById === admin.id &&
         account.emailVerified === true,
         JSON.stringify({ role: account?.role, initials: account?.initials }));
+  check("the username she chose is stored, folded to lower case",
+        account?.username === "ayla" && account.displayUsername === "Ayla",
+        JSON.stringify({ username: account?.username,
+                         displayUsername: account?.displayUsername }));
   check("the name she chose beat the one the admin guessed",
         account?.name === "Ayla Berg", account?.name);
   check("the invite is marked accepted",
         (await db.invite.findFirst({ where: { email: AYLA } }))?.acceptedAt !== null);
+  check("a password was actually stored, and not in the clear",
+        await passwordIsHashed(account!.id), "the account has no usable credential");
 
   // ------------------------------------------------------------------------
   section("4. the invitation link is single-use");
@@ -240,7 +262,82 @@ async function main() {
   check("a second visit is refused", replay.includes("has been used"));
 
   // ------------------------------------------------------------------------
-  section("5. a client cannot reach the admin surface");
+  section("5. signing in with a username and a password");
+  await clearRateLimit();
+  const returning = new Browser();
+  const good = await signInWithPassword(returning, APP, "ayla");
+  check("the right password is accepted", good.status === 200, `status ${good.status}`);
+  check("and a session cookie is set", signedIn(returning));
+
+  const mixedCase = new Browser();
+  await signInWithPassword(mixedCase, APP, "AyLa");
+  check("the username is matched case-insensitively", signedIn(mixedCase));
+
+  const wrongPassword = new Browser();
+  const bad = await signInWithPassword(wrongPassword, APP, "ayla", "not-the-password-x9");
+  check("a wrong password is refused", bad.status === 401, `status ${bad.status}`);
+  check("and no session is handed out", !signedIn(wrongPassword));
+
+  const noSuchUser = await signInWithPassword(new Browser(), APP, "nobody-here", "not-the-password-x9");
+  const badBody = await bad.clone().text();
+  const missingBody = await noSuchUser.clone().text();
+  check("an unknown username is answered exactly like a wrong password",
+        noSuchUser.status === bad.status && missingBody === badBody,
+        `${noSuchUser.status} ${missingBody} vs ${bad.status} ${badBody}`);
+
+  // ------------------------------------------------------------------------
+  section("6. a username is claimed once");
+  const DUP = "dup@office.example";
+  await createInvite({ email: DUP, invitedById: admin.id });
+  await clearRateLimit();
+  const dup = await signUp(new Browser(), {
+    email: DUP, name: "Dup Licate", username: "AYLA", password: TEST_PASSWORD,
+  });
+  check("a username somebody already has is refused", dup.status === 400,
+        `status ${dup.status}`);
+  check("even spelled differently — the comparison is case-insensitive",
+        (await dup.clone().text()).toUpperCase().includes("ALREADY"),
+        (await dup.clone().text()).slice(0, 120));
+  check("and no account was created",
+        (await db.user.count({ where: { email: DUP } })) === 0);
+
+  // ------------------------------------------------------------------------
+  section("7. a breached password is refused");
+  await clearRateLimit();
+  const breached = await signUp(new Browser(), {
+    email: DUP, name: "Dup Licate", username: "duplicate", password: "Password123!",
+  });
+  const breachedBody = await breached.clone().text();
+  check("a password from a known breach corpus does not get through",
+        breached.status === 400 && /breach|compromis/i.test(breachedBody),
+        `status ${breached.status} ${breachedBody.slice(0, 120)}`);
+  check("and still no account",
+        (await db.user.count({ where: { email: DUP } })) === 0);
+
+  // The same invite still works with a password that is not in the corpus,
+  // which is what makes the refusal a refusal rather than a broken flow.
+  const survivor = new Browser();
+  const ok = await signUp(survivor, {
+    email: DUP, name: "Dup Licate", username: "duplicate", password: TEST_PASSWORD,
+  });
+  check("a password that is not breached goes straight through", ok.status === 200,
+        `status ${ok.status}`);
+  await db.user.deleteMany({ where: { email: DUP } });
+
+  // ------------------------------------------------------------------------
+  section("8. guessing is rate limited");
+  await clearRateLimit();
+  let limited = false;
+  for (let i = 0; i < 25 && !limited; i++) {
+    const r = await signInWithPassword(new Browser(), APP, "ayla", `guess-${i}-nope`);
+    if (r.status === 429) limited = true;
+  }
+  check("repeated wrong passwords hit the limiter", limited,
+        "25 attempts in a row were all answered normally");
+  await clearRateLimit();
+
+  // ------------------------------------------------------------------------
+  section("9. a client cannot reach the admin surface");
   const denied = await ayla.go(`${APP}/admin/invites`);
   check("the guest list answers 404, not 403", denied.status === 404, `status ${denied.status}`);
 
@@ -251,23 +348,131 @@ async function main() {
         (await db.invite.count({ where: { email: "gatecrasher@nowhere.test" } })) === 0);
 
   // ------------------------------------------------------------------------
-  section("6. privileged fields cannot be set over the wire");
+  section("10. privileged fields cannot be set over the wire");
   const BOB = "bob@office.example";
   await createInvite({ email: BOB, invitedById: admin.id });
-  const bob = new Browser();
-  await bob.raw(`${APP}/api/auth/sign-in/magic-link`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      email: BOB, callbackURL: "/", role: "admin", initials: "XX",
-    }),
+
+  // `input: false` is not "quietly stripped": Better Auth refuses the whole
+  // request. Loud is the right failure — a sign-up that half-worked would be
+  // harder to notice than one that did not.
+  for (const field of ["role", "initials", "invitedById"] as const) {
+    await clearRateLimit();
+    const spoof = await signUp(new Browser(), {
+      email: BOB,
+      name: "Bob Ross",
+      username: "bob",
+      password: TEST_PASSWORD,
+      [field]: field === "role" ? "admin" : field === "initials" ? "XX" : admin.id,
+    });
+    check(`posting ${field} at sign-up is refused outright`, spoof.status === 400,
+          `status ${spoof.status} ${(await spoof.clone().text()).slice(0, 90)}`);
+  }
+  check("and none of those attempts left an account behind",
+        (await db.user.count({ where: { email: BOB } })) === 0);
+
+  // A clean sign-up: every one of those fields is written server-side, from
+  // the invite row rather than the request.
+  await clearRateLimit();
+  await signUp(new Browser(), {
+    email: BOB,
+    name: "Bob Ross",
+    username: "bob",
+    password: TEST_PASSWORD,
+    // Neither of these is declared at all, so they reach the endpoint and are
+    // simply overruled. That is the other half of the same guarantee.
+    id: "chosen-by-attacker",
+    emailVerified: false,
   });
-  const bobLink = await mailLink(BOB, VERIFY_LINK);
-  if (bobLink) await bob.go(bobLink);
   const bobRow = await db.user.findUnique({ where: { email: BOB } });
-  check("the posted role and initials are ignored",
-        bobRow?.role === "client" && bobRow.initials === "BO",
-        JSON.stringify({ role: bobRow?.role, initials: bobRow?.initials }));
+  check("role, initials and invitedById are stamped from the invite",
+        bobRow?.role === "client" &&
+        bobRow.initials === "BO" &&
+        bobRow.invitedById === admin.id,
+        JSON.stringify({ role: bobRow?.role, initials: bobRow?.initials,
+                         invitedById: bobRow?.invitedById }));
+  check("a chosen id and a posted emailVerified are overruled",
+        bobRow?.id !== "chosen-by-attacker" && bobRow?.emailVerified === true,
+        JSON.stringify({ id: bobRow?.id, emailVerified: bobRow?.emailVerified }));
+
+  // ------------------------------------------------------------------------
+  section("11. the admin can reset a forgotten password");
+  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
+  const guestList = await (await ruben.go(`${APP}/admin/invites`)).text();
+  check("members are listed with a recovery control",
+        guestList.includes("Ayla Berg") && guestList.includes("Forgotten password?"));
+
+  const resetForm = formContaining(guestList, `value="${account!.id}"`);
+  check("the control targets the right member", resetForm !== null);
+  const reset = await ruben.submit(`${APP}/admin/invites`, resetForm ?? "", {
+    userId: account!.id,
+  });
+  check("triggering it is accepted", reset.status < 400, `status ${reset.status}`);
+  check("it is audited as a request, by the admin who made it",
+        (await db.auditEvent.count({
+          where: { action: "password.reset_requested", actorId: admin.id },
+        })) === 1);
+
+  // Mail is configured in this run, so the link goes to her and NOT back to
+  // the admin — the same rule invitations follow.
+  const resetBody = await reset.clone().text();
+  check("with mail working, the link is not handed back to the admin",
+        !SET_PASSWORD_LINK.test(resetBody),
+        "the admin was shown a link that had already been emailed");
+
+  const setUrl = await mailLink(AYLA, SET_PASSWORD_LINK);
+  check("a set-password email arrived", setUrl !== null, String(setUrl));
+  if (!setUrl) throw new Error("no set-password link; cannot continue");
+
+  const recovering = new Browser();
+  const setPage = await (await recovering.go(setUrl)).text();
+  check("the link opens a set-password form", setPage.includes('name="password"'));
+  check("and it does NOT sign anybody in", !signedIn(recovering),
+        "following a reset link established a session");
+
+  // A breached password is refused here too — and, crucially, does not burn
+  // the link on the way out.
+  const refused = await recovering.submit(setUrl, setPage, { password: "Password123!" });
+  check("a breached password is refused at the set-password form",
+        /breach|compromis/i.test(await refused.clone().text()),
+        "a corpus password was accepted");
+
+  const NEW_PASSWORD = "ppp-suite-second-key-parked-outside";
+  const stillGood = await (await recovering.go(setUrl)).text();
+  check("the link survives a refused password", stillGood.includes('name="password"'),
+        "being told to pick another password spent the link");
+
+  const done = await recovering.submit(setUrl, stillGood, { password: NEW_PASSWORD });
+  check("a good password is accepted", done.status >= 300 && done.status < 400,
+        `status ${done.status}`);
+  check("and it is audited as completed",
+        (await db.auditEvent.count({
+          where: { action: "password.reset_completed", subject: AYLA },
+        })) === 1);
+
+  await clearRateLimit();
+  const oldTry = await signInWithPassword(new Browser(), APP, "ayla", TEST_PASSWORD);
+  check("the old password stops working", oldTry.status === 401, `status ${oldTry.status}`);
+
+  const newBrowser = new Browser();
+  const newTry = await signInWithPassword(newBrowser, APP, "ayla", NEW_PASSWORD);
+  check("the new one works", newTry.status === 200 && signedIn(newBrowser),
+        `status ${newTry.status}`);
+
+  const spent = await (await new Browser().go(setUrl)).text();
+  check("and the link is spent once it has been used", spent.includes("spent"),
+        "a used set-password link still opened the form");
+
+  check("her earlier session was revoked with the password",
+        (await (await ayla.raw(`${APP}/api/auth/get-session`)).text()).length < 5,
+        "a session opened with the old password outlived it");
+
+  // ------------------------------------------------------------------------
+  section("12. reset tokens are not stored in a form anyone can replay");
+  const rawToken = new URL(setUrl).searchParams.get("token")!;
+  const rows = await db.verification.findMany();
+  check("no verification row holds the raw token",
+        rows.every((v) => v.identifier !== rawToken && !v.identifier.includes(rawToken)),
+        "a raw set-password token was found in the verification table");
 
   // ------------------------------------------------------------------------
   section("mail is optional, not required");
@@ -318,8 +523,52 @@ async function main() {
     where: { email: { in: ["mailed@office.example", "handover@office.example"] } },
   });
 
+  // ------------------------------------------------------------------------
+  section("14. the printer owner bootstraps from a printed link");
+
+  // Exactly the state a fresh deploy is in: an admin row that nobody invited,
+  // with no username and no password. The seed prints a link for this; here
+  // the link is minted directly so the check does not depend on scraping
+  // container logs.
+  await db.account.deleteMany({ where: { userId: admin.id, providerId: "credential" } });
+  await db.user.update({
+    where: { id: admin.id },
+    data: { username: null, displayUsername: null },
+  });
+
+  const bootstrapUrl = await issuePasswordSetupUrl(admin.id);
+  const owner = new Browser();
+  const bootstrapPage = await (await owner.go(bootstrapUrl)).text();
+  check("an account with no username is asked for one",
+        bootstrapPage.includes('name="username"') && bootstrapPage.includes('name="password"'),
+        "the bootstrap link did not offer a username field");
+
+  const OWNER_PASSWORD = "ppp-suite-owner-key-parked-outside";
+  const bootstrapped = await owner.submit(bootstrapUrl, bootstrapPage, {
+    username: "Ruben",
+    password: OWNER_PASSWORD,
+  });
+  check("submitting it is accepted",
+        bootstrapped.status >= 300 && bootstrapped.status < 400,
+        `status ${bootstrapped.status}`);
+
+  const ownerRow = await db.user.findUnique({ where: { id: admin.id } });
+  check("the username is stored folded, with what was typed kept alongside",
+        ownerRow?.username === "ruben" && ownerRow.displayUsername === "Ruben",
+        JSON.stringify({ username: ownerRow?.username,
+                         displayUsername: ownerRow?.displayUsername }));
+
+  await clearRateLimit();
+  const ownerIn = new Browser();
+  const ownerSignIn = await signInWithPassword(ownerIn, APP, "ruben", OWNER_PASSWORD);
+  check("and the printer owner can sign in with it",
+        ownerSignIn.status === 200 && signedIn(ownerIn), `status ${ownerSignIn.status}`);
+
+  const ownerHome = await (await ownerIn.go(`${APP}/admin/invites`)).text();
+  check("as the admin, not as a client", ownerHome.includes("The guest list"));
+
   // --------------------------------------------------------------------------
-  section("7. the database itself permits only one admin");
+  section("13. the database itself permits only one admin");
   check("exactly one admin exists",
         (await db.user.count({ where: { role: "admin" } })) === 1);
   // A client with logging off: the constraint violation below is the expected
@@ -349,6 +598,22 @@ async function main() {
       : `${failures.length} FAILED:\n  - ${failures.join("\n  - ")}`),
   );
   process.exitCode = failures.length === 0 ? 0 : 1;
+}
+
+/** A stored password must be a digest, never the password itself. */
+async function passwordIsHashed(userId: string): Promise<boolean> {
+  const account = await db.account.findFirst({
+    where: { userId, providerId: "credential" },
+    select: { password: true },
+  });
+  const stored = account?.password ?? "";
+  return stored.length > 0 && !stored.includes(TEST_PASSWORD);
+}
+
+/** The one `<form>` on the page whose markup contains a marker. */
+function formContaining(html: string, marker: string): string | null {
+  const forms = html.match(/<form\b[\s\S]*?<\/form>/g) ?? [];
+  return forms.find((f) => f.includes(marker)) ?? null;
 }
 
 main()

--- a/scripts/verify-passkey.ts
+++ b/scripts/verify-passkey.ts
@@ -13,11 +13,11 @@
  */
 import "./_env";
 import { existsSync } from "node:fs";
-import puppeteer, { type Browser } from "puppeteer-core";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
 import { db } from "../src/lib/db";
+import { TEST_PASSWORD, ensureCredentials } from "./_accounts";
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
-const MAILPIT = process.env.MAILPIT_URL ?? "http://localhost:8025";
 /**
  * The real executable, not a launcher. /snap/bin/chromium is a symlink to the
  * snap wrapper, which does not forward puppeteer's flags.
@@ -39,21 +39,19 @@ function check(name: string, ok: boolean, detail = "") {
   ok ? passed++ : failures.push(name);
 }
 
-async function magicLinkFor(email: string): Promise<string | null> {
+/**
+ * Sign in through the real form, so the session exists before any passkey
+ * does. Typed rather than posted: this is the screen a person uses, and if it
+ * cannot be driven with a keyboard the passkey path is being tested on top of
+ * something broken.
+ */
+async function signInWithPassword(page: Page, username: string): Promise<void> {
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
-  await fetch(`${APP}/api/auth/sign-in/magic-link`, {
-    method: "POST",
-    headers: { "content-type": "application/json", origin: APP },
-    body: JSON.stringify({ email, callbackURL: "/board" }),
-  });
-  const list = await (await fetch(`${MAILPIT}/api/v1/messages?limit=50`)).json();
-  for (const m of list.messages ?? []) {
-    const body = await (await fetch(`${MAILPIT}/api/v1/message/${m.ID}`)).json();
-    const hit = /http:\/\/[^\s"'<]+\/api\/auth\/magic-link\/verify[^\s"'<]*/.exec(body.Text ?? "");
-    if (hit) return hit[0].replace(/[.,]$/, "");
-  }
-  return null;
+  await page.goto(`${APP}/signin`, { waitUntil: "networkidle2" });
+  await page.type("#username", username);
+  await page.type("#password", TEST_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForFunction(() => location.pathname !== "/signin", { timeout: 15_000 });
 }
 
 async function main() {
@@ -96,23 +94,22 @@ async function main() {
     });
     check("a virtual authenticator is attached", !!authenticatorId);
 
-    // --- sign in with a magic link so there is a session to enrol against ---
-    const link = await magicLinkFor(email);
-    if (!link) throw new Error("no magic link was delivered");
-    await page.goto(link, { waitUntil: "networkidle2" });
-    check("signed in via magic link",
+    // --- sign in with a password so there is a session to enrol against ---
+    await ensureCredentials(APP, user.id, "petra");
+    await signInWithPassword(page, "petra");
+    check("signed in with a username and a password",
           (await db.session.count({ where: { userId: user.id } })) === 1);
 
     // --- the nudge: the only thing that reaches someone who skipped ---
     await page.goto(`${APP}/board`, { waitUntil: "networkidle2" });
     await page.waitForFunction(
-      () => document.body.innerText.includes("Tired of waiting"),
+      () => document.body.innerText.includes("Tired of typing"),
       { timeout: 8_000 },
     ).catch(() => {});
     const beforeEnrol = await page.evaluate(() => document.body.innerText);
     check("someone with no passkey is prompted to get one",
-          beforeEnrol.includes("Tired of waiting"),
-          "no nudge — a skipper would stay on emailed links forever");
+          beforeEnrol.includes("Tired of typing"),
+          "no nudge — a skipper would type a password forever");
 
     // --- register a passkey ---
     await page.goto(`${APP}/welcome`, { waitUntil: "networkidle2" });
@@ -141,7 +138,7 @@ async function main() {
     await page.goto(`${APP}/board`, { waitUntil: "networkidle2" });
     const afterEnrol = await page.evaluate(() => document.body.innerText);
     check("the prompt disappears once a passkey exists",
-          !afterEnrol.includes("Tired of waiting"), "still nagging after enrolment");
+          !afterEnrol.includes("Tired of typing"), "still nagging after enrolment");
 
     // --- sign out, then sign back in with the passkey alone ---
     await page.evaluate(async () => {

--- a/scripts/verify-queue.ts
+++ b/scripts/verify-queue.ts
@@ -11,9 +11,9 @@ import "./_env";
  * DESTRUCTIVE: wipes users and stories. Development database only.
  */
 import { db } from "../src/lib/db";
+import { ensureCredentials, signInWithPassword, usernameFor } from "./_accounts";
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
-const MAILPIT = process.env.MAILPIT_URL ?? "http://localhost:8025";
 
 let passed = 0;
 const failures: string[] = [];
@@ -93,22 +93,20 @@ const unescapeHtml = (s: string) =>
   s.replace(/&quot;/g, '"').replace(/&#x27;|&#39;/g, "'")
    .replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
 
-async function signIn(email: string): Promise<Browser> {
+/**
+ * A signed-in browser for an existing user row.
+ *
+ * Takes the id as well as the address because a password is set against the
+ * account, not the mailbox: `ensureCredentials` gives the row a username and
+ * a password through the app's own reset endpoint, and the sign-in below is
+ * the same request the sign-in form makes. `verify:auth` owns the real
+ * registration path; this is the short way to a session.
+ */
+async function signIn(user: { id: string; email: string }): Promise<Browser> {
   const b = new Browser();
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
-  await b.raw(`${APP}/api/auth/sign-in/magic-link`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ email, callbackURL: "/" }),
-  });
-  const list = await (await fetch(`${MAILPIT}/api/v1/messages?limit=50`)).json();
-  for (const m of list.messages ?? []) {
-    if (!(m.To ?? []).some((a: { Address?: string }) => a.Address?.toLowerCase() === email)) continue;
-    const body = await (await fetch(`${MAILPIT}/api/v1/message/${m.ID}`)).json();
-    const hit = /http:\/\/[^\s"'<]+\/api\/auth\/magic-link\/verify[^\s"'<]*/.exec(body.Text ?? "");
-    if (hit) { await b.go(hit[0].replace(/[.,]$/, "")); break; }
-  }
+  await ensureCredentials(APP, user.id, usernameFor(user.email));
+  await signInWithPassword(b, APP, usernameFor(user.email));
   return b;
 }
 
@@ -147,8 +145,8 @@ async function main() {
             role: "client", emailVerified: true, invitedById: admin.id },
   });
 
-  const ruben = await signIn(admin.email);
-  const client = await signIn(ayla.email);
+  const ruben = await signIn(admin);
+  const client = await signIn(ayla);
   console.info(`  admin=${admin.email}  client=${ayla.email}`);
 
   // ------------------------------------------------------------------
@@ -342,7 +340,7 @@ async function main() {
     data: { email: "mallory@office.example", name: "Mallory Vance", initials: "MA",
             role: "client", emailVerified: true, invitedById: admin.id },
   });
-  const other = await signIn(mallory.email);
+  const other = await signIn(mallory);
   const trespass = new FormData();
   trespass.set("storyId", String(talk.id));
   trespass.set("body", "I should not be able to say this");
@@ -364,43 +362,40 @@ async function main() {
         "raw markup from a comment reached the page");
 
   // ------------------------------------------------------------------
-  section("re-issuing access when someone loses their passkey");
+  section("resetting a password from the guest list");
 
   const guestList = await (await ruben.go(`${APP}/admin/invites`)).text();
   check("members are listed with a recovery control",
-        rendered(guestList).includes("Ayla Berg") && guestList.includes("Lost access?"));
+        rendered(guestList).includes("Ayla Berg") && guestList.includes("Forgotten password?"));
 
-  const reissueIdx = formIndexContaining(guestList, `value="${ayla.id}"`);
-  check("the control targets the right member", reissueIdx >= 0);
-  const reissued = await ruben.submit(`${APP}/admin/invites`, guestList, reissueIdx, {});
-  const reissuedBody = await reissued.text();
-  const linkMatch = /http:\/\/[^\s"'<\\]+\/api\/auth\/magic-link\/verify[^\s"'<\\]*/.exec(reissuedBody);
-  check("a sign-in link comes back for the admin to hand over", linkMatch !== null,
-        reissuedBody.slice(0, 160));
+  const resetIdx = formIndexContaining(guestList, `value="${ayla.id}"`);
+  check("the control targets the right member", resetIdx >= 0);
+  const reset = await ruben.submit(`${APP}/admin/invites`, guestList, resetIdx, {});
+  const resetBody = await reset.text();
 
-  check("and it is recorded loudly — it signs someone in as that person",
+  // A transport is configured in this run, so the link goes to her inbox and
+  // the admin is told it was sent rather than being handed the token.
+  check("the admin is told it went out, not shown the link",
+        resetBody.includes("Sent to") && !resetBody.includes("/set-password?token="),
+        resetBody.slice(0, 200));
+
+  check("and it is recorded, by the admin who asked for it",
         (await db.auditEvent.count({
-          where: { action: "access.reissued", actorId: admin.id },
+          where: { action: "password.reset_requested", actorId: admin.id },
         })) === 1);
 
-  if (linkMatch) {
-    const recovered = new Browser();
-    await recovered.go(linkMatch[0].replace(/&amp;/g, "&"));
-    const landed = await (await recovered.go(`${APP}/board`)).text();
-    check("the link really signs that person in",
-          rendered(landed).includes("Private to you and"),
-          "the recovery link did not establish a session");
-    check("as the client, not the admin",
-          !rendered(landed).includes("Admin view"),
-          "the recovery link granted admin access");
-  }
+  // Asking for a reset must not itself sign anybody out. Only using the link
+  // does that, which is what makes the control safe to press by mistake.
+  check("her existing session survives the request",
+        (await db.session.count({ where: { userId: ayla.id } })) > 0,
+        "requesting a reset revoked a session before a password was set");
 
   const clientTry = new FormData();
   clientTry.set("userId", admin.id);
   await client.raw(`${APP}/admin/invites`, { method: "POST", body: clientTry });
   check("a client cannot mint one for anybody",
-        (await db.auditEvent.count({ where: { action: "access.reissued" } })) === 1,
-        "a client re-issued access");
+        (await db.auditEvent.count({ where: { action: "password.reset_requested" } })) === 1,
+        "a client triggered a password reset");
 
   // ------------------------------------------------------------------
   section("the uploader sees what happened");

--- a/scripts/verify-upload.ts
+++ b/scripts/verify-upload.ts
@@ -13,6 +13,7 @@ import "./_env";
 import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 
 import { db } from "../src/lib/db";
+import { ensureCredentials, signInWithPassword, usernameFor } from "./_accounts";
 
 /**
  * A client of its own rather than the app's.
@@ -33,7 +34,6 @@ const s3 = new S3Client({
 });
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
-const MAILPIT = process.env.MAILPIT_URL ?? "http://localhost:8025";
 const BUCKET = process.env.S3_BUCKET ?? "ppp-models";
 
 let passed = 0;
@@ -82,27 +82,20 @@ class Browser {
   }
 }
 
-async function signIn(email: string): Promise<Browser> {
+/**
+ * A signed-in browser for an existing user row.
+ *
+ * Takes the id as well as the address because a password is set against the
+ * account, not the mailbox: `ensureCredentials` gives the row a username and
+ * a password through the app's own reset endpoint, and the sign-in below is
+ * the same request the sign-in form makes. `verify:auth` owns the real
+ * registration path; this is the short way to a session.
+ */
+async function signIn(user: { id: string; email: string }): Promise<Browser> {
   const b = new Browser();
   await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
-  await fetch(`${MAILPIT}/api/v1/messages`, { method: "DELETE" });
-  await b.raw(`${APP}/api/auth/sign-in/magic-link`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ email, callbackURL: "/" }),
-  });
-  const list = await (await fetch(`${MAILPIT}/api/v1/messages?limit=50`)).json();
-  for (const m of list.messages ?? []) {
-    if (!(m.To ?? []).some((a: { Address?: string }) => a.Address?.toLowerCase() === email)) continue;
-    const body = await (await fetch(`${MAILPIT}/api/v1/message/${m.ID}`)).json();
-    const link = /http:\/\/[^\s"'<]+\/api\/auth\/magic-link\/verify[^\s"'<]*/.exec(
-      `${body.Text ?? ""}`,
-    );
-    if (link) {
-      await b.go(link[0].replace(/[.,]$/, ""));
-      break;
-    }
-  }
+  await ensureCredentials(APP, user.id, usernameFor(user.email));
+  await signInWithPassword(b, APP, usernameFor(user.email));
   return b;
 }
 
@@ -163,9 +156,9 @@ async function main() {
             role: "client", emailVerified: true, invitedById: admin.id },
   });
 
-  const aylaB = await signIn(ayla.email);
-  const jonasB = await signIn(jonas.email);
-  const rubenB = await signIn(admin.email);
+  const aylaB = await signIn(ayla);
+  const jonasB = await signIn(jonas);
+  const rubenB = await signIn(admin);
   const anon = new Browser();
   check("three sessions established",
         [aylaB, jonasB, rubenB].every((b) => [...b.jar.keys()].some((k) => k.includes("session_token"))));

--- a/src/app/admin/invites/actions.ts
+++ b/src/app/admin/invites/actions.ts
@@ -3,12 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
-import { headers } from "next/headers";
-
 import { db } from "@/lib/db";
-import { issueSignInUrl } from "@/lib/auth";
 import { requireAdmin } from "@/lib/authz";
 import { record } from "@/lib/audit";
+import { passwordResetEmail, sendMail } from "@/lib/email";
 import {
   createInvite,
   InviteError,
@@ -16,6 +14,11 @@ import {
   revokeInvite,
   isUniqueViolation,
 } from "@/lib/invites";
+import {
+  RESET_TTL_MINUTES,
+  issuePasswordSetupUrl,
+  revokePasswordSetupLinks,
+} from "@/lib/password-reset";
 
 export type InviteFormState = {
   error?: string;
@@ -104,20 +107,19 @@ export async function revokeInviteAction(formData: FormData): Promise<void> {
 }
 
 /**
- * Give an existing member a fresh way in.
+ * Reset a member's password.
  *
- * The answer to "I wiped my phone and the passkey went with it", and to
- * "the mail server is down and nobody can sign in". Mints a single-use
- * ten-minute sign-in link and hands it to the admin rather than mailing it,
- * because the case this exists for is precisely the one where mail is not an
- * option.
+ * The answer to "I have forgotten it", and to "I wiped the phone my passkey
+ * lived on". Mints a single-use link that lets them choose a new password —
+ * it does not sign anybody in, which is the meaningful difference from the
+ * sign-in link this replaces. Whoever holds that link can set a password and
+ * then has to use it; the old one stops working the moment they do.
  *
- * This is impersonation-shaped: whoever holds the link is signed in as that
- * person. It grants the printer owner nothing they did not already have —
- * they own the machine and the database — but it is recorded loudly, because
- * an audited action beats a quiet UPDATE.
+ * Mailed when there is a transport, handed to the admin when there is not,
+ * which is the same split invitations use and the reason the app needs no
+ * mail server at all.
  */
-export async function reissueAccessAction(
+export async function resetPasswordAction(
   _prev: InviteFormState,
   formData: FormData,
 ): Promise<InviteFormState> {
@@ -132,19 +134,43 @@ export async function reissueAccessAction(
 
   let url: string;
   try {
-    url = await issueSignInUrl(target.email, await headers(), "/");
+    // Any earlier link goes first: "reset it again" should leave exactly one
+    // live link, and the older one is the likelier to have gone astray.
+    await revokePasswordSetupLinks(target.id);
+    url = await issuePasswordSetupUrl(target.id);
   } catch (error) {
-    console.error("reissue failed", error);
+    console.error("password reset failed", error);
     return { error: "That link could not be created. Try again." };
   }
 
+  // A transport that refuses is treated as no transport: the link already
+  // exists, and showing it to the admin beats losing it to a bounced send.
+  let delivered = false;
+  try {
+    delivered = await sendMail(
+      passwordResetEmail({
+        to: target.email,
+        url,
+        expiresInMinutes: RESET_TTL_MINUTES,
+      }),
+    );
+  } catch (error) {
+    console.error("reset mail failed; handing the link over instead", error);
+  }
+
   await record({
-    action: "access.reissued",
+    action: "password.reset_requested",
     actor: admin,
     subject: target.email,
-    detail: { forName: target.name, validMinutes: 10, singleUse: true },
+    detail: {
+      forName: target.name,
+      validMinutes: RESET_TTL_MINUTES,
+      delivery: delivered ? "email" : "handover",
+    },
   });
 
   revalidatePath("/admin/invites");
-  return { sent: target.email, handoverUrl: url };
+  // Same rule as invitations: when the link was delivered it stays inside the
+  // message, so not even the admin who triggered it can replay it.
+  return delivered ? { sent: target.email } : { sent: target.email, handoverUrl: url };
 }

--- a/src/app/admin/invites/page.tsx
+++ b/src/app/admin/invites/page.tsx
@@ -4,9 +4,10 @@ import type { Invite } from "@prisma/client";
 import { db } from "@/lib/db";
 import { requireAdmin } from "@/lib/authz";
 import { INVITE_TTL_DAYS } from "@/lib/invites";
+import { RESET_TTL_MINUTES } from "@/lib/password-reset";
 import { Kicker, StatusChip } from "@/components/ui";
 import { InviteForm } from "./invite-form";
-import { ReissueAccess } from "@/components/reissue-access";
+import { ResetPassword } from "@/components/reset-password";
 import { resendInviteAction, revokeInviteAction } from "./actions";
 
 export const dynamic = "force-dynamic";
@@ -104,7 +105,11 @@ export default async function InvitesPage() {
                   <p className="m-0 font-display text-[17px] text-ink">{m.name}</p>
                   <p className="m-0 font-mono text-[11.5px] text-ink-3">{m.email}</p>
                 </div>
-                <ReissueAccess userId={m.id} name={m.name.split(" ")[0] ?? m.name} />
+                <ResetPassword
+                  userId={m.id}
+                  name={m.name.split(" ")[0] ?? m.name}
+                  expiresInMinutes={RESET_TTL_MINUTES}
+                />
               </div>
             ))}
           </div>

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -2,8 +2,8 @@ import { toNextJsHandler } from "better-auth/next-js";
 import { auth } from "@/lib/auth";
 
 /**
- * Every Better Auth endpoint — magic link issue/verify, passkey
- * register/authenticate, session, sign-out, admin — hangs off this one
- * catch-all. Nothing else in the app mints or reads credentials directly.
+ * Every Better Auth endpoint — sign-up, username sign-in, reset-password,
+ * passkey register/authenticate, session, sign-out, admin — hangs off this
+ * one catch-all. Nothing else in the app mints or reads credentials directly.
  */
 export const { GET, POST } = toNextJsHandler(auth.handler);

--- a/src/app/invite/[token]/actions.ts
+++ b/src/app/invite/[token]/actions.ts
@@ -5,15 +5,60 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 
 import { db } from "@/lib/db";
-import { issueSignInUrl } from "@/lib/auth";
+import { auth } from "@/lib/auth";
+import {
+  PASSWORD_MAX,
+  PASSWORD_MIN,
+  USERNAME_MAX,
+  USERNAME_MIN,
+  USERNAME_PATTERN,
+  USERNAME_RULE,
+} from "@/lib/auth-rules";
 import { checkInviteToken } from "@/lib/invites";
 
 const ClaimSchema = z.object({
   token: z.string().min(1),
   name: z.string().trim().min(1, "Tell us what to call you.").max(80),
+  // Passed on as typed. The username plugin folds it to lower case for
+  // `username` and keeps the original in `displayUsername`, so the person
+  // sees back what they wrote and still signs in either way.
+  username: z
+    .string()
+    .trim()
+    .min(USERNAME_MIN, `A username needs at least ${USERNAME_MIN} characters.`)
+    .max(USERNAME_MAX, `A username can be at most ${USERNAME_MAX} characters.`)
+    .regex(USERNAME_PATTERN, USERNAME_RULE),
+  password: z
+    .string()
+    .min(PASSWORD_MIN, `A password needs at least ${PASSWORD_MIN} characters.`)
+    .max(PASSWORD_MAX, `That password is longer than ${PASSWORD_MAX} characters.`),
 });
 
-export type ClaimState = { error?: string };
+/** `field` puts the message against the input it belongs to. */
+export type ClaimState = {
+  error?: string;
+  field?: "name" | "username" | "password";
+};
+
+/** Better Auth's codes, in the words the person at the keyboard needs. */
+function claimFailure(code: string | undefined, message: string): ClaimState {
+  switch (code) {
+    case "USERNAME_IS_ALREADY_TAKEN":
+      return { error: "Somebody already has that username. Try another.", field: "username" };
+    case "USERNAME_TOO_SHORT":
+    case "USERNAME_TOO_LONG":
+    case "INVALID_USERNAME":
+      return { error: USERNAME_RULE, field: "username" };
+    case "PASSWORD_COMPROMISED":
+      return { error: message, field: "password" };
+    case "PASSWORD_TOO_SHORT":
+      return { error: `A password needs at least ${PASSWORD_MIN} characters.`, field: "password" };
+    case "PASSWORD_TOO_LONG":
+      return { error: `That password is longer than ${PASSWORD_MAX} characters.`, field: "password" };
+    default:
+      return { error: message || "That did not go through. Try again." };
+  }
+}
 
 /**
  * Turn a valid invite into an account.
@@ -21,6 +66,11 @@ export type ClaimState = { error?: string };
  * The token is re-checked here rather than trusted from the page render: the
  * page may have been sitting open while the invite was revoked or claimed
  * elsewhere.
+ *
+ * Registration goes through Better Auth's own sign-up rather than a direct
+ * insert, which is what keeps the two server-side rules attached to it — the
+ * `user.validateUserInfo` invite gate, and the `user.create.before` hook that
+ * stamps `role`, `initials` and `invitedById` from the invite row.
  */
 export async function acceptInvite(
   _prev: ClaimState,
@@ -29,9 +79,15 @@ export async function acceptInvite(
   const parsed = ClaimSchema.safeParse({
     token: formData.get("token"),
     name: formData.get("name"),
+    username: formData.get("username"),
+    password: formData.get("password"),
   });
   if (!parsed.success) {
-    return { error: parsed.error.issues[0]?.message ?? "Check the form." };
+    const issue = parsed.error.issues[0];
+    return {
+      error: issue?.message ?? "Check the form.",
+      field: issue?.path[0] as ClaimState["field"],
+    };
   }
 
   const check = await checkInviteToken(parsed.data.token);
@@ -47,13 +103,27 @@ export async function acceptInvite(
     data: { name: parsed.data.name },
   });
 
-  const url = await issueSignInUrl(
-    check.invite.email,
-    await headers(),
-    "/welcome",
-  );
+  try {
+    await auth.api.signUpEmail({
+      body: {
+        email: check.invite.email,
+        name: parsed.data.name,
+        username: parsed.data.username,
+        password: parsed.data.password,
+      },
+      headers: await headers(),
+    });
+  } catch (error) {
+    const e = error as { body?: { code?: string; message?: string }; message?: string };
+    const code = e.body?.code;
+    if (code === "invite_required") {
+      // The invite went away between the check above and here.
+      redirect(`/invite/${encodeURIComponent(parsed.data.token)}`);
+    }
+    return claimFailure(code, e.body?.message ?? e.message ?? "");
+  }
 
-  // Redeeming the link is what actually creates the user and the session —
-  // it runs the same validation any magic link would.
-  redirect(url);
+  // `nextCookies()` has copied the session cookie into the response by now, so
+  // /welcome renders for the person who just registered.
+  redirect("/welcome");
 }

--- a/src/app/invite/[token]/claim-form.tsx
+++ b/src/app/invite/[token]/claim-form.tsx
@@ -3,14 +3,38 @@
 import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 import { acceptInvite, type ClaimState } from "./actions";
+import { PASSWORD_MIN, USERNAME_MAX, USERNAME_MIN } from "@/lib/auth-rules";
 import { Button, Input, Label, Notice } from "@/components/ui";
 
 function Submit() {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending} className="w-full">
-      {pending ? "Setting you up…" : "Claim your account"}
+      {pending ? "Setting you up…" : "Create your account"}
     </Button>
+  );
+}
+
+/** The hint under a field, or the error if this is the field that failed. */
+function Hint({
+  state,
+  field,
+  children,
+}: {
+  state: ClaimState;
+  field: NonNullable<ClaimState["field"]>;
+  children: React.ReactNode;
+}) {
+  const failed = state.field === field && state.error;
+  return (
+    <p
+      id={`${field}-hint`}
+      className={`mt-[6px] text-[12.5px] leading-[1.4] ${
+        failed ? "font-bold text-cherry-dk" : "font-mono uppercase tracking-[0.04em] text-ink-3"
+      }`}
+    >
+      {failed ? state.error : children}
+    </p>
   );
 }
 
@@ -52,10 +76,55 @@ export function ClaimForm({
           defaultValue={suggestedName}
           placeholder="Ayla Berg"
           autoComplete="name"
+          aria-describedby="name-hint"
+          aria-invalid={state.field === "name" || undefined}
         />
+        <Hint state={state} field="name">
+          Shown on your tickets and in the conversation.
+        </Hint>
       </div>
 
-      {state.error && <Notice tone="warn">{state.error}</Notice>}
+      <div>
+        <Label htmlFor="username">Pick a username</Label>
+        <Input
+          id="username"
+          name="username"
+          required
+          minLength={USERNAME_MIN}
+          maxLength={USERNAME_MAX}
+          pattern="[A-Za-z0-9_\-]+"
+          placeholder="ayla"
+          autoComplete="username"
+          autoCapitalize="none"
+          spellCheck={false}
+          aria-describedby="username-hint"
+          aria-invalid={state.field === "username" || undefined}
+        />
+        <Hint state={state} field="username">
+          What you sign in with — letters, digits, - and _
+        </Hint>
+      </div>
+
+      <div>
+        <Label htmlFor="password">And a password</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          required
+          minLength={PASSWORD_MIN}
+          autoComplete="new-password"
+          aria-describedby="password-hint"
+          aria-invalid={state.field === "password" || undefined}
+        />
+        <Hint state={state} field="password">
+          At least {PASSWORD_MIN} characters. Length beats punctuation.
+        </Hint>
+      </div>
+
+      {/* Anything the fields could not carry: a revoked invite, a refused
+          breach check, a server that fell over. */}
+      {state.error && !state.field && <Notice tone="warn">{state.error}</Notice>}
 
       <Submit />
     </form>

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -62,8 +62,8 @@ export default async function InvitePage({
       <Lead>
         Upload an <span className="font-mono">.stl</span> or{" "}
         <span className="font-mono">.3mf</span>, say what you are hoping for,
-        and it lands on the backlog as a story you can follow. Two details and
-        you are in.
+        and it lands on the backlog as a story you can follow. Pick a name to
+        go by, a username and a password, and you are in.
       </Lead>
 
       <ClaimForm
@@ -74,8 +74,9 @@ export default async function InvitePage({
 
       <div className="mt-[22px]">
         <Notice>
-          No password to pick. Claiming the account signs you in on this device,
-          and you can add a passkey on the next screen.
+          This link registers the account — there is no second email. You are
+          signed in the moment it is created, and the next screen offers a
+          passkey so you can skip the password on this device.
         </Notice>
       </div>
     </AuthShell>

--- a/src/app/set-password/actions.ts
+++ b/src/app/set-password/actions.ts
@@ -1,0 +1,154 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+
+import { auth } from "@/lib/auth";
+import {
+  PASSWORD_MAX,
+  PASSWORD_MIN,
+  USERNAME_MAX,
+  USERNAME_MIN,
+  USERNAME_PATTERN,
+  USERNAME_RULE,
+} from "@/lib/auth-rules";
+import { db } from "@/lib/db";
+import { record } from "@/lib/audit";
+import { isUniqueViolation } from "@/lib/invites";
+import { readResetToken, restorePasswordSetupLink } from "@/lib/password-reset";
+
+const SetPasswordSchema = z.object({
+  token: z.string().min(1),
+  password: z
+    .string()
+    .min(PASSWORD_MIN, `A password needs at least ${PASSWORD_MIN} characters.`)
+    .max(PASSWORD_MAX, `That password is longer than ${PASSWORD_MAX} characters.`),
+  /** Only asked for by an account that has none yet — the seeded admin. */
+  username: z
+    .string()
+    .trim()
+    .min(USERNAME_MIN, `A username needs at least ${USERNAME_MIN} characters.`)
+    .max(USERNAME_MAX, `A username can be at most ${USERNAME_MAX} characters.`)
+    .regex(USERNAME_PATTERN, USERNAME_RULE)
+    .optional(),
+});
+
+export type SetPasswordState = { error?: string; field?: "username" | "password" };
+
+const SPENT =
+  "That link has already been used, or it expired. Ask the printer owner for another.";
+
+/**
+ * Redeem a set-password link.
+ *
+ * Better Auth's `/reset-password` does the work: it consumes the verification
+ * row, refuses an expired one, enforces the length bounds, runs the breach
+ * lookup, and revokes every session the old password opened. What is left for
+ * us is the username an account may not have yet, the audit line, and where to
+ * send the browser.
+ *
+ * It deliberately does not establish a session. Whoever followed the link has
+ * proved they hold the link, not that they own the account — so they set a
+ * password and then have to use it. That is the whole difference between this
+ * and the sign-in link it replaces.
+ */
+export async function setPassword(
+  _prev: SetPasswordState,
+  formData: FormData,
+): Promise<SetPasswordState> {
+  const rawUsername = formData.get("username");
+  const parsed = SetPasswordSchema.safeParse({
+    token: formData.get("token"),
+    password: formData.get("password"),
+    username: typeof rawUsername === "string" && rawUsername ? rawUsername : undefined,
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return {
+      error: issue?.message ?? "Check the form.",
+      field: issue?.path[0] as SetPasswordState["field"],
+    };
+  }
+
+  // Resolved before redeeming: the row is gone afterwards, and an audit line
+  // that cannot name its subject is not much of an audit line.
+  const resolved = await readResetToken(parsed.data.token);
+  if (!resolved) return { error: SPENT };
+  const { user, expiresAt } = resolved;
+
+  // The username goes first, and on purpose. Claiming it before the password
+  // means there is no moment where an account has a password and no way to
+  // sign in with it; if the password is then refused, the link comes back and
+  // this step is simply skipped on the retry — including when the retry posts
+  // a different username, because by then the account already has one and a
+  // reset link is not the place to change it.
+  if (!user.username) {
+    if (!parsed.data.username) {
+      return { error: "Pick a username to sign in with.", field: "username" };
+    }
+    try {
+      // Written straight through Prisma, so the folding the username plugin
+      // would have done on a Better Auth path is done here instead: `username`
+      // lower-cased because that is what the unique index compares, and
+      // `displayUsername` as typed because that is what gets shown back.
+      await db.user.update({
+        where: { id: user.id },
+        data: {
+          username: parsed.data.username.toLowerCase(),
+          displayUsername: parsed.data.username,
+        },
+      });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        return {
+          error: "Somebody already has that username. Try another.",
+          field: "username",
+        };
+      }
+      throw error;
+    }
+  }
+
+  try {
+    await auth.api.resetPassword({
+      body: { token: parsed.data.token, newPassword: parsed.data.password },
+      headers: await headers(),
+    });
+  } catch (error) {
+    const e = error as { body?: { code?: string; message?: string }; message?: string };
+    const code = e.body?.code;
+
+    if (code === "INVALID_TOKEN") return { error: SPENT };
+
+    // Everything else happened after the token was consumed. Put it back so
+    // the person can correct the password they were just told to correct.
+    await restorePasswordSetupLink(parsed.data.token, user.id, expiresAt);
+
+    switch (code) {
+      case "PASSWORD_COMPROMISED":
+        return { error: e.body?.message ?? "Pick a different password.", field: "password" };
+      case "PASSWORD_TOO_SHORT":
+        return {
+          error: `A password needs at least ${PASSWORD_MIN} characters.`,
+          field: "password",
+        };
+      case "PASSWORD_TOO_LONG":
+        return {
+          error: `That password is longer than ${PASSWORD_MAX} characters.`,
+          field: "password",
+        };
+      default:
+        console.error("set-password failed", error);
+        return { error: "That did not go through. Try again in a moment." };
+    }
+  }
+
+  await record({
+    action: "password.reset_completed",
+    actor: user,
+    subject: user.email,
+  });
+
+  redirect("/signin?reset=1");
+}

--- a/src/app/set-password/page.tsx
+++ b/src/app/set-password/page.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+
+import { readResetToken } from "@/lib/password-reset";
+import { AuthShell, H1, Kicker, Lead, Notice } from "@/components/ui";
+import { SetPasswordForm } from "./set-password-form";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Where a set-password link lands.
+ *
+ * Reachable without a session on purpose — the whole point is that somebody
+ * who cannot get in can get back in. It is not an authenticated surface and
+ * grants nothing on its own: the token is checked here only to decide what to
+ * render, and checked again for real when the form is submitted.
+ */
+export default async function SetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const { token } = await searchParams;
+  const resolved = token ? await readResetToken(token) : null;
+
+  if (!resolved) {
+    return (
+      <AuthShell>
+        <Kicker>New key, cut fresh</Kicker>
+        <H1>That link is spent</H1>
+        <Lead>
+          Set-password links work once and expire quickly. Ask whoever owns the
+          printer for another — it takes them a moment.
+        </Lead>
+        <Link
+          href="/signin"
+          className="font-bold text-[15px] text-cherry-dk underline underline-offset-2 hover:text-cherry"
+        >
+          Go to sign in →
+        </Link>
+      </AuthShell>
+    );
+  }
+
+  const { user } = resolved;
+  const needsUsername = !user.username;
+
+  return (
+    <AuthShell>
+      <Kicker>New key, cut fresh</Kicker>
+      <H1>
+        {needsUsername ? "Set yourself up" : `Pick a password, ${user.name.split(" ")[0]}`}
+      </H1>
+      <Lead>
+        {needsUsername
+          ? "Nobody invited this account, so it has no username yet. Pick one, and a password to go with it."
+          : "This link sets a password and nothing else — you will sign in with it on the next screen. Anything you were signed in on with the old one is signed out."}
+      </Lead>
+
+      <SetPasswordForm token={token!} needsUsername={needsUsername} />
+
+      <div className="mt-[22px]">
+        <Notice>
+          Did not ask for this? Have a word with whoever runs the printer before
+          you use it.
+        </Notice>
+      </div>
+    </AuthShell>
+  );
+}

--- a/src/app/set-password/set-password-form.tsx
+++ b/src/app/set-password/set-password-form.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+
+import { setPassword, type SetPasswordState } from "./actions";
+import { PASSWORD_MIN, USERNAME_MAX, USERNAME_MIN } from "@/lib/auth-rules";
+import { Button, Input, Label, Notice } from "@/components/ui";
+
+function Submit() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} className="w-full">
+      {pending ? "Saving…" : "Save this password"}
+    </Button>
+  );
+}
+
+export function SetPasswordForm({
+  token,
+  needsUsername = false,
+}: {
+  token: string;
+  /** True only for an account that has never had one — the seeded admin. */
+  needsUsername?: boolean;
+}) {
+  const [state, formAction] = useActionState<SetPasswordState, FormData>(
+    setPassword,
+    {},
+  );
+
+  return (
+    <form action={formAction} className="flex flex-col gap-[17.6px]">
+      <input type="hidden" name="token" value={token} />
+
+      {needsUsername && (
+        <div>
+          <Label htmlFor="username">Pick a username</Label>
+          <Input
+            id="username"
+            name="username"
+            required
+            minLength={USERNAME_MIN}
+            maxLength={USERNAME_MAX}
+            pattern="[A-Za-z0-9_\-]+"
+            placeholder="ruben"
+            autoComplete="username"
+            autoCapitalize="none"
+            spellCheck={false}
+            autoFocus
+            aria-describedby="username-hint"
+            aria-invalid={state.field === "username" || undefined}
+          />
+          <p
+            id="username-hint"
+            className={`mt-[6px] text-[12.5px] leading-[1.4] ${
+              state.field === "username"
+                ? "font-bold text-cherry-dk"
+                : "font-mono uppercase tracking-[0.04em] text-ink-3"
+            }`}
+          >
+            {state.field === "username"
+              ? state.error
+              : "What you sign in with — letters, digits, - and _"}
+          </p>
+        </div>
+      )}
+
+      <div>
+        <Label htmlFor="password">New password</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          required
+          minLength={PASSWORD_MIN}
+          autoComplete="new-password"
+          autoFocus={!needsUsername}
+          aria-describedby="password-hint"
+          aria-invalid={state.field === "password" || undefined}
+        />
+        <p
+          id="password-hint"
+          className={`mt-[6px] text-[12.5px] leading-[1.4] ${
+            state.field === "password"
+              ? "font-bold text-cherry-dk"
+              : "font-mono uppercase tracking-[0.04em] text-ink-3"
+          }`}
+        >
+          {state.field === "password"
+            ? state.error
+            : `At least ${PASSWORD_MIN} characters, and not a breached one.`}
+        </p>
+      </div>
+
+      {state.error && !state.field && <Notice tone="warn">{state.error}</Notice>}
+
+      <Submit />
+    </form>
+  );
+}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -16,17 +16,20 @@ function safeNext(raw: string | undefined): string {
 const ERRORS: Record<string, string> = {
   invite_required:
     "That address has not been invited. Pretty Please Print is invite-only — ask whoever owns the printer for a link.",
-  INVALID_TOKEN: "That link is no longer valid. Ask for a fresh one below.",
-  TOKEN_EXPIRED: "That link expired. Links last 10 minutes — here is another go.",
+  INVALID_TOKEN: "That link is no longer valid. Ask the printer owner for a fresh one.",
+  TOKEN_EXPIRED: "That link expired. Ask the printer owner for another.",
   banned: "That account has been suspended.",
 };
+
+/** Set by /set-password once a new one has been chosen. */
+const PASSWORD_SET = "Password saved. Sign in with it.";
 
 export default async function SignInPage({
   searchParams,
 }: {
-  searchParams: Promise<{ next?: string; error?: string }>;
+  searchParams: Promise<{ next?: string; error?: string; reset?: string }>;
 }) {
-  const { next, error } = await searchParams;
+  const { next, error, reset } = await searchParams;
 
   const user = await currentUser();
   if (user) redirect(safeNext(next));
@@ -36,9 +39,14 @@ export default async function SignInPage({
       <Kicker>Members only · ask at the counter</Kicker>
       <H1>What&rsquo;ll it be?</H1>
       <Lead>
-        No passwords on this menu. Use the passkey on this device, or have a
-        one-time link sent to your inbox.
+        Use the passkey on this device, or your username and password.
       </Lead>
+
+      {reset && (
+        <div className="mb-[22px]">
+          <Notice tone="good">{PASSWORD_SET}</Notice>
+        </div>
+      )}
 
       {error && (
         <div className="mb-[22px]">

--- a/src/app/signin/signin-form.tsx
+++ b/src/app/signin/signin-form.tsx
@@ -4,11 +4,19 @@ import { useEffect, useState } from "react";
 import { authClient } from "@/lib/auth-client";
 import { Button, Input, Label, Notice } from "@/components/ui";
 
-type Phase = "idle" | "sending" | "sent";
+/**
+ * One message for every way a sign-in can fail.
+ *
+ * Distinguishing "no such username" from "wrong password" turns this form
+ * into a membership oracle for the office, and there is nothing the person at
+ * the keyboard can do with the difference anyway.
+ */
+const REFUSED = "That username and password do not match. Try again.";
 
 export function SignInForm({ next }: { next: string }) {
-  const [email, setEmail] = useState("");
-  const [phase, setPhase] = useState<Phase>("idle");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [passkeySupported, setPasskeySupported] = useState(false);
 
@@ -17,9 +25,9 @@ export function SignInForm({ next }: { next: string }) {
     setPasskeySupported(true);
 
     // Conditional UI: if the browser already holds a passkey for this site it
-    // offers it straight from the email field, with no click at all. Browsers
-    // without support simply never resolve this, which is why it is fire and
-    // forget.
+    // offers it straight from the username field, with no click at all.
+    // Browsers without support simply never resolve this, which is why it is
+    // fire and forget.
     void authClient.signIn.passkey({ autoFill: true }).then((res) => {
       if (res && !res.error) window.location.assign(next);
     });
@@ -31,50 +39,35 @@ export function SignInForm({ next }: { next: string }) {
     if (res?.error) {
       setError(
         res.error.message ??
-          "That passkey was not accepted. Try the email link instead.",
+          "That passkey was not accepted. Use your password instead.",
       );
       return;
     }
     window.location.assign(next);
   }
 
-  async function sendLink(e: React.FormEvent) {
+  async function signInWithPassword(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    setPhase("sending");
+    setBusy(true);
 
-    const { error } = await authClient.signIn.magicLink({
-      email: email.trim().toLowerCase(),
-      callbackURL: next,
+    const { error } = await authClient.signIn.username({
+      username: username.trim().toLowerCase(),
+      password,
     });
 
-    // Deliberately identical UI whether or not the address has an account.
-    // Telling a stranger "no such user" turns this form into a membership
-    // oracle for the office.
-    if (error && error.status !== 403) {
-      setPhase("idle");
-      setError("Something went wrong sending that link. Try again in a moment.");
+    if (error) {
+      setBusy(false);
+      // 429 is worth saying out loud: "wrong password" would send someone
+      // hunting for a typo that is not there.
+      setError(
+        error.status === 429
+          ? "Too many attempts. Wait a minute and try again."
+          : REFUSED,
+      );
       return;
     }
-    setPhase("sent");
-  }
-
-  if (phase === "sent") {
-    return (
-      <div className="flex flex-col gap-[17.6px]">
-        <Notice tone="good">
-          If <strong>{email}</strong> belongs to someone here, a sign-in link is
-          on its way. It works once and expires in 10 minutes.
-        </Notice>
-        <button
-          type="button"
-          onClick={() => setPhase("idle")}
-          className="cursor-pointer self-start font-bold text-[14px] text-cherry-dk underline underline-offset-2 hover:text-cherry"
-        >
-          ← Use a different address
-        </button>
-      </div>
-    );
+    window.location.assign(next);
   }
 
   return (
@@ -92,18 +85,33 @@ export function SignInForm({ next }: { next: string }) {
         </>
       )}
 
-      <form onSubmit={sendLink} className="flex flex-col gap-[13.2px]">
+      <form onSubmit={signInWithPassword} className="flex flex-col gap-[13.2px]">
         <div>
-          <Label htmlFor="email">Your email</Label>
+          <Label htmlFor="username">Username</Label>
           <Input
-            id="email"
-            name="email"
-            type="email"
+            id="username"
+            name="username"
             required
+            // "webauthn" is what lets conditional UI offer a passkey from this
+            // field before a single character is typed.
             autoComplete="username webauthn"
-            placeholder="ayla@office.example"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            autoCapitalize="none"
+            spellCheck={false}
+            placeholder="ayla"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
           />
         </div>
         {/* Secondary on purpose: one primary per screen, and the passkey is
@@ -111,10 +119,10 @@ export function SignInForm({ next }: { next: string }) {
         <Button
           type="submit"
           variant="secondary"
-          disabled={phase === "sending"}
+          disabled={busy}
           className="w-full"
         >
-          {phase === "sending" ? "Sending…" : "Email me a link"}
+          {busy ? "Checking…" : "Sign in"}
         </Button>
       </form>
 
@@ -122,7 +130,8 @@ export function SignInForm({ next }: { next: string }) {
 
       <p className="m-0 border-t-2 border-dashed border-rule pt-[13.2px] text-[13.5px] leading-[1.5] text-ink-2">
         Pretty Please Print is invite-only — there is no sign-up. If you have not
-        been invited yet, ask whoever owns the printer for a link.
+        been invited yet, or you have forgotten your password, ask whoever owns
+        the printer.
       </p>
     </div>
   );

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -25,9 +25,9 @@ export default async function WelcomePage() {
       <Kicker>You&rsquo;re in</Kicker>
       <H1>Welcome, {user.name.split(" ")[0]}</H1>
       <Lead>
-        One last thing worth thirty seconds: save a passkey. It replaces the
-        emailed link with your fingerprint, face or device PIN, and it cannot be
-        phished the way a link in an inbox can.
+        One last thing worth thirty seconds: save a passkey. It puts your
+        fingerprint, face or device PIN where the password goes, and unlike a
+        password there is nothing to phish, reuse or forget.
       </Lead>
       <PasskeyPrompt deviceHint={deviceLabel(ua)} />
     </AuthShell>

--- a/src/app/welcome/passkey-prompt.tsx
+++ b/src/app/welcome/passkey-prompt.tsx
@@ -41,8 +41,8 @@ export function PasskeyPrompt({ deviceHint }: { deviceHint: string }) {
     return (
       <div className="flex flex-col gap-[17.6px]">
         <Notice>
-          This browser does not do passkeys. You will sign in with an emailed
-          link instead, which works fine.
+          This browser does not do passkeys. Your username and password work
+          everywhere, which is why they are the way in.
         </Notice>
         <Button onClick={() => router.push("/")}>Take me in</Button>
       </div>
@@ -53,8 +53,8 @@ export function PasskeyPrompt({ deviceHint }: { deviceHint: string }) {
     return (
       <div className="flex flex-col gap-[17.6px]">
         <Notice tone="good">
-          Passkey saved. Next time, signing in is a fingerprint or a face —
-          no inbox round trip.
+          Passkey saved. Next time, signing in is a fingerprint or a face — no
+          password to type. It still works if you would rather.
         </Notice>
         <Button onClick={() => router.push("/")}>Take me in</Button>
       </div>
@@ -70,14 +70,14 @@ export function PasskeyPrompt({ deviceHint }: { deviceHint: string }) {
       {message && <Notice tone="warn">{message}</Notice>}
 
       {/* Honest about the consequence. The old copy said "Skip for now" and
-          then never mentioned it again, which is how people ended up on
-          emailed links permanently without choosing to. */}
+          then never mentioned it again, which is how people ended up typing a
+          password every time without ever choosing to. */}
       <button
         type="button"
         onClick={() => router.push("/")}
         className="cursor-pointer self-center text-[13.5px] font-bold text-ink-2 underline underline-offset-2 hover:text-cherry-dk"
       >
-        Not now — keep using emailed links
+        Not now — keep typing my password
       </button>
     </div>
   );

--- a/src/components/passkey-nudge.tsx
+++ b/src/components/passkey-nudge.tsx
@@ -4,12 +4,12 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 
 /**
- * The one prompt that gets people off emailed links.
+ * The one prompt that gets people onto passkeys.
  *
- * Accepting an invite offers a passkey once. Anyone who taps "not now" is on
- * an inbox round trip for every sign-in after that, forever, with nothing to
- * tell them there is a better way — which is the actual reason emailed links
- * feel like the whole experience.
+ * Registration offers a passkey once. Anyone who taps "not now" types a
+ * password for every sign-in after that, forever, with nothing to tell them
+ * there is a better way — which is the actual reason passwords feel like the
+ * whole experience.
  *
  * So it asks again. Dismissible, but only for the session: closing it is "not
  * right now", not "never mention this again". It disappears for good the
@@ -39,10 +39,10 @@ export function PasskeyNudge() {
       <div className="mx-auto flex max-w-[1180px] flex-wrap items-center gap-[13.2px] px-[26.4px] py-[11px]">
         <p className="m-0 flex-1 text-[14.5px] leading-[1.4] text-ink">
           <strong className="font-display text-[15px]">
-            Tired of waiting for the sign-in email?
+            Tired of typing your password?
           </strong>{" "}
           Save a passkey and this device signs you in with a fingerprint —
-          no inbox, no link, no typing.
+          nothing to remember, nothing to phish.
         </p>
         <Link
           href="/welcome"

--- a/src/components/reset-password.tsx
+++ b/src/components/reset-password.tsx
@@ -3,7 +3,7 @@
 import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 
-import { reissueAccessAction, type InviteFormState } from "@/app/admin/invites/actions";
+import { resetPasswordAction, type InviteFormState } from "@/app/admin/invites/actions";
 import { HandoverLink } from "@/components/handover-link";
 import { Notice } from "@/components/ui";
 
@@ -15,40 +15,63 @@ function Submit() {
       disabled={pending}
       className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink hover:bg-sun disabled:opacity-50"
     >
-      {pending ? "Minting…" : "New way in"}
+      {pending ? "Minting…" : "Reset password"}
     </button>
   );
 }
 
 /**
- * "I wiped my phone and the passkey went with it."
+ * "I have forgotten my password", and "I wiped my phone and the passkey went
+ * with it."
  *
- * Also the answer when the mail server is down, which is exactly when you
- * cannot email someone a link. Sits behind a disclosure because it is not an
- * everyday action and it signs whoever holds the link in as that person.
+ * Sits behind a disclosure because it is not an everyday action. Unlike the
+ * sign-in link it replaces, the link this mints does not sign anybody in — it
+ * lets them choose a new password, which they then have to use. An admin who
+ * keeps the link for themselves would be locking the member out rather than
+ * quietly becoming them, and the audit trail names them either way.
  */
-export function ReissueAccess({ userId, name }: { userId: string; name: string }) {
+export function ResetPassword({
+  userId,
+  name,
+  expiresInMinutes,
+}: {
+  userId: string;
+  name: string;
+  expiresInMinutes: number;
+}) {
   const [state, formAction] = useActionState<InviteFormState, FormData>(
-    reissueAccessAction,
+    resetPasswordAction,
     {},
   );
 
   return (
     <details>
       <summary className="inline-block cursor-pointer list-none rounded-chip border-[3px] border-transparent px-[13.2px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink-2 hover:border-ink hover:bg-cream-2">
-        Lost access?
+        Forgotten password?
       </summary>
       <form action={formAction} className="mt-[8px] max-w-[560px]">
         <input type="hidden" name="userId" value={userId} />
         <div className="rounded-card border-[3px] border-ink bg-cream-2 p-[11px]">
           <p className="m-0 mb-[8px] text-[13.5px] leading-[1.45] text-ink-2">
-            Mints a single-use link that signs {name} in, valid ten minutes.
-            It is recorded in the audit log.
+            Mints a single-use link that lets {name} pick a new password, valid{" "}
+            {expiresInMinutes} minutes. It does not sign anyone in, it signs
+            {" "}{name} out everywhere, and it is recorded in the audit log.
           </p>
           <Submit />
         </div>
+        {state.sent && !state.handoverUrl && (
+          <div className="mt-[8px]">
+            <Notice tone="good">
+              Sent to {state.sent}. The link is inside the message and nowhere
+              else — not even here.
+            </Notice>
+          </div>
+        )}
         {state.handoverUrl && (
-          <HandoverLink url={state.handoverUrl} note="works once, expires in 10 minutes" />
+          <HandoverLink
+            url={state.handoverUrl}
+            note={`works once, expires in ${expiresInMinutes} minutes`}
+          />
         )}
         {state.error && (
           <div className="mt-[8px]">

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -63,7 +63,7 @@ export function UserMenu({
           <div className="mt-[13.2px] border-t-2 border-dashed border-rule pt-[13.2px]">
             <p className="m-0 font-mono text-[11.5px] uppercase text-ink-3">
               {passkeyCount === 0
-                ? "Signing in by emailed link"
+                ? "Signing in with a password"
                 : `${passkeyCount} passkey${passkeyCount === 1 ? "" : "s"} on this account`}
             </p>
             <a

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -26,7 +26,8 @@ export type AuditAction =
   | "auth.signed_in"
   | "auth.signed_out"
   | "user.role_changed"
-  | "access.reissued"
+  | "password.reset_requested"
+  | "password.reset_completed"
   // work
   | "story.created"
   | "upload.rejected"

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,13 +1,12 @@
 "use client";
 
 import { createAuthClient } from "better-auth/react";
-import { magicLinkClient } from "better-auth/client/plugins";
-import { adminClient } from "better-auth/client/plugins";
+import { adminClient, usernameClient } from "better-auth/client/plugins";
 import { passkeyClient } from "@better-auth/passkey/client";
 
 export const authClient = createAuthClient({
   baseURL: process.env.NEXT_PUBLIC_APP_URL ?? undefined,
-  plugins: [magicLinkClient(), passkeyClient(), adminClient()],
+  plugins: [usernameClient(), passkeyClient(), adminClient()],
 });
 
 export const { signIn, signOut, useSession, passkey } = authClient;

--- a/src/lib/auth-rules.ts
+++ b/src/lib/auth-rules.ts
@@ -1,0 +1,38 @@
+/**
+ * What counts as a username and a password.
+ *
+ * Its own module because both sides need it: `src/lib/auth.ts` hands these to
+ * Better Auth, and the registration and set-password forms render them as
+ * hints and as `minLength` attributes. Importing `auth.ts` into a client
+ * component would drag the database and `server-only` into the browser
+ * bundle, and a rule stated twice is a rule that drifts.
+ */
+
+/**
+ * Usernames: 3–32 characters of letters, digits, `-` and `_`.
+ *
+ * Narrower than Better Auth's default, which also allows `.`. Case is
+ * accepted but not kept: the plugin folds to lower case on write and looks up
+ * by the folded value, so `Ayla_B` is stored as `ayla_b`, signs in as either,
+ * and cannot be registered twice in different clothes. `displayUsername`
+ * keeps whatever was typed, for showing back.
+ *
+ * Matching case-insensitively rather than refusing capitals is the friendlier
+ * half of that: somebody whose phone capitalises the first letter should be
+ * told their username is taken, not that it is malformed.
+ */
+export const USERNAME_MIN = 3;
+export const USERNAME_MAX = 32;
+export const USERNAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+export const USERNAME_RULE =
+  "A username is 3–32 characters: letters, digits, hyphen or underscore.";
+
+/**
+ * Ten, not Better Auth's default eight.
+ *
+ * Length is the control that does the work; composition rules mostly move
+ * people to `Password1!`. The upper bound exists so a megabyte of "a" cannot
+ * be handed to the hasher as a denial-of-service lever.
+ */
+export const PASSWORD_MIN = 10;
+export const PASSWORD_MAX = 128;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,17 +1,23 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
-import { magicLink } from "better-auth/plugins/magic-link";
 import { admin } from "better-auth/plugins/admin";
+import { haveIBeenPwned } from "better-auth/plugins/haveibeenpwned";
+import { username } from "better-auth/plugins/username";
 import { passkey } from "@better-auth/passkey";
 
 import { db } from "@/lib/db";
-import { magicLinkEmail, sendMail } from "@/lib/email";
-import { consumeInvitesFor, normalizeEmail, pendingInviteFor } from "@/lib/invites";
+import { normalizeEmail, pendingInviteFor, consumeInvitesFor } from "@/lib/invites";
 import { initialsFor } from "@/lib/tokens";
 import { isBuildPhase } from "@/lib/runtime";
 import { record } from "@/lib/audit";
+import {
+  PASSWORD_MAX,
+  PASSWORD_MIN,
+  USERNAME_MAX,
+  USERNAME_MIN,
+  USERNAME_PATTERN,
+} from "@/lib/auth-rules";
 
 const baseURL = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
 const isProd = process.env.NODE_ENV === "production";
@@ -28,8 +34,6 @@ const isProd = process.env.NODE_ENV === "production";
  */
 const isHttps = baseURL.startsWith("https://");
 
-const MAGIC_LINK_TTL_MINUTES = 10;
-
 /** localhost is never a real deployment, whatever NODE_ENV happens to say. */
 const isLoopback = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i.test(
   baseURL,
@@ -42,8 +46,8 @@ if (isProd && !isBuildPhase) {
   if (!isHttps && !isLoopback) {
     throw new Error(
       `BETTER_AUTH_URL must be an https:// URL in production (got "${baseURL}"). ` +
-        "Session cookies carry the Secure flag and magic links are sent by " +
-        "email; neither is safe to serve over plain HTTP.",
+        "Session cookies carry the Secure flag and passwords are posted to " +
+        "this origin; neither is safe to serve over plain HTTP.",
     );
   }
   if (isLoopback) {
@@ -55,34 +59,46 @@ if (isProd && !isBuildPhase) {
   }
 }
 
-/**
- * ---------------------------------------------------------------------------
- * Direct grant, used only by invite acceptance.
- * ---------------------------------------------------------------------------
- * Someone who followed an invite link has already proved they control the
- * mailbox — the token was delivered there and nowhere else. Making them read a
- * *second* email to finish signing up adds a hop without adding assurance.
- *
- * So invite acceptance calls `issueInviteSignInUrl()`, which runs the normal
- * magic-link issuance inside this store. `sendMagicLink` sees the store, hands
- * the URL back in-process instead of mailing it, and the route redirects the
- * browser through it. Every check Better Auth performs on a magic link still
- * runs — the link is simply redeemed immediately rather than days later, and
- * it never leaves the server.
- */
-const directGrant = new AsyncLocalStorage<{ url?: string }>();
-
 export const auth = betterAuth({
   appName: "Pretty Please Print",
   baseURL,
   secret: process.env.BETTER_AUTH_SECRET,
   database: prismaAdapter(db, { provider: "postgresql" }),
 
-  // There is no password anywhere in this app. Nothing to phish, nothing to
-  // reuse, nothing to leak.
-  emailAndPassword: { enabled: false },
+  /**
+   * Username and password is how people get in.
+   *
+   * `requireEmailVerification` stays off: the address was verified by
+   * construction. The only way to reach sign-up at all is through an invite
+   * link that was delivered to that mailbox, and the invite gate below
+   * refuses anything else.
+   */
+  emailAndPassword: {
+    enabled: true,
+    minPasswordLength: PASSWORD_MIN,
+    maxPasswordLength: PASSWORD_MAX,
+    // Registration hands back a session; there is no second hop to /signin.
+    autoSignIn: true,
+    /**
+     * A reset is what you do when you have lost control of the account, so
+     * every session opened with the old password dies with it.
+     */
+    revokeSessionsOnPasswordReset: true,
+    // Self-service "forgot password" is deliberately absent: with no
+    // `sendResetPassword` configured, /request-password-reset refuses. Resets
+    // are minted by the admin (src/lib/password-reset.ts) so the flow does
+    // not depend on a mail server that may not exist.
+  },
 
   trustedOrigins: [baseURL],
+
+  /**
+   * Reset links are filed under a digest of their token rather than the token
+   * itself, so a database reader sees no link they can put in a URL. The
+   * digest is Better Auth's, and `prisma/reset-token.ts` reproduces it for
+   * the two places that mint a row directly.
+   */
+  verification: { storeIdentifier: "hashed" },
 
   session: {
     expiresAt: undefined,
@@ -109,18 +125,36 @@ export const auth = betterAuth({
     useSecureCookies: isHttps,
     defaultCookieAttributes: {
       httpOnly: true,
-      sameSite: "lax", // "strict" would break the magic-link landing
+      // "strict" would drop the cookie on the hop from a set-password link,
+      // and the sign-in would appear to silently fail.
+      sameSite: "lax",
       path: "/",
       secure: isHttps,
     },
   },
 
-  // Blanket limiter; the magic-link plugin adds a tighter one of its own.
   rateLimit: {
     enabled: true,
     window: 60,
     max: 60,
     storage: "database",
+    /**
+     * A password is guessable in a way a link in an inbox never was, so the
+     * paths that take one are capped well below the blanket rule.
+     *
+     * Ten a minute rather than three, for the same reason the invite limit is
+     * ten: an office shares one NAT address, and a limit tuned for a single
+     * user locks out the colleague at the next desk. Ten per minute still
+     * puts online guessing several thousand years away from a ten-character
+     * password, which is the number that matters.
+     */
+    customRules: {
+      "/sign-in/username": { window: 60, max: 10 },
+      "/sign-up/email": { window: 60, max: 10 },
+      "/reset-password": { window: 60, max: 10 },
+      // Would otherwise be a free oracle for "who is already here".
+      "/is-username-available": { window: 60, max: 20 },
+    },
   },
 
   user: {
@@ -137,9 +171,11 @@ export const auth = betterAuth({
      * The invite-only gate.
      *
      * Called before any identity is provisioned, by every authentication
-     * method — today magic link and passkey, tomorrow whatever gets added.
-     * No pending invite, no account. This is the one place that decides who
-     * is allowed to exist, which is why it lives here and not in a route.
+     * method — password sign-up and passkey today, whatever gets added
+     * tomorrow. Better Auth runs it from `internalAdapter.createUser`, which
+     * `/sign-up/email` goes through with `{ method: "email-password" }`, so
+     * adding passwords did not move this rule or add a second copy of it.
+     * No pending invite, no account.
      */
     async validateUserInfo({ user, source }) {
       if (source.action !== "create-user") return;
@@ -182,7 +218,7 @@ export const auth = betterAuth({
               initials: initialsFor(name),
               role: invite?.role ?? "client",
               invitedById: invite?.invitedById ?? null,
-              // Provisioning only happens off a link sent to this address,
+              // Registration only happens off a link sent to this address,
               // so the address is verified by construction.
               emailVerified: true,
             },
@@ -229,30 +265,41 @@ export const auth = betterAuth({
   },
 
   plugins: [
-    magicLink({
-      expiresIn: 60 * MAGIC_LINK_TTL_MINUTES,
-      // Digest at rest: a database reader sees hashes, not usable links.
-      storeToken: "hashed",
-      // Per IP. Deliberately not tighter: an office sits behind one NAT
-      // address, so a limit of 3 would refuse the fourth colleague to claim
-      // an invite in the same minute. Ten still stops mail-bombing an inbox,
-      // and the responses are identical either way, so this is not an
-      // enumeration oracle to grind against.
-      rateLimit: { window: 60, max: 10 },
-      async sendMagicLink({ email, url }) {
-        const box = directGrant.getStore();
-        if (box) {
-          box.url = url;
-          return;
-        }
-        await sendMail(
-          magicLinkEmail({
-            to: email,
-            url,
-            expiresInMinutes: MAGIC_LINK_TTL_MINUTES,
-          }),
-        );
-      },
+    username({
+      minUsernameLength: USERNAME_MIN,
+      maxUsernameLength: USERNAME_MAX,
+      usernameValidator: (value) => USERNAME_PATTERN.test(value),
+      // `validationOrder` is left at the default (pre-normalization), which is
+      // the only setting under which sign-up and sign-in agree: sign-in
+      // normalises *before* validating, so a case-sensitive rule applied after
+      // normalisation would accept `Ayla_B` at registration and then refuse it
+      // at the door. The validator above is case-insensitive for the same
+      // reason — the plugin folds the value either way.
+    }),
+
+    /**
+     * Refuse a password that is already in a breach corpus.
+     *
+     * The single highest-value password control there is: a ten-character
+     * password is only strong if it is not one of the several hundred million
+     * that have already been published. Checked by k-anonymity — five
+     * characters of a SHA-1 prefix leave the machine, never the password.
+     *
+     * It fails closed. If api.pwnedpasswords.com cannot be reached, setting a
+     * password fails rather than quietly skipping the check, which is the
+     * right way round: the alternative is a control that silently is not one.
+     * Registration and reset are the only paths that set a password, so an
+     * outage cannot lock out anybody who already has one.
+     *
+     * `HIBP_DISABLED=true` is the escape hatch for a deployment with no
+     * outbound internet at all — a NAS on an isolated VLAN, say. Failing
+     * closed there would mean nobody could ever register, which is worse than
+     * losing the check. It is off by default and should stay that way.
+     */
+    haveIBeenPwned({
+      enabled: process.env.HIBP_DISABLED !== "true",
+      customPasswordCompromisedMessage:
+        "That password appears in a known breach. Pick another — length beats cleverness.",
     }),
 
     passkey({
@@ -260,8 +307,8 @@ export const auth = betterAuth({
       rpName: process.env.PASSKEY_RP_NAME ?? "Pretty Please Print",
       origin: baseURL,
       authenticatorSelection: {
-        // Discoverable credentials let someone sign in without typing an
-        // address at all. "preferred" rather than "required" so older
+        // Discoverable credentials let someone sign in without typing a
+        // username at all. "preferred" rather than "required" so older
         // security keys still work.
         residentKey: "preferred",
         userVerification: "preferred",
@@ -280,37 +327,3 @@ export const auth = betterAuth({
 });
 
 export type Session = typeof auth.$Infer.Session;
-
-/**
- * Issue a magic-link URL without mailing it.
- *
- * Two callers, both deliberate:
- *   - invite acceptance, which already proved control of the mailbox
- *   - the admin re-issuing access for someone who lost their passkey and
- *     cannot receive mail
- *
- * The second is effectively impersonation: the link signs the browser in AS
- * that person. It is allowed because it grants the printer owner nothing they
- * did not already have — they own the machine and the database — and an
- * audited action is strictly better than a quiet `UPDATE`. It is recorded
- * loudly for that reason.
- */
-export async function issueSignInUrl(
-  email: string,
-  headers: Headers,
-  callbackURL: string,
-): Promise<string> {
-  const box: { url?: string } = {};
-
-  await directGrant.run(box, () =>
-    auth.api.signInMagicLink({
-      body: { email: normalizeEmail(email), callbackURL },
-      headers,
-    }),
-  );
-
-  if (!box.url) {
-    throw new Error("No sign-in link was issued.");
-  }
-  return box.url;
-}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -24,9 +24,9 @@ export function mailTransport(): Transport {
  * Is there anywhere to send mail?
  *
  * Running without one is a supported mode, not a broken deployment. Mail here
- * is only ever used for authentication — never for notifications, which are
- * in-app — so with no transport the app hands the admin a link to pass on
- * directly instead. For a group that shares an office that is arguably the
+ * is only ever used to deliver a link — an invitation, or a password reset —
+ * never for notifications, which are in-app. With no transport the app hands
+ * the admin the link to pass on directly instead. For a group that shares an office that is arguably the
  * better channel: a token in an inbox sits there indefinitely and can be
  * forwarded; one handed over in person cannot.
  *
@@ -37,8 +37,9 @@ export const mailConfigured = () => mailTransport() !== "none";
 
 if (!isBuildPhase && process.env.NODE_ENV === "production" && !mailConfigured()) {
   console.info(
-    "[mail] No transport configured. Invitations and recovery links will be " +
-      "shown to the admin to hand over; sign-in is passkey-first.",
+    "[mail] No transport configured. Invitations and password-reset links " +
+      "will be shown to the admin to hand over. Nothing else needs mail: " +
+      "people sign in with a username and password.",
   );
 }
 
@@ -193,32 +194,34 @@ export function inviteEmail(opts: {
   };
 }
 
-export function magicLinkEmail(opts: {
+export function passwordResetEmail(opts: {
   to: string;
   url: string;
   expiresInMinutes: number;
 }): Mail {
   return {
     to: opts.to,
-    subject: "Your sign-in link",
+    subject: "Set a new password",
     text:
-      `Sign in to Pretty Please Print: ${opts.url}\n\n` +
+      `Someone with the keys to the printer reset your Pretty Please Print password.\n\n` +
+      `Choose a new one: ${opts.url}\n\n` +
       `The link works once and expires in ${opts.expiresInMinutes} minutes. ` +
-      `If you did not ask for it, ignore this message.`,
+      `It does not sign you in — you pick a password, then use it. ` +
+      `If you did not expect this, say so before you use it.`,
     html: shell(
-      "OPEN &middot; COME ON IN",
-      `<h1 style="margin:0 0 14px;font-family:${SLAB};font-size:29px;line-height:1.1;color:${INK}">Sign in</h1>
+      "NEW KEY &middot; ONE USE",
+      `<h1 style="margin:0 0 14px;font-family:${SLAB};font-size:29px;line-height:1.1;color:${INK}">Set a new password</h1>
        <p style="margin:0 0 20px">
-         Here&rsquo;s the link you asked for. It signs you in on this device and
-         then stops working.
+         Whoever runs the printer reset your password. This link lets you pick a
+         new one — it does <strong>not</strong> sign you in on its own.
        </p>
-       ${button(opts.url, "Sign in")}
+       ${button(opts.url, "Choose a password")}
        <p style="margin:20px 0 0;padding:9px 13px;background:${SUN};border:2px solid ${INK};border-radius:999px;display:inline-block;font-family:${MONO};font-size:11px;font-weight:bold;letter-spacing:1px;color:${INK}">
          ONE USE &middot; EXPIRES IN ${opts.expiresInMinutes} MINUTES
        </p>
        <p style="margin:18px 0 0;font-family:${SANS};font-size:13.5px;color:${INK_2}">
-         Didn&rsquo;t ask for this? Ignore it — nobody can sign in without the link.
-         Tired of waiting for these? Save a passkey once you&rsquo;re in.
+         Didn&rsquo;t expect this? Have a word with them before you use it.
+         Tired of typing a password? Save a passkey once you&rsquo;re back in.
        </p>
        ${fallback(opts.url)}`,
     ),

--- a/src/lib/password-reset.ts
+++ b/src/lib/password-reset.ts
@@ -1,0 +1,107 @@
+// No `server-only` guard here, deliberately: the verification suites import
+// this module under tsx to mint a link the same way the app does, and that
+// package only resolves inside a Next build. `@/lib/invites` is server-side
+// for the same reasons and carries none either.
+import { db } from "@/lib/db";
+import { appUrl } from "@/lib/invites";
+import {
+  RESET_TTL_MINUTES,
+  newResetToken,
+  resetIdentifier,
+} from "../../prisma/reset-token";
+
+export { RESET_TTL_MINUTES };
+
+/**
+ * Mint a single-use link that lets someone set a password.
+ *
+ * Used for two things that are the same mechanism wearing different words:
+ * the admin resetting a member's forgotten password, and the printer owner
+ * establishing their own for the first time (`prisma/seed.ts`).
+ *
+ * The row it writes is Better Auth's, so redeeming it goes through Better
+ * Auth's `/reset-password` endpoint with all of its checks — expiry, single
+ * use, length, and the breach lookup. Nothing here re-implements any of that;
+ * this only decides *when* a token exists.
+ *
+ * Note what the link does NOT do: it does not sign anybody in. Whoever holds
+ * it can set a password and must then use it, which is the whole difference
+ * between this and the sign-in link it replaces.
+ */
+export async function issuePasswordSetupUrl(userId: string): Promise<string> {
+  const token = newResetToken();
+
+  await db.verification.create({
+    data: {
+      identifier: resetIdentifier(token),
+      value: userId,
+      expiresAt: new Date(Date.now() + RESET_TTL_MINUTES * 60_000),
+    },
+  });
+
+  return appUrl(`/set-password?token=${encodeURIComponent(token)}`);
+}
+
+/**
+ * Throw away every outstanding reset link for a user.
+ *
+ * Called before minting a new one so "reset it again" cannot leave two live
+ * links in circulation — the older one is usually the one that leaked.
+ *
+ * Matching on `value` rather than `identifier` because the identifier is a
+ * digest we cannot search by prefix. It is exact enough: a reset row's value
+ * is the bare user id, and the only other rows in this table are WebAuthn
+ * challenges, whose value is always a JSON object.
+ */
+export async function revokePasswordSetupLinks(userId: string): Promise<void> {
+  await db.verification.deleteMany({ where: { value: userId } });
+}
+
+/**
+ * What a set-password link resolves to, or null if it resolves to nothing.
+ *
+ * Looked up through the same digest the row was filed under, so the raw token
+ * is never compared against anything stored. `expiresAt` comes back because
+ * redeeming the link deletes the row and the caller may need to put it back —
+ * see `restorePasswordSetupLink`.
+ */
+export async function readResetToken(token: string) {
+  const row = await db.verification.findFirst({
+    where: { identifier: resetIdentifier(token) },
+    orderBy: { createdAt: "desc" },
+    select: { value: true, expiresAt: true },
+  });
+  if (!row || row.expiresAt.getTime() <= Date.now()) return null;
+
+  const user = await db.user.findUnique({
+    where: { id: row.value },
+    select: { id: true, email: true, name: true, username: true },
+  });
+  return user ? { user, expiresAt: row.expiresAt } : null;
+}
+
+/**
+ * Put a redeemed link back.
+ *
+ * Better Auth consumes the token before it hashes the new password, so a
+ * password refused by the breach check burns the link on its way out and the
+ * person is told to go and ask for another — over a password they were about
+ * to correct. Restoring the row makes the link spent when a password is
+ * actually set, which is what "single use" was ever meant to mean.
+ *
+ * The expiry is the original one, so this extends nothing.
+ */
+export async function restorePasswordSetupLink(
+  token: string,
+  userId: string,
+  expiresAt: Date,
+): Promise<void> {
+  const identifier = resetIdentifier(token);
+  const stillThere = await db.verification.findFirst({
+    where: { identifier },
+    select: { id: true },
+  });
+  if (stillThere) return;
+
+  await db.verification.create({ data: { identifier, value: userId, expiresAt } });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,8 +19,15 @@ import { buildCsp, newNonce } from "@/lib/csp";
  * server action. A forged cookie gets past this file and no further; there is
  * a probe for exactly that (A01-forge).
  */
-/** Pages anyone may reach without a session. */
-const PUBLIC_PREFIXES = ["/signin", "/invite"];
+/**
+ * Pages anyone may reach without a session.
+ *
+ * `/set-password` is on the list for the same reason `/invite` is: the whole
+ * point of the link is that somebody who cannot get in can use it. It grants
+ * nothing on its own — the token is checked by the page and again by the
+ * action behind it.
+ */
+const PUBLIC_PREFIXES = ["/signin", "/invite", "/set-password"];
 
 const isProd = process.env.NODE_ENV === "production";
 


### PR DESCRIPTION
Replaces the magic-link model with a conventional one.

- **An invitation link is a registration link.** It asks for a username and a password, creates the account and signs you in. No second email, no inbox round trip.
- **After that, username and password.** Passkeys stay, as the optional accelerator they should always have been.
- **`SMTP_URL` is genuinely optional for the first time.** Nothing in the running system needs mail — it only ever carries a link, and with no transport the admin is shown that link to hand over.

## Removed

The magic-link plugin, `issueSignInUrl`, and the `AsyncLocalStorage` trick that existed only to redeem a link in-process at invite acceptance. Registration creates the session directly, so none of that has anywhere left to be.

"Lost access?" is gone too. It minted a link that signed its holder in *as* someone; the replacement mints one that lets them **set a password**, which they then have to use. Audited as `password.reset_requested` / `password.reset_completed`; `access.reissued` is dropped.

## Kept, and verified rather than assumed

The invite gate did not move. Better Auth calls `user.validateUserInfo` from `internalAdapter.createUser`, which `/sign-up/email` goes through with `{ method: "email-password" }`, so the one hook that decides who may exist keeps working untouched. `verify:auth` asserts it directly: registering an address with no pending invite is answered 403 and leaves no row.

Every authorisation rule is unchanged — `storyScope`, 404-not-403, admin-only routes, the audit trail.

## Password controls

Ten characters minimum, 128 max, and refused outright if HIBP has seen them (k-anonymity — the password never leaves the machine). The breach check **fails closed**; `HIBP_DISABLED=true` exists for an air-gapped host and is off by default. Guessing is capped at 10/min per IP on `/sign-in/username`, `/sign-up/email` and `/reset-password`.

Reset links are hashed at rest, single-use, thirty minutes, and establish **no session**. One deliberate deviation, documented in SECURITY.md: Better Auth consumes the token *before* it hashes, so a breach-refused password would burn the link on its way out — the row goes back with its original expiry, and the link is spent when a password is actually set.

## Also in here

`account.issuer`, which Better Auth has always required and this app never needed until it had a credential row to store. Nothing had ever written an `account` row — passkeys live in their own table — so the column was dead weight right up until it wasn't. Backfilled rather than added bare.

## Admin bootstrap

`prisma/seed.ts` prints a one-use set-password link when the admin has no password. Deliberately not `ADMIN_PASSWORD`: that would sit in `.env.docker`, in `docker inspect`, in the shell history that wrote it and in every backup of the host, still valid months later. Idempotent — re-seeding never resets an existing password.

## Verification

All six suites green against the **built container image**, not a dev server:

| suite | result |
| --- | --- |
| `verify:auth` | 79 checks, all pass |
| `probe:security` | 62 probes, 0 flagged |
| `verify:passkey` | 13 pass — passkeys still work alongside |
| `verify:queue` | 50 pass |
| `verify:upload` | 53 pass |
| `verify:models` | 29 pass |

New coverage: registration through an invite, the invite gate under password sign-up, login and wrong-password (with byte-identical responses *and* a timing check), duplicate usernames, a breached password, rate limiting, the full reset cycle, and the printer owner bootstrapping from a printed link.

## Docs

README's "How authentication works" rewritten — it opened with "There are no passwords anywhere". SECURITY.md carries a new **A07 with passwords in the picture** section: what got worse, what got better, and the residual risk accepted.