### PR TITLE
MIT, so the careful ones are allowed in

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Danilo Licitra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Built from `Print That for Me/design_handoff_print_that_for_me/`. Built so far:
 Not built: the admin queue and status transitions, the conversation thread,
 the 3D viewer, the profile screen, and notification delivery by email.
 
+## Licence
+
+[MIT](LICENSE). Self-host it, fork it, change it, run it for your office — the
+licence exists to say yes, and to say the warranty is nil.
+
 ## Stack
 
 | | |

--- a/package.json
+++ b/package.json
@@ -2,6 +2,17 @@
   "name": "pretty-please-print",
   "version": "0.1.0",
   "private": true,
+  "description": "Invite-only 3D print requests for a small office \u2014 upload a model, follow it through the print stages.",
+  "license": "MIT",
+  "author": "Danilo Licitra",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danileau/ppp.git"
+  },
+  "homepage": "https://github.com/danileau/ppp#readme",
+  "bugs": {
+    "url": "https://github.com/danileau/ppp/issues"
+  },
   "type": "module",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
There was no `LICENSE`, which under copyright default means **all rights reserved** — legally nobody may run this, fork it or self-host it.

The reason to fix that isn't enforcement. Nobody is going to pursue a violation over an office print queue, and anyone determined copies the code regardless. **A licence is a permission slip, not a lock**, and its absence stops the wrong people:

- a company whose IT policy forbids unlicensed code — which for an office print queue is the actual audience;
- a packager for Debian, Nix, Homebrew or the TrueNAS catalogue, all of which mechanically refuse repos with no licence;
- anyone who wants to send a PR and finds the copyright status of their own contribution undefined.

The people who would ignore a licence ignore its absence just as happily. The asymmetry runs the opposite way to how it feels.

**MIT rather than AGPL** because the threat AGPL guards against — someone running a closed modified fork as a service — isn't one this app faces, and ceremony aimed at an imaginary risk is worse than none.

It also restores the warranty disclaimer. Publishing without a licence publishes without the "AS IS, NO WARRANTY" clause too.

Also fills in `package.json`'s `license`, `description`, `author`, `repository`, `homepage` and `bugs`, all of which were null, and adds a short Licence section to the README.
