### PR TITLE
A deploy wizard, and a guest list you can leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ docker compose --env-file .env.docker \
 App on :3000, Mailpit on :8025 — every invitation and sign-in link lands there,
 so the whole flow is clickable without a mail server.
 
-Four compose files, each with one job:
+Five compose files, each with one job:
 
 | File | Job |
 | --- | --- |
@@ -467,7 +467,8 @@ Four compose files, each with one job:
 | `docker-compose.prod.yml` | the full stack, **consuming published images**. Publishes no host ports. |
 | `docker-compose.build.yml` | puts the build context back, for local work and CI |
 | `docker-compose.test.yml` | publishes the ports a local run and the host-side suites need |
-| `docker-compose.truenas.yml` | the proxy network, for a deployment |
+| `docker-compose.truenas.yml` | the proxy network, for a deployment behind Nginx Proxy Manager alone |
+| `docker-compose.cf.yml` | the same, but with Cloudflare proxying in front of NPM |
 
 `prod` consumes rather than builds on purpose: a deployment then needs no
 source tree and no toolchain, and what runs there is byte-for-byte what CI
@@ -536,6 +537,42 @@ docker compose --env-file .env.docker \
 
 Deploying is a human action by design. Nothing in CI reaches into the NAS.
 
+### The deploy wizard
+
+`scripts/deploy-wizard.sh` is the single entry point for a deploy. Copy it next
+to `docker-compose.prod.yml` on the NAS and run it there — it needs `docker`,
+`curl` and `python3`, and deliberately not `git`, `gh` or a checkout, because
+the NAS is a consumer of images and should stay one.
+
+```bash
+./deploy-wizard.sh            # interactive
+./deploy-wizard.sh --status   # read-only: what is live, and what is newer
+```
+
+It answers what a bare `sed PPP_TAG && docker compose up -d` does not:
+
+1. **Which image?** It asks ghcr.io what is actually published, newest first,
+   with build dates and the live one marked, so you pick from a menu instead of
+   copying a SHA out of a CI log. It filters to 7-hex-char tags — the cosign
+   `.sig` and SBOM `.att` tags live in the same package and are not runnable
+   images — and sorts by `created_at`, because re-pointing `latest` touches the
+   *previous* version's `updated_at` and would otherwise reshuffle history.
+2. **Is it intact?** It `cosign verify`s both images against the identity of
+   this repo's `release-images` workflow before anything is swapped. If cosign
+   is missing it says so and asks, rather than skipping quietly.
+3. **Did it work?** It polls the public health URL after the swap and **rolls
+   back to the previous tag automatically** if health does not stabilise —
+   then tells you whether the rollback is healthy, which distinguishes "bad
+   image" from "the proxy or the database is down".
+
+The registry token is borrowed and returned: read from a hidden prompt, used
+for the pull, then `docker logout` on exit including on failure. Nothing
+long-lived is left on the NAS, which costs nothing — the images are local
+afterwards, and `restart: unless-stopped` brings them back after a reboot with
+no registry access at all.
+
+Rollback is the same menu: pick the older tag.
+
 **In Nginx Proxy Manager**, add a Proxy Host:
 
 | | |
@@ -563,6 +600,16 @@ audit log and pin their own refused attempts on another address.
 So it is off by default, and the trail records *no* address rather than a
 fictional one. `docker-compose.truenas.yml` turns it on, and is also the file
 that makes it true by keeping the app off every host port.
+
+**Put Cloudflare in front and it has to go off again**, which is why
+`docker-compose.cf.yml` exists as a separate overlay. Cloudflare *appends* to
+`X-Forwarded-For` instead of replacing it, and NPM appends after that, so the
+left-most entry — the one `clientIp()` reads — is whatever the client chose to
+send. `CF-Connecting-IP` is the header that cannot be spoofed there, and the
+app does not read it yet. Until it does, a Cloudflare-fronted deployment
+records no address, which is the honest answer rather than an attacker-chosen
+one. The `cf` overlay is identical to the `truenas` one except that it leaves
+the setting to `.env.docker`, where it must be `false`.
 
 ### HTTPS is not optional, and here is why
 
@@ -686,6 +733,7 @@ src/app/
   story/[id]/            story detail (read half)
   api/upload/            validation, storage, story creation
 scripts/
+  deploy-wizard.sh       pick an image, verify it, deploy, auto-rollback
   verify-models.ts       validator vs. hostile fixtures
   verify-auth.ts         registration, sign-in and password reset
   verify-upload.ts       upload -> board -> story

--- a/docker-compose.cf.yml
+++ b/docker-compose.cf.yml
@@ -1,0 +1,27 @@
+# Nginx Proxy Manager overlay, with Cloudflare proxying in front of NPM.
+#
+#   docker compose --env-file .env.docker \
+#     -f docker-compose.prod.yml -f docker-compose.cf.yml up -d
+#
+# Same shape as docker-compose.truenas.yml — the app joins the shared network
+# so NPM can reach it as ppp-app:3000, and publishes no host port, so nothing
+# on the LAN can bypass the proxy and talk to it in cleartext.
+#
+# The one difference, and the reason this file exists instead: truenas.yml
+# forces TRUST_PROXY_HEADERS=true, which is right when NPM is the only thing
+# in front. With Cloudflare proxying, it is wrong. Cloudflare *appends* to
+# X-Forwarded-For rather than replacing it, and NPM appends again, so the
+# left-most entry — the one src/lib/audit.ts reads — is whatever the client
+# chose to send. CF-Connecting-IP is the header that cannot be spoofed there,
+# and the app does not read it yet. So the value is left to .env.docker,
+# where it must be false: the trail then records no address rather than an
+# attacker-chosen one, which is the failure this app prefers.
+services:
+  app:
+    networks:
+      - default
+      - npm-proxy
+
+networks:
+  npm-proxy:
+    external: true

--- a/scripts/deploy-wizard.sh
+++ b/scripts/deploy-wizard.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+#
+# ppp deploy wizard — the single entry point for deploying Pretty Please Print.
+#
+# Runs ON THE NAS, in the directory holding docker-compose.prod.yml and
+# .env.docker. That placement is the whole design: the NAS has no source tree,
+# no git and no toolchain — it consumes images CI built, signed and scanned —
+# so the wizard asks the registry what exists rather than asking a checkout.
+#
+# It answers the questions a bare `sed PPP_TAG && docker compose up -d` does
+# not:
+#   1. WHICH image?   → lists what is actually published to ghcr.io, newest
+#      first, with publish dates and the live one marked. You pick from a menu
+#      instead of copying a 7-char SHA out of a CI log.
+#   2. IS IT INTACT?  → cosign-verifies the image against the identity of the
+#      release-images workflow on this repo before anything is swapped. If
+#      cosign is absent it says so loudly rather than quietly skipping.
+#   3. DID IT WORK?   → polls the public health URL after the swap, and rolls
+#      back to the previous tag automatically if it does not come good.
+#
+# The registry token is borrowed and returned: read from a hidden prompt,
+# used for the pull, then `docker logout`. Nothing long-lived is left behind,
+# which matters because the images are local afterwards and reboots need no
+# registry access at all.
+#
+# Usage:
+#   ./deploy-wizard.sh              # interactive
+#   ./deploy-wizard.sh -n 25        # widen the candidate window
+#   ./deploy-wizard.sh --status     # read-only: what is live, and what is new
+#
+# Nothing is pulled or swapped without an explicit menu choice and a y/N.
+
+set -euo pipefail
+
+# ----- config ---------------------------------------------------------------
+# Overridable from the environment or from ./deploy.conf, so a second
+# deployment does not need the script edited.
+PROJECT_DIR="${PPP_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+[ -f "$PROJECT_DIR/deploy.conf" ] && . "$PROJECT_DIR/deploy.conf"
+
+COMPOSE_FILES="${PPP_COMPOSE_FILES:--f docker-compose.prod.yml -f docker-compose.cf.yml}"
+HEALTH_URL="${PPP_HEALTH_URL:-https://ppp.danileau.com/api/health}"
+REGISTRY_OWNER="${PPP_REGISTRY_OWNER:-danileau}"
+REPO="${PPP_REPO:-danileau/ppp}"
+IMAGES="${PPP_IMAGES:-ppp-app ppp-migrate}"
+WINDOW="${PPP_WINDOW:-15}"
+HEALTH_TIMEOUT="${PPP_HEALTH_TIMEOUT:-300}"
+
+# ----- pretty ---------------------------------------------------------------
+if [ -t 1 ]; then
+  B=$'\e[1m'; DIM=$'\e[2m'; R=$'\e[0m'
+  RED=$'\e[31m'; GRN=$'\e[32m'; YLW=$'\e[33m'; CYN=$'\e[36m'
+else
+  B=""; DIM=""; R=""; RED=""; GRN=""; YLW=""; CYN=""
+fi
+die() { echo "${RED}✗ $*${R}" >&2; exit 1; }
+hr()  { printf '%s\n' "${DIM}────────────────────────────────────────────────────────────────${R}"; }
+
+compose() { ( cd "$PROJECT_DIR" && docker compose --env-file .env.docker $COMPOSE_FILES "$@" ); }
+
+# ----- args -----------------------------------------------------------------
+STATUS_ONLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n) WINDOW="${2:?-n needs a number}"; shift 2 ;;
+    --status) STATUS_ONLY=1; shift ;;
+    -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+done
+
+# ----- preflight ------------------------------------------------------------
+command -v docker  >/dev/null || die "docker required"
+command -v curl    >/dev/null || die "curl required"
+command -v python3 >/dev/null || die "python3 required (for reading the registry's JSON)"
+docker compose version >/dev/null 2>&1 || die "the docker compose plugin is required"
+[ -f "$PROJECT_DIR/.env.docker" ] || die "no .env.docker in $PROJECT_DIR — is PPP_DIR right?"
+
+CURRENT="$(sed -n 's/^PPP_TAG="\{0,1\}\([^"]*\)"\{0,1\}.*/\1/p' "$PROJECT_DIR/.env.docker" | head -1)"
+[ -n "$CURRENT" ] || die "PPP_TAG not found in .env.docker"
+
+echo "${B}ppp deploy wizard${R}  ${DIM}· ${PROJECT_DIR}${R}"
+hr
+
+# ----- live state -----------------------------------------------------------
+HEALTH="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "$HEALTH_URL" 2>/dev/null || echo '000')"
+if [ "$HEALTH" = "200" ]; then HSTR="${GRN}healthy (200)${R}"; else HSTR="${RED}not 200 (${HEALTH})${R}"; fi
+
+echo "${B}Currently deployed:${R} ${CYN}${CURRENT}${R}"
+echo "${B}Live health:${R}        ${HSTR}  ${DIM}${HEALTH_URL}${R}"
+printf "${B}Containers:${R}         "
+docker ps --filter 'name=ppp-' --format '{{.Names}} ({{.Status}})' \
+  | sed 's/ (Up[^)]*(healthy))/ ok/' | paste -sd, - | sed 's/,/, /g' || true
+hr
+
+# ----- candidates -----------------------------------------------------------
+# Asked of the registry, not of a checkout: the NAS has no git, and "what is
+# published" is the honest definition of what is deployable anyway.
+read_token() {
+  if [ -n "${PPP_TOKEN:-}" ]; then TOKEN="$PPP_TOKEN"; return; fi
+  printf 'ghcr.io token (read:packages, hidden): '
+  stty -echo 2>/dev/null || true
+  read -r TOKEN
+  stty echo 2>/dev/null || true
+  printf '\n'
+  [ -n "$TOKEN" ] || die "no token given"
+}
+read_token
+
+echo "${DIM}→ asking ghcr.io what is published…${R}"
+VERSIONS="$(curl -sS --max-time 20 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/user/packages/container/ppp-app/versions?per_page=100" 2>/dev/null || true)"
+
+# Two things this filtering has to get right, both learned the hard way:
+#   - release-images publishes cosign signatures and SBOM attestations to the
+#     same package, tagged `sha256-<digest>.sig` / `.att`. Those are not
+#     runnable images; only a 7-hex-char tag is one.
+#   - sort by created_at, NOT updated_at. Re-pointing `latest` on a new
+#     release touches the OLD version's updated_at too, so ordering by it
+#     reshuffles history and shows a build's date as the day it was
+#     superseded.
+CANDIDATES="$(printf '%s' "$VERSIONS" | python3 -c '
+import json, re, sys
+SHA = re.compile(r"^[0-9a-f]{7}$")
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+if not isinstance(data, list):
+    sys.exit(1)
+rows = []
+for v in data:
+    tags = (v.get("metadata") or {}).get("container", {}).get("tags", []) or []
+    sha = next((t for t in tags if SHA.match(t)), None)
+    if not sha:
+        continue
+    rows.append((v.get("created_at") or "", sha, "latest" in tags))
+rows.sort(reverse=True)
+for when, sha, is_latest in rows:
+    print("\t".join([sha, when[:16].replace("T", " "), "latest" if is_latest else ""]))
+' 2>/dev/null || true)"
+
+if [ -z "$CANDIDATES" ]; then
+  echo "${YLW}⚠ could not read the package list.${R}"
+  echo "  ${DIM}Most likely the token lacks read:packages, or it expired."
+  echo "  Verify with:  curl -sSI -H \"Authorization: Bearer \$TOKEN\" https://api.github.com/user | grep -i x-oauth-scopes${R}"
+  exit 1
+fi
+
+echo
+echo "${B}Published images${R} ${DIM}(newest first):${R}"
+echo
+printf "  ${DIM} %-3s %-10s %-18s %-8s %s${R}\n" "#" "tag" "published" "moving" "state"
+
+declare -a IDX_SHA
+i=0; DEFAULT=""
+while IFS=$'\t' read -r sha when islatest; do
+  [ -n "$sha" ] || continue
+  i=$((i+1)); [ "$i" -gt "$WINDOW" ] && break
+  IDX_SHA[$i]="$sha"
+  if [ "$sha" = "$CURRENT" ]; then
+    state="${CYN}LIVE${R}"
+  else
+    state="${DIM}-${R}"
+  fi
+  # Recommend the newest published image that is not already live, and only
+  # when it is NEWER than what is live — never point the default backwards at
+  # something old that simply never shipped; that would read as a regression.
+  if [ -z "$DEFAULT" ] && [ "$sha" != "$CURRENT" ] && [ "$i" -eq 1 ]; then
+    DEFAULT="$i"; mark="${B}${GRN}»${R}"
+  else
+    mark=" "
+  fi
+  printf " %b %-3s ${CYN}%-10s${R} %-18s %-8s %b\n" "$mark" "$i" "$sha" "$when" "${islatest:-}" "$state"
+done <<< "$CANDIDATES"
+echo
+
+if [ -n "$DEFAULT" ]; then
+  echo "${DIM}» = recommended (newest published image, not yet live)${R}"
+else
+  echo "${GRN}✓ up to date — the newest published image is already live.${R}"
+  echo "${DIM}  (You can still redeploy or roll back by number.)${R}"
+fi
+hr
+
+[ "$STATUS_ONLY" -eq 1 ] && exit 0
+
+# ----- selection ------------------------------------------------------------
+echo "${B}Choose an action:${R}"
+echo "   ${B}<number>${R}  deploy that image"
+[ -n "$DEFAULT" ] && echo "   ${B}<enter>${R}   deploy the recommended image (${CYN}${IDX_SHA[$DEFAULT]}${R})"
+echo "   ${B}q${R}         quit"
+printf "> "
+read -r choice
+
+if [ -z "$choice" ]; then
+  [ -n "$DEFAULT" ] || { echo "aborted."; exit 0; }
+  choice="$DEFAULT"
+fi
+case "$choice" in q|Q) echo "aborted."; exit 0 ;; esac
+[[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$i" ] \
+  || die "invalid selection: $choice"
+
+TARGET="${IDX_SHA[$choice]}"
+[ "$TARGET" = "$CURRENT" ] && echo "${YLW}note: ${TARGET} is already live — this is a redeploy.${R}"
+
+echo
+if [ "$TARGET" = "$CURRENT" ]; then
+  printf "Redeploy %s? [y/N] " "$TARGET"
+else
+  printf "Deploy ${CYN}%s${R} (replacing %s)? [y/N] " "$TARGET" "$CURRENT"
+fi
+read -r ans; case "$ans" in y|Y|yes|YES) ;; *) echo "aborted."; exit 0 ;; esac
+
+# ----- signature ------------------------------------------------------------
+# CI signs both images with cosign keyless, pinning the identity of the
+# release-images workflow on this repo. That signature is what protects the
+# registry-to-NAS link against a substituted or tampered image, so it is
+# checked BEFORE anything is swapped — and its absence is reported, never
+# silently skipped.
+if command -v cosign >/dev/null; then
+  echo "${DIM}→ verifying signatures…${R}"
+  for img in $IMAGES; do
+    if cosign verify \
+        --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/release-images\.yml@refs/heads/main$" \
+        --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+        "ghcr.io/${REGISTRY_OWNER}/${img}:${TARGET}" >/dev/null 2>&1; then
+      echo "  ${GRN}✓${R} ${img}:${TARGET} signed by release-images on ${REPO}"
+    else
+      die "${img}:${TARGET} failed signature verification — refusing to deploy."
+    fi
+  done
+else
+  echo "${YLW}⚠ cosign is not installed — signatures were NOT checked.${R}"
+  echo "  ${DIM}The images are still pulled by tag over TLS, but nothing proves they"
+  echo "  came from this repo's workflow. Install cosign to close that gap:"
+  echo "  https://docs.sigstore.dev/cosign/installation/${R}"
+  printf "Continue without verification? [y/N] "
+  read -r ans; case "$ans" in y|Y|yes|YES) ;; *) echo "aborted."; exit 0 ;; esac
+fi
+
+# ----- deploy ---------------------------------------------------------------
+cleanup() { docker logout ghcr.io >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "${DIM}→ authenticating to ghcr.io…${R}"
+printf '%s' "$TOKEN" | docker login ghcr.io -u "$REGISTRY_OWNER" --password-stdin >/dev/null \
+  || die "docker login failed — check the token's read:packages scope"
+
+echo "${DIM}→ pulling ${TARGET}…${R}"
+( cd "$PROJECT_DIR" && sed -i "s|^PPP_TAG=.*|PPP_TAG=\"$TARGET\"|" .env.docker )
+if ! compose pull; then
+  ( cd "$PROJECT_DIR" && sed -i "s|^PPP_TAG=.*|PPP_TAG=\"$CURRENT\"|" .env.docker )
+  die "pull failed — .env.docker restored to ${CURRENT}, nothing was restarted"
+fi
+
+echo "${DIM}→ starting…${R}"
+compose up -d
+
+# ----- health, with automatic rollback --------------------------------------
+echo "${DIM}→ waiting for health (polling ${HEALTH_URL}, up to $((HEALTH_TIMEOUT/60)) min)…${R}"
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT )); ok=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$HEALTH_URL" || true)"
+  if [ "$code" = "200" ]; then ok=$((ok+1)); [ "$ok" -ge 2 ] && break; else ok=0; fi
+  sleep 10
+done
+
+if [ "$ok" -ge 2 ]; then
+  echo "  ${GRN}✓${R} ${HEALTH_URL} → 200 (stable)"
+  echo "${GRN}✓ ${TARGET} is live and healthy.${R}"
+  compose ps
+  exit 0
+fi
+
+echo "${RED}✗ health did not stabilise — rolling back to ${CURRENT}.${R}" >&2
+( cd "$PROJECT_DIR" && sed -i "s|^PPP_TAG=.*|PPP_TAG=\"$CURRENT\"|" .env.docker )
+compose up -d
+sleep 10
+code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "$HEALTH_URL" || true)"
+if [ "$code" = "200" ]; then
+  echo "${YLW}⚠ rolled back to ${CURRENT}, which is healthy again.${R}" >&2
+  echo "  ${DIM}Check what went wrong:  docker compose logs app --tail=100${R}" >&2
+else
+  echo "${RED}✗ rollback to ${CURRENT} is ALSO unhealthy (${code}).${R}" >&2
+  echo "  ${DIM}This is not the image — look at the proxy, the database, or the tunnel."
+  echo "  docker compose ps ; docker compose logs --tail=100${R}" >&2
+fi
+exit 1

--- a/src/app/admin/invites/page.tsx
+++ b/src/app/admin/invites/page.tsx
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { requireAdmin } from "@/lib/authz";
 import { INVITE_TTL_DAYS } from "@/lib/invites";
 import { RESET_TTL_MINUTES } from "@/lib/password-reset";
+import { AppHeader } from "@/components/app-header";
 import { Kicker, StatusChip } from "@/components/ui";
 import { InviteForm } from "./invite-form";
 import { ResetPassword } from "@/components/reset-password";
@@ -49,7 +50,7 @@ function relative(date: Date): string {
 }
 
 export default async function InvitesPage() {
-  await requireAdmin();
+  const admin = await requireAdmin();
 
   const [invites, memberList] = await Promise.all([
     db.invite.findMany({
@@ -68,120 +69,130 @@ export default async function InvitesPage() {
   const open = invites.filter((i) => stateOf(i) === "Pending");
 
   return (
-    <main className="mx-auto w-full max-w-[1180px] px-[26.4px] pb-[80px] pt-[35.2px]">
-      <Kicker>Admin · who gets a table</Kicker>
-      <h1 className="m-0 mb-[13.2px] text-[46px] leading-[0.98] text-ink">
-        The guest list
-      </h1>
-      <p className="m-0 mb-[26.4px] max-w-[620px] text-[16.5px] leading-[1.5] text-ink-2 text-pretty">
-        {members} {members === 1 ? "person" : "people"} can send you models, and{" "}
-        {open.length} {open.length === 1 ? "invite is" : "invites are"} still
-        outstanding. Links expire after {INVITE_TTL_DAYS} days and work exactly
-        once.
-      </p>
+    <>
+      <AppHeader user={admin} active="/admin/invites" />
 
-      <InviteForm />
+      <main className="mx-auto w-full max-w-[1180px] px-[26.4px] pb-[80px] pt-[35.2px]">
+        <Kicker>Admin · who gets a table</Kicker>
+        <h1 className="m-0 mb-[13.2px] text-[46px] leading-[0.98] text-ink">
+          The guest list
+        </h1>
+        <p className="m-0 mb-[26.4px] max-w-[620px] text-[16.5px] leading-[1.5] text-ink-2 text-pretty">
+          {members} {members === 1 ? "person" : "people"} can send you models, and{" "}
+          {open.length} {open.length === 1 ? "invite is" : "invites are"} still
+          outstanding. Links expire after {INVITE_TTL_DAYS} days and work exactly
+          once.
+        </p>
 
-      {memberList.length > 0 && (
-        <>
-          <h2 className="mb-[13.2px] mt-[35.2px] font-display text-[26px] text-ink">
-            Who is in
-          </h2>
-          <div className="overflow-hidden rounded-panel border-[3px] border-ink bg-porcelain shadow-stamp">
-            {memberList.map((m, i) => (
-              <div
-                key={m.id}
-                className={`flex flex-wrap items-center gap-[15px] p-[15px] ${
-                  i < memberList.length - 1 ? "border-b-2 border-dashed border-rule" : ""
-                }`}
-              >
-                <span
-                  aria-hidden
-                  className="flex h-[36px] w-[36px] flex-none items-center justify-center rounded-full border-[3px] border-ink bg-aqua font-mono text-[12px] font-bold text-ink"
+        <InviteForm />
+
+        {memberList.length > 0 && (
+          <>
+            <h2 className="mb-[13.2px] mt-[35.2px] font-display text-[26px] text-ink">
+              Who is in
+            </h2>
+            <div className="overflow-hidden rounded-panel border-[3px] border-ink bg-porcelain shadow-stamp">
+              {memberList.map((m, i) => (
+                <div
+                  key={m.id}
+                  className={`flex flex-wrap items-center gap-[15px] p-[15px] ${
+                    i < memberList.length - 1 ? "border-b-2 border-dashed border-rule" : ""
+                  }`}
                 >
-                  {m.initials}
-                </span>
-                <div className="min-w-[180px] flex-[1_1_240px]">
-                  <p className="m-0 font-display text-[17px] text-ink">{m.name}</p>
-                  <p className="m-0 font-mono text-[11.5px] text-ink-3">{m.email}</p>
+                  <span
+                    aria-hidden
+                    className="flex h-[36px] w-[36px] flex-none items-center justify-center rounded-full border-[3px] border-ink bg-aqua font-mono text-[12px] font-bold text-ink"
+                  >
+                    {m.initials}
+                  </span>
+                  <div className="min-w-[180px] flex-[1_1_240px]">
+                    <p className="m-0 font-display text-[17px] text-ink">{m.name}</p>
+                    <p className="m-0 font-mono text-[11.5px] text-ink-3">{m.email}</p>
+                  </div>
+                  <ResetPassword
+                    userId={m.id}
+                    name={m.name.split(" ")[0] ?? m.name}
+                    expiresInMinutes={RESET_TTL_MINUTES}
+                  />
                 </div>
-                <ResetPassword
-                  userId={m.id}
-                  name={m.name.split(" ")[0] ?? m.name}
-                  expiresInMinutes={RESET_TTL_MINUTES}
-                />
-              </div>
-            ))}
-          </div>
-        </>
-      )}
-
-      <h2 className="mb-[13.2px] mt-[35.2px] font-display text-[26px] text-ink">
-        Invitations
-      </h2>
-
-      <div className="rounded-panel border-[3px] border-ink bg-porcelain px-[22px] pb-[22px] pt-[8.8px] shadow-stamp">
-        {invites.length === 0 && (
-          <p className="py-[17.6px] font-mono text-[12px] uppercase text-ink-3">
-            Nobody yet. The office is very quiet.
-          </p>
+              ))}
+            </div>
+          </>
         )}
 
-        {invites.map((invite) => {
-          const state = stateOf(invite);
-          return (
-            <div
-              key={invite.id}
-              className="flex flex-wrap items-center gap-[17.6px] border-b-2 border-dashed border-rule py-[17.6px] last:border-b-0"
-            >
-              <div className="min-w-[190px] flex-[1_1_240px]">
-                <div className="font-mono text-[15px] font-bold text-ink">{invite.email}</div>
-                <div className="mt-[3px] text-[13px] text-ink-3">
-                  {invite.name ? `${invite.name} · ` : ""}
-                  invited by {invite.invitedBy.name} · {relative(invite.createdAt)}
-                </div>
-              </div>
+        <h2 className="mb-[13.2px] mt-[35.2px] font-display text-[26px] text-ink">
+          Invitations
+        </h2>
 
-              <span
-                className={`rounded-chip border-2 border-ink px-[11px] py-[3px] font-mono text-[11.5px] font-bold uppercase tracking-[0.06em] ${CHIP[state]}`}
+        <div className="rounded-panel border-[3px] border-ink bg-porcelain px-[22px] pb-[22px] pt-[8.8px] shadow-stamp">
+          {invites.length === 0 && (
+            <p className="py-[17.6px] font-mono text-[12px] uppercase text-ink-3">
+              Nobody yet. The office is very quiet.
+            </p>
+          )}
+
+          {invites.map((invite) => {
+            const state = stateOf(invite);
+            return (
+              <div
+                key={invite.id}
+                className="flex flex-wrap items-center gap-[17.6px] border-b-2 border-dashed border-rule py-[17.6px] last:border-b-0"
               >
-                {state}
-              </span>
-
-              <div className="w-[150px] font-mono text-[11.5px] uppercase text-ink-3">
-                {state === "Pending"
-                  ? `expires ${relative(invite.expiresAt)}`
-                  : state === "Accepted"
-                    ? `joined ${relative(invite.acceptedAt!)}`
-                    : ""}
-              </div>
-
-              {state === "Pending" || state === "Expired" ? (
-                <div className="flex flex-wrap gap-[8.8px]">
-                  <form action={resendInviteAction}>
-                    <input type="hidden" name="id" value={invite.id} />
-                    <button
-                      type="submit"
-                      className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-aqua px-[15px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink hover:bg-sun"
-                    >
-                      Send again
-                    </button>
-                  </form>
-                  <form action={revokeInviteAction}>
-                    <input type="hidden" name="id" value={invite.id} />
-                    <button
-                      type="submit"
-                      className="cursor-pointer rounded-chip border-[3px] border-transparent px-[15px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink-2 hover:border-ink hover:bg-cherry-wash"
-                    >
-                      Withdraw
-                    </button>
-                  </form>
+                <div className="min-w-[190px] flex-[1_1_240px]">
+                  <div className="font-mono text-[15px] font-bold text-ink">{invite.email}</div>
+                  <div className="mt-[3px] text-[13px] text-ink-3">
+                    {invite.name ? `${invite.name} · ` : ""}
+                    invited by {invite.invitedBy.name} · {relative(invite.createdAt)}
+                  </div>
                 </div>
-              ) : null}
-            </div>
-          );
-        })}
-      </div>
-    </main>
+
+                <span
+                  className={`rounded-chip border-2 border-ink px-[11px] py-[3px] font-mono text-[11.5px] font-bold uppercase tracking-[0.06em] ${CHIP[state]}`}
+                >
+                  {state}
+                </span>
+
+                <div className="w-[150px] font-mono text-[11.5px] uppercase text-ink-3">
+                  {state === "Pending"
+                    ? `expires ${relative(invite.expiresAt)}`
+                    : state === "Accepted"
+                      ? `joined ${relative(invite.acceptedAt!)}`
+                      : ""}
+                </div>
+
+                {state === "Pending" || state === "Expired" ? (
+                  <div className="flex flex-wrap gap-[8.8px]">
+                    <form action={resendInviteAction}>
+                      <input type="hidden" name="id" value={invite.id} />
+                      <button
+                        type="submit"
+                        className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-aqua px-[15px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink hover:bg-sun"
+                      >
+                        Send again
+                      </button>
+                    </form>
+                    {/* Carries the same keyline as its neighbour. It used to be
+                        a transparent-bordered grey label, which on a page with
+                        no header read as body text — the destructive action was
+                        the least visible thing on the row. Cherry-wash marks it
+                        as the dangerous one without letting it shout louder than
+                        the primary. */}
+                    <form action={revokeInviteAction}>
+                      <input type="hidden" name="id" value={invite.id} />
+                      <button
+                        type="submit"
+                        className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-wash px-[15px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-cherry-dk hover:bg-cherry hover:text-cream"
+                      >
+                        Withdraw
+                      </button>
+                    </form>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
Three things the first real deployment turned up.

## `scripts/deploy-wizard.sh`

The single entry point for a deploy, modelled on ciphra's. The shape had to change: ciphra deploys by pushing a git tag that a VPS timer picks up, so its wizard reads `origin/main` and needs `git` + `gh`. The NAS has neither and shouldn't — it consumes images CI built, signed and scanned. So this one **asks the registry what exists** rather than asking a checkout, and runs on the NAS with `docker`, `curl` and `python3`.

| | ciphra | ppp |
| --- | --- | --- |
| Which image? | commits on `origin/main` + CI status | published tags on ghcr.io + build dates |
| Am I allowed? | GitHub repo write permission | holding a `read:packages` token |
| Is it intact? | VPS cosign-verifies on pull | wizard cosign-verifies before the swap |
| Did it work? | VPS health-checks, auto-rollback | wizard health-checks, auto-rollback |

Two bugs caught by testing against a fixture rather than reading the code:

- **`.sig` and `.att` tags were offered as deployable images.** cosign signatures and the SBOM attestation land in the same package. Now filtered to 7-hex-char tags.
- **Sorting by `updated_at` scrambled history.** Re-pointing `latest` touches the *previous* version's timestamp, so a build displayed the date it was superseded rather than the date it was built. Now `created_at`.

The registry token is borrowed and returned — hidden prompt, used for the pull, `docker logout` on exit including on failure. Nothing long-lived is left on the NAS, which costs nothing: the images are local afterwards and `restart: unless-stopped` needs no registry access at all.

Rollback is the same menu — pick the older tag. On a failed health check it rolls back on its own, then reports whether the rollback is healthy, which is what separates "bad image" from "the proxy or the database is down".

## `docker-compose.cf.yml`

Cloudflare in front of Nginx Proxy Manager. It existed only on the NAS, which is exactly where a deployment file should not only exist.

Identical to `docker-compose.truenas.yml` but for the setting that matters. Cloudflare **appends** to `X-Forwarded-For` instead of replacing it, and NPM appends again — so the left-most entry, the one `clientIp()` reads, is whatever the client chose to send. `TRUST_PROXY_HEADERS` has to be `false` there, and hard-coding it `true` was the one thing the `truenas` overlay could not be talked out of.

Follow-up worth doing: teach `src/lib/audit.ts` to read `CF-Connecting-IP` when configured, which would let a Cloudflare-fronted deployment record real client addresses again instead of blanks.

## `/admin/invites`

Two defects, only one of which was what it looked like.

- **No navigation.** It was the only authenticated page not rendering `AppHeader`, while the header's own admin nav links straight to it. You could navigate in and not out.
- **The withdraw control was invisible, not missing.** A transparent-bordered grey label beside a saturated aqua button, on a page with no header, reads as body text. The behaviour was correct all along — submitting the form as a JS-less browser does revokes the invite and audits it. It now carries the same keyline as its neighbour, in cherry-wash: visibly a control, visibly the dangerous one.

## Verification

`verify:auth`, `verify:queue` 50, `verify:upload` 53, `probe:security` 62, `verify:models` 29 — all green against the built container image. The wizard was exercised end to end against stubbed `curl`/`docker`: help and guard paths, the candidate table in both up-to-date and update-available states, quit / redeploy / replace / invalid selections, and the `PPP_TAG` read-write round-trip against quoted, unquoted and comment-suffixed forms with sibling keys intact.