### PR TITLE
A front door, and a security policy that is one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,750 +1,290 @@
 # Pretty Please Print
 
-Invite-only 3D print requests for a small office. One person owns the printer;
-everyone else uploads a model and follows it through the print stages.
+[![CI](https://github.com/danileau/ppp/actions/workflows/ci.yml/badge.svg)](https://github.com/danileau/ppp/actions/workflows/ci.yml)
+[![Licence: MIT](https://img.shields.io/badge/licence-MIT-blue.svg)](LICENSE)
+[![Self-hosted](https://img.shields.io/badge/self--hosted-docker%20compose-2496ed)](docs/deployment.md)
+[![Stars](https://img.shields.io/github/stars/danileau/ppp?style=flat)](https://github.com/danileau/ppp/stargazers)
+[![Forks](https://img.shields.io/github/forks/danileau/ppp?style=flat)](https://github.com/danileau/ppp/network/members)
 
-Previously *Print That For Me*, the name the design handoff uses. The handoff
-is unchanged in `Print That for Me/`; everything in the app reads
-*Pretty Please Print*, story refs included (`PPP-104`).
+**Invite-only 3D print requests for a small office.** One person owns the
+printer. Everyone else uploads a model, says what they are hoping for, and
+follows it through the print stages on a board — instead of asking in a
+corridor and then wondering.
 
-Built from `Print That for Me/design_handoff_print_that_for_me/`. Built so far:
+Self-hosted, Docker Compose, no accounts anywhere but your own machine. Five
+people and one printer is the size it is built for, and it is honest about
+that: there is no multi-tenancy, no billing, and no queue theory.
 
-- **Authentication and invitation-link registration** — username and password,
-  passkeys, invite-only with no public sign-up.
-- **Upload → board → story detail** — real file validation, object storage,
-  mesh measurement, the kanban board, and the read half of story detail.
-- **An audit trail** covering access and story events, readable at
-  `/admin/audit`.
+## What it does
 
-Not built: the admin queue and status transitions, the conversation thread,
-the 3D viewer, the profile screen, and notification delivery by email.
+- **Invite-only.** There is no public sign-up. A `User` row cannot come into
+  existence without a pending invitation, enforced in a single hook that every
+  authentication method goes through.
+- **Upload a model** — `.stl` or `.3mf`, validated against its actual bytes
+  rather than its filename, measured for its bounding box, stored in object
+  storage and never in the web root.
+- **Follow it on a board** — Requested → Accepted → Printing → Done →
+  Delivery, one step at a time, forwards only. Or Declined, with a reason.
+- **Talk on the ticket** — a conversation thread per request, so "can you do it
+  in teal" lives with the model rather than in a chat app.
+- **See the actual geometry** — the uploaded mesh rendered in the browser,
+  auto-framed, drag to rotate.
+- **An audit trail** of everything that changes who can get in or what happens
+  to someone's model, readable at `/admin/audit`, never edited or deleted.
+
+## Requirements
+
+| | |
+| --- | --- |
+| Host | anything that runs Docker Compose — a NAS, a Pi 5, a VPS, a spare laptop |
+| Memory | ~1 GB for the whole stack (app, Postgres, MinIO) |
+| Disk | small — the database is megabytes; uploads are capped at 50 MB each |
+| TLS | **required.** The app refuses to start on plain `http://` in production, and passkeys need a secure context |
+| Mail | **optional.** Nothing needs it — see [Mail is optional](docs/authentication.md#mail-is-optional--genuinely) |
+
+## Quick start
+
+```bash
+git clone https://github.com/danileau/ppp.git && cd ppp
+cp .env.docker.example .env.docker
+```
+
+Edit `.env.docker` — at minimum generate the three secrets and set your
+hostname and admin:
+
+```bash
+BETTER_AUTH_SECRET="$(openssl rand -base64 32)"
+DB_PASSWORD="$(openssl rand -hex 24)"
+S3_SECRET_KEY="$(openssl rand -hex 24)"
+APP_URL="https://print.example.org"
+PASSKEY_RP_ID="print.example.org"
+ADMIN_EMAIL="you@example.org"
+ADMIN_NAME="Your Name"
+```
+
+Then bring it up. This build-from-source variant publishes ports and catches
+mail locally, which is what you want for a first look:
+
+```bash
+docker compose --env-file .env.docker \
+  -f docker-compose.prod.yml -f docker-compose.build.yml \
+  -f docker-compose.test.yml --profile mailcatcher up -d --build
+```
+
+The migrator prints a **one-use link** for the admin to choose a username and
+a password. Read it, and open it within thirty minutes:
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
+```
+
+Then invite the office from `/admin/invites`. For a real deployment behind a
+reverse proxy, see **[docs/deployment.md](docs/deployment.md)**.
+
+> There is deliberately no `ADMIN_PASSWORD`. A password in an env file is also
+> in `docker inspect`, in the shell history that wrote it, and in every backup
+> of the host — still valid months later. A link that expires in half an hour
+> is a smaller thing to leak.
+
+## Configuration
+
+Everything is environment variables, read from `.env.docker`. The full file
+with commentary is [`.env.docker.example`](.env.docker.example).
+
+| Variable | Required | What it does |
+| --- | --- | --- |
+| `BETTER_AUTH_SECRET` | **yes** | Signs session cookies. `openssl rand -base64 32`. Losing it invalidates every session. |
+| `DB_PASSWORD` | **yes** | Postgres password. Baked into the data directory on first start — see [Restore](#restore). |
+| `S3_SECRET_KEY` | **yes** | MinIO root password. |
+| `S3_ACCESS_KEY` | | MinIO root user. Default `ppp`. |
+| `S3_BUCKET` | | Default `ppp-models`. |
+| `APP_URL` | **yes** | The origin the browser sees, including scheme. Cookies, invitation links and the WebAuthn relying party derive from it. Must be `https://` in production. |
+| `PASSKEY_RP_ID` | **yes** | Registrable domain, no scheme or port. **Permanent** — changing it kills every enrolled passkey. |
+| `PASSKEY_RP_NAME` | | Shown in the browser's passkey prompt. |
+| `ADMIN_EMAIL` / `ADMIN_NAME` | **yes** | The single admin, created on first start. |
+| `DATA_ROOT` | | Where the database and uploads live on disk. Default `./data`. |
+| `SMTP_URL` | | SMTP transport. **Leave unset and the app still works** — links are shown to the admin to hand over. |
+| `RESEND_API_KEY` | | Alternative to `SMTP_URL`; takes precedence. |
+| `MAIL_FROM` | | Envelope sender. |
+| `TRUST_PROXY_HEADERS` | | `true` only when the app is unreachable except through your proxy. See [the reasoning](docs/deployment.md#why-trust_proxy_headers-is-a-separate-switch). |
+| `HIBP_DISABLED` | | `true` disables the breach check. Only for a host with no outbound internet — it fails closed, so without it nobody could register. |
+| `PPP_REGISTRY` / `PPP_TAG` | | Which published image to run. Pin `PPP_TAG` to a commit SHA; that is also how you roll back. |
+
+## Deploying
+
+The short version: pull a published image, put a reverse proxy in front, point
+`DATA_ROOT` at real storage.
+
+```bash
+docker compose --env-file .env.docker \
+  -f docker-compose.prod.yml -f docker-compose.truenas.yml up -d
+```
+
+`docker-compose.prod.yml` **consumes** images rather than building them, so a
+deployment needs no source tree and no toolchain, and what runs there is
+byte-for-byte what CI tested and signed. It publishes **no host ports at all** —
+each overlay adds only what its context needs.
+
+`scripts/deploy-wizard.sh` is the way to move between versions: it lists what is
+published, cosign-verifies before swapping, health-checks after, and rolls back
+on its own if the new image does not come good. See
+**[docs/deployment.md](docs/deployment.md)**.
+
+## Backup and restore
+
+### Back up
+
+Everything that matters is under `DATA_ROOT` plus one file:
+
+| | |
+| --- | --- |
+| `$DATA_ROOT/db/` | Postgres — accounts, tickets, comments, the audit trail |
+| `$DATA_ROOT/models/` | the uploaded `.stl` / `.3mf` files |
+| `.env.docker` | the secrets. **Not** under `DATA_ROOT`, and not in the repo. |
+
+On ZFS, one recursive snapshot of the parent dataset captures all three:
+
+```bash
+zfs snapshot -r storage/applications/ppp@$(date +%F)
+```
+
+That snapshot is *crash-consistent*, not clean — Postgres replays its WAL on
+start and recovers, which is fine and is what it is designed for. If you want a
+backup that can be restored into any Postgres rather than only onto this data
+directory, take a logical dump alongside it:
+
+```bash
+docker exec ppp-db pg_dump -U ppp -Fc ppp > ppp-$(date +%F).dump
+```
+
+### Restore
+
+```bash
+# 1. stop the stack — never restore under a running Postgres
+docker compose --env-file .env.docker -f docker-compose.prod.yml down
+
+# 2. put the data back (ZFS rollback, or copy the files)
+zfs rollback storage/applications/ppp/data/db@2026-08-23
+zfs rollback storage/applications/ppp/data/models@2026-08-23
+
+# 3. bring it up; the migrator applies any pending migrations
+docker compose --env-file .env.docker -f docker-compose.prod.yml up -d
+docker compose --env-file .env.docker -f docker-compose.prod.yml ps
+```
+
+Two things that will bite if you do not know them:
+
+- **`DB_PASSWORD` must be the one the restored data was created with.** Postgres
+  stores the password inside the data directory. Restore `db/` from an old
+  backup while `.env.docker` holds a newly generated password and the app
+  cannot connect, with an authentication error that looks like a config typo.
+  This is the main reason `.env.docker` belongs in the backup.
+- **`BETTER_AUTH_SECRET` is not recoverable.** Lose it and every session is
+  invalidated — nobody is locked out permanently, everyone simply signs in
+  again. Passwords and passkeys are unaffected.
+
+Restore into a *different* host, or from a `pg_dump`, needs the database
+recreated first:
+
+```bash
+docker exec -i ppp-db pg_restore -U ppp -d ppp --clean --if-exists < ppp-2026-08-23.dump
+```
+
+## Troubleshooting
+
+**502 from the reverse proxy, nothing in the app's logs.**
+The proxy cannot reach the container. If you route by container name over a
+shared Docker network, check both are still on it — updating a proxy that is
+itself a managed app recreates its container and silently drops the
+attachment:
+
+```bash
+docker network inspect npm-proxy --format '{{range .Containers}}{{.Name}} {{end}}'
+docker run --rm --network npm-proxy curlimages/curl -sS -m 5 http://ppp-app:3000/api/health
+```
+
+**`unauthorized` when pulling the images.**
+The registry token needs **`read:packages`** and nothing else — it is a
+*classic* token scope, nested under `write:packages` in the checkbox list.
+Fine-grained tokens do not work with ghcr.io at all. Check what yours carries:
+
+```bash
+curl -sSI -H "Authorization: Bearer $TOKEN" https://api.github.com/user | grep -i x-oauth-scopes
+```
+
+**The certificate will not issue.**
+ACME HTTP-01 validation goes to whatever the public DNS record points at. If
+that is still your web host rather than your proxy, the challenge is answered
+by the wrong machine and nothing you change locally will help. Check where the
+name actually resolves, and what answers there:
+
+```bash
+dig +short your.host.example
+curl -sS -D - "http://your.host.example/.well-known/acme-challenge/probe" | head -5
+```
+
+Behind Cloudflare's proxy, visitors see Cloudflare's certificate regardless, so
+an **Origin Certificate** plus SSL mode *Full (strict)* removes ACME from the
+picture entirely.
+
+**Audit rows have no IP address.**
+Expected when `TRUST_PROXY_HEADERS=false`, which is correct behind Cloudflare:
+it *appends* to `X-Forwarded-For` rather than replacing it, so the left-most
+entry is whatever the client chose to send. The app records nothing rather than
+something attacker-chosen.
+
+**The bootstrap link expired.**
+Re-run the migrator; it prints a fresh one, and keeps doing so until a password
+is actually set. It never resets an existing password.
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml up -d migrate
+docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
+```
+
+**Nobody can register, and the error mentions a breach check.**
+The password check calls `api.pwnedpasswords.com` and fails closed. If the host
+has no outbound internet, set `HIBP_DISABLED=true` — and only then.
+
+## Documentation
+
+| | |
+| --- | --- |
+| **[Authentication](docs/authentication.md)** | invite-only registration, passwords, passkeys, resets, and why each decision went the way it did |
+| **[Architecture](docs/architecture.md)** | the viewer, upload validation, decisions taken against the design handoff, and the file layout |
+| **[Deployment](docs/deployment.md)** | containers, reverse proxies, the deploy wizard, TLS, first run |
+| **[Development](docs/development.md)** | stack, local setup, the six verification suites, CI |
+| **[Security audit](docs/security-audit.md)** | the OWASP Top 10 assessment, findings, and residual risk accepted |
+| **[Security policy](SECURITY.md)** | how to report a vulnerability |
+
+## Security
+
+Invite-only enforced in one hook across every authentication method. Passwords
+are ≥10 characters and refused if they appear in a known breach corpus.
+Authorisation answers **404, not 403**, for a resource you may not see — a 403
+confirms it exists. Session cookies are `HttpOnly`, `SameSite=Lax` and
+`__Secure-` prefixed, with cookie caching deliberately off so sign-out is
+immediate. CSP carries a per-request nonce. Every access and content change is
+audited.
+
+The full assessment, including what was found and fixed and what is knowingly
+accepted, is in [docs/security-audit.md](docs/security-audit.md). To report
+something, see [SECURITY.md](SECURITY.md).
+
+## Contributing
+
+Issues and pull requests are welcome. The six verification suites in
+`scripts/` are the contract — `npm run verify:auth`, `verify:upload`,
+`verify:queue`, `verify:models`, `verify:passkey` and `probe:security` all run
+in CI against the built container image, not a dev server. If a change makes
+one fail, that is the change talking.
+
+See [docs/development.md](docs/development.md) to get set up.
 
 ## Licence
 
 [MIT](LICENSE). Self-host it, fork it, change it, run it for your office — the
 licence exists to say yes, and to say the warranty is nil.
 
-## Stack
-
-| | |
-| --- | --- |
-| Framework | Next.js 15 (App Router), React 19, TypeScript |
-| Auth | [Better Auth](https://better-auth.com) 1.7 — username/password, passkeys, breach check, admin plugin |
-| Data | Prisma 6 → PostgreSQL 17 |
-| Styling | Tailwind v4, design tokens from the handoff as CSS variables |
-| Local infra | Docker Compose: Postgres, MinIO (model files), Mailpit (mail) |
-
-Chosen to match the existing house style (`huere-siech` is Next 15 + Prisma,
-`danileau.com` is React + TS + Tailwind) and the handoff's own suggested stack.
-
-## Getting started
-
-```bash
-cp .env.example .env          # then set BETTER_AUTH_SECRET: openssl rand -base64 32
-docker compose up -d          # postgres :5432, minio :9000, mailpit :8025
-npm install
-npm run db:migrate
-npm run db:seed               # creates the one admin from ADMIN_EMAIL/ADMIN_NAME
-npm run dev
-```
-
-`npm run db:seed` prints a one-use link for the admin to choose a username and
-a password — open it, then invite people from `/admin/invites`. In development
-every outgoing email is caught by **Mailpit at http://localhost:8025**, so
-invitation and reset links are clickable there.
-
-```bash
-npm run verify:models         # upload validator vs. hostile fixtures (no server needed)
-npm run verify:auth           # registration, sign-in and password reset, end to end
-npm run verify:upload         # upload -> board -> story, end to end
-npm run verify:queue          # the admin queue, status flow and conversation
-npm run verify:passkey        # WebAuthn ceremonies in a real browser
-npm run probe:security        # 62 OWASP-mapped security probes
-```
-
-## How authentication works
-
-**An invitation link registers you; after that you sign in with a username and
-a password.** No inbox round trip, and nothing in the running system depends on
-a mail server.
-
-Two ways in:
-
-- **Username and password** — the way in, and the one that always works. At
-  least 10 characters, capped at 128, and refused outright if the password
-  already appears in a known breach corpus.
-- **Passkey** (WebAuthn) — optional, stronger, and faster. Offered through
-  browser conditional UI, so it can sign someone in from the username field
-  with no click at all.
-
-The passkey is an accelerator, not the way in. That is the correction this
-model makes over the one before it: an emailed link was doing the job of a
-password while being harder to use and impossible to use at all when mail was
-down.
-
-### Why ten characters, and why a breach check
-
-Length is the control that does the work. Composition rules — a digit, a
-symbol, a capital — mostly move people to `Password1!`, which is in every
-corpus there is. So the rules here are: ten characters minimum, and
-[Have I Been Pwned](https://haveibeenpwned.com) says no.
-
-The breach lookup is k-anonymity: five characters of a SHA-1 prefix go to
-`api.pwnedpasswords.com`, and the password itself never leaves the machine. It
-**fails closed** — if that service cannot be reached, setting a password fails
-rather than quietly skipping the check. Only registration and reset set a
-password, so an outage cannot lock out anybody who already has one.
-
-`HIBP_DISABLED=true` turns it off, and exists for exactly one case: a
-deployment with no outbound internet at all, where failing closed would mean
-nobody could ever register.
-
-### Getting people onto passkeys
-
-The thing that decides whether people get there is not the technology, it is
-whether anyone ever asks them twice. Registration offers a passkey once; the
-first version let people tap "Skip for now" and then never mentioned it again,
-which left them typing a password every time without having chosen that.
-
-So there are three prompts, and two tests holding them in place:
-
-- A banner for anyone with zero passkeys, dismissible **for the session only** —
-  closing it means "not right now", not "never".
-- A line in the account menu saying how you currently sign in, with a way to
-  change it.
-- Honest copy on the skip: "Not now — keep typing my password", rather than
-  implying it is a postponement.
-
-All three disappear the moment a passkey exists.
-
-### Mail is optional — genuinely
-
-**Nothing in the running system needs a mail server.** People sign in with a
-password, and notifications are in-app, written by `notify()` and read by the
-Activity panel. Mail is called in exactly three places, and every one of them
-is delivering a *link*: sending an invitation, resending one, and sending a
-password reset.
-
-With `SMTP_URL` or `RESEND_API_KEY` set, those links are emailed. With neither,
-the admin gets the link on screen to hand over directly, and the app boots
-normally rather than refusing to start. Same token, same single use, same
-expiry either way.
-
-For a group that shares an office, handing a link over is arguably the safer
-channel: a token in an inbox sits there indefinitely and can be forwarded,
-where one passed over in person cannot. When mail *is* configured the raw
-token is still withheld from the admin — it exists only inside the message —
-because that property is worth keeping wherever it can be kept.
-
-### Forgotten passwords
-
-**"Forgotten password?"** sits against each member on the guest list. The admin
-presses it; a single-use, thirty-minute token is minted, emailed if there is a
-transport and shown to the admin to hand over if there is not.
-
-The link opens a set-password form. It does **not** sign anyone in — that is
-the whole difference from the sign-in link it replaces, which signed whoever
-held it in *as* that person. Here they choose a password and then have to use
-it, and setting it revokes every session the old password opened. Both halves
-are audited: `password.reset_requested` names the admin, `password.reset_completed`
-names the member.
-
-There is no self-service "forgot password" form. With no `sendResetPassword`
-configured, Better Auth's `/request-password-reset` refuses outright — resets
-are admin-minted so the flow cannot depend on a mail server that may not exist.
-
-One detail worth knowing, because it is a deliberate deviation: Better Auth
-consumes the reset token *before* it hashes the new password, so a password
-refused by the breach check would burn the link on its way out and send someone
-back to the admin over a password they were about to correct. `setPassword`
-puts the row back — with its original expiry — when the failure happened after
-consumption. The link is spent when a password is actually set, which is what
-"single use" was ever meant to mean.
-
-### Bootstrapping the admin
-
-The printer owner is the one account nobody invites, so `prisma/seed.ts` writes
-the row directly. A row cannot sign in on its own, so when the admin has no
-password the seed mints a set-password link and **prints it**:
-
-```bash
-docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
-```
-
-Open it within thirty minutes to choose a username and a password. Lost it?
-Re-run the migrator and it prints a fresh one — but only while no password has
-been set. Re-seeding never resets an existing one.
-
-There is deliberately no `ADMIN_PASSWORD`. It would sit in `.env.docker`, in
-`docker inspect`, in the shell history that wrote the file and in every backup
-of the host, still valid months later. A link that expires in half an hour is a
-smaller thing to leak.
-
-### Invite-only, enforced in one place
-
-A `User` row can only come into existence when a pending invite matches the
-address. That decision lives in a single hook, `user.validateUserInfo` in
-[`src/lib/auth.ts`](src/lib/auth.ts):
-
-```ts
-async validateUserInfo({ user, source }) {
-  if (source.action !== "create-user") return;
-  if (!(await pendingInviteFor(user.email)))
-    return { error: "invite_required", ... };
-}
-```
-
-Better Auth calls it before provisioning an identity **by any method**, from
-`internalAdapter.createUser`. Password sign-up goes through that path with
-`{ method: "email-password" }` exactly as passkey enrolment does, so adding
-passwords neither moved this rule nor added a second copy of it in a route
-handler to drift out of sync. `verify:auth` asserts it directly: registering an
-address with no pending invite is answered 403 and leaves no row.
-
-### The invitation link
-
-1. The admin submits an address at `/admin/invites`.
-2. `createInvite` mints 32 bytes of CSPRNG output, stores **only its SHA-256
-   digest**, and emails the raw token inside the link. The raw token is never
-   returned to the admin either — it exists in the email and nowhere else.
-3. The invitee opens `/invite/<token>`, sees who invited them and which
-   address the invite is bound to, and picks a display name, a **username** and
-   a **password**.
-4. Submitting calls Better Auth's sign-up, which runs the invite gate and the
-   stamping hook, creates the account and returns a session. They land on
-   `/welcome`, which offers a passkey.
-5. `databaseHooks.user.create.after` burns every open invite for that address,
-   so the link cannot mint a second account.
-
-Invites expire after 7 days, can be withdrawn, and can be re-sent — re-sending
-**rotates the token**, so a previously leaked email stops working.
-
-#### Why registering does not send a second email
-
-The invite token was delivered to that mailbox and nowhere else, so following
-the link already proves control of it. Making someone read a *second* email to
-finish registering adds a hop without adding assurance — and it would put a
-mail server back on the critical path for getting in, which is precisely what
-this model exists to remove.
-
-So registration creates the session directly. There is no in-process link to
-redeem and no `AsyncLocalStorage` machinery holding one; the previous version
-had both, and they existed only to work around the absence of a password.
-
-#### Usernames
-
-3–32 characters of letters, digits, `-` and `_`. Case is accepted but not kept:
-the value is folded to lower case on write and looked up folded, so `Ayla_B` is
-stored as `ayla_b`, signs in as either, and cannot be registered twice in
-different clothes. `displayUsername` keeps whatever was typed.
-
-Matching case-insensitively rather than refusing capitals is the friendlier
-half of that: somebody whose phone capitalises the first letter should be told
-the username is taken, not that it is malformed.
-
-### Privileged fields cannot be set over the wire
-
-`role`, `initials` and `invitedById` are declared `input: false`. Better Auth
-does not quietly strip them — it **refuses the whole request** with
-`FIELD_NOT_ALLOWED`, which is the better failure: a sign-up that half-worked
-would be harder to notice than one that did not. They are written server-side
-in `databaseHooks.user.create.before`, read out of the invite row.
-
-Fields that are not declared at all — a chosen `id`, a posted `emailVerified` —
-reach the endpoint and are simply overruled. There are tests for both halves.
-
-### Exactly one admin
-
-Application code refuses to seed a second admin, but application code is one
-bug away from being wrong, so the storage layer enforces it too:
-
-```sql
-CREATE UNIQUE INDEX "user_single_admin" ON "user" (role) WHERE role = 'admin';
-```
-
-The index covers only admin rows, so it permits any number of clients and
-exactly one admin.
-
-### Authorisation
-
-[`src/lib/authz.ts`](src/lib/authz.ts) holds the handoff's core rule as one
-exported fragment that every query composes:
-
-```ts
-export function storyScope(actor: Actor): Prisma.StoryWhereInput {
-  return actor.role === "admin" ? {} : { uploaderId: actor.id };
-}
-```
-
-`getStoryOr404` answers **404, not 403**, for a client asking after somebody
-else's story — a 403 would confirm the story exists. `requireAdmin` does the
-same for admin-only routes.
-
-`src/middleware.ts` only checks that a session cookie is *present*, to redirect
-early instead of flashing a shell. It is deliberately not the boundary: a
-forged cookie gets past it and no further. The real checks run in every page
-and every server action.
-
-### Other decisions worth knowing
-
-- **Cookies** are `HttpOnly`, `SameSite=Lax`, `__Secure-` prefixed, and keyed
-  on the *URL scheme* rather than `NODE_ENV` — a production boot over plain
-  HTTP throws unless it is loopback, and an HTTPS deployment always gets the
-  flag regardless of how the env is set.
-- **Session cookie caching is off.** It would trust a signed snapshot without
-  a database lookup, which makes sign-out lag by the cache lifetime. A DAST
-  probe caught exactly that; see [SECURITY.md](SECURITY.md).
-- **CSP carries a per-request nonce** minted in `src/middleware.ts`, so
-  `script-src` needs no `'unsafe-inline'`. Every script tag on a rendered page
-  carries it.
-- **Rate limiting** is on, in Postgres, with the password paths capped well
-  below the blanket rule: `/sign-in/username`, `/sign-up/email` and
-  `/reset-password` get 10 a minute per IP. Ten rather than three *because an
-  office sits behind one NAT address* — a tighter limit would lock out the
-  colleague at the next desk. Ten a minute still puts online guessing several
-  thousand years away from a ten-character password, which is the number that
-  matters.
-- **No user enumeration**: a wrong password and an invented username get
-  byte-identical responses, and an unknown username still pays for a password
-  hash so the wall clock does not answer either. Both are probed.
-- `SameSite=Lax`, not `Strict`, because `Strict` would drop the cookie on the
-  hop from a set-password link and the sign-in would appear to silently fail.
-- **Reset tokens are hashed at rest.** `verification.storeIdentifier: "hashed"`
-  means the table holds a digest, not a link anyone could paste into a URL.
-  `prisma/reset-token.ts` reproduces that digest for the two places that mint a
-  row directly — the admin control and the seed — and is the single definition
-  of the format, because the migrator image ships `prisma/` and nothing else.
-
-## The viewer
-
-Story detail renders the actual uploaded geometry with three.js — `STLLoader`
-for `.stl`, `ThreeMFLoader` for `.3mf` — auto-framed, drag to rotate, with an
-idle spin that stops on first touch and never starts under
-`prefers-reduced-motion`.
-
-The handoff's lighting rig is kept exactly: hemisphere, a key at (3,5,4) and a
-cool rim behind. It reads well on filament colours from near-black to bone
-white, which is the whole job. The ground and grid moved to this palette,
-because the print bed should look like the app it sits in.
-
-Three details worth knowing:
-
-- **The bytes are proxied, not signed.** `/api/models/[id]` streams from
-  object storage through the app. That is not the elegant option, it is the
-  only correct one here: the deployment publishes no port for MinIO, so a
-  signed URL would point at something the browser cannot reach. Proxying also
-  keeps `connect-src` at `'self'`, so the viewer needs no CSP relaxation —
-  verified with zero violations in a real browser.
-- **It is scoped like the story.** Same `storyScope` fragment, so a client
-  asking for someone else's model gets 404, not 403.
-- **three.js is imported dynamically**, inside the effect. It is fetched when
-  someone opens a ticket and never on the board or the queue.
-
-The trade: every viewer load moves the whole file through Next. At 50 MB and a
-handful of people that is fine. If this ever faces a wider audience, put
-storage behind the same reverse proxy, hand out a signed URL, and widen
-`connect-src` to that origin.
-
-## Uploads
-
-`POST /api/upload` is a route handler rather than a server action, so the
-browser can watch a real XHR progress bar — a 50 MB model over office wifi is
-too long for a spinner.
-
-Nothing is written to storage until the bytes have been inspected, and no
-story row exists until the object is in place: a rejected file leaves nothing
-behind, and a story never points at an object that was not stored.
-
-`src/lib/models.ts` decides what is acceptable, against the bytes rather than
-the filename:
-
-- **Binary STL is identified structurally** — 80-byte header, uint32 triangle
-  count, exactly 50 bytes per triangle. If `84 + count × 50` does not equal
-  the file length it is not a binary STL. This check runs *first*, because
-  some tools write the word `solid` into a binary STL's header and a naive
-  sniffer reads that as the ASCII format.
-- **3MF must be a zip containing a model part**, and the archive is guarded
-  against inflating to an implausible size.
-- **Extension and content must agree.** An STL renamed `.3mf` is refused even
-  though both are printable.
-- **Storage keys are generated, never derived from the filename** — that is
-  how path traversal and object overwrites happen. The display name lives in
-  a database column.
-
-Bounding boxes are measured from the actual mesh, honouring the 3MF `unit`
-attribute. Nothing is inferred beyond that — see the estimate decision above.
-
-`npm run verify:models` covers all of this with 29 checks, including a PDF and
-an ELF binary renamed `.stl`, an STL that lies about its triangle count, a
-traversal path inside a 3MF, and a zip bomb.
-
-## Decisions taken against the handoff
-
-The handoff contradicts itself in two places and leaves three things open.
-All five are settled, and recorded here so nobody has to re-derive them:
-
-| Question | Decision |
-| --- | --- |
-| Tip pill radius — README §3 says `8px`, the prototype renders `999px` | **8px.** The tokens reserve `999px` for "avatars, dots and status chips only", so two written sources beat the render. |
-| *Printing* column label — README §2 says amber `#79541a`, the prototype uses teal `#0b4340` | **Amber.** The tokens call amber "warning / in-progress only", and Printing is the in-progress state. It also makes the live column findable. |
-| Where declined stories go — `Declined` is not in the flow, so it has no column | **Off the board entirely.** The board is for work that is still moving; the profile at `/me` carries the whole history, declined included. |
-| The whole-board empty state, which the handoff says to ask about | **Minimal.** One quiet panel saying what is true, with the Upload button already above it. No invented onboarding. |
-| Print-time estimates | **Dropped.** See below. |
-
-### The one stat that changed
-
-The handoff's admin profile card is "Printer time given". There is no honest
-number behind it once print-time estimates are gone, so rather than invent
-one it counts something real — how much geometry has actually come off the
-plate, in bytes. Swap it back the day a slicer is wired in and the hours are
-known rather than assumed.
-
-### Why there is no print-time estimate
-
-A figure derived from the bounding box is a guess dressed as a measurement —
-it cannot know infill, layer height, wall count or the printer's speeds, and
-it is worst on exactly the models people care about. The handoff's definition
-of done says nothing should claim to know what the printer is doing, and a
-number someone might plan their afternoon around is the kind of claim it warns
-about.
-
-So the app shows only what it measured: **dimensions and file size**. A story
-in *Printing* says `on the bed` and nothing more.
-
-To add a real one, run `prusa-slicer --export-gcode` in a background job after
-upload and read `; estimated printing time` out of the G-code. `src/lib/models.ts`
-says so at the point where the old heuristic used to live.
-
-## What is deliberately not built
-
-- **Email/Slack notification delivery.** `Notification` rows and the `notify()`
-  helper exist and the Activity panel reads them; only the in-app record is
-  written so far.
-- **A designed whole-board empty state.** There is a minimal one that says what
-  is true rather than showing a blank page, but the handoff asks for a design
-  decision here — treat it as a placeholder.
-
-## Verifying it
-
-`npm run verify:auth` drives the real HTTP surface — including submitting the
-server-action forms the way a browser with JavaScript disabled does — and reads
-delivered mail out of Mailpit. Nothing is stubbed. It checks that:
-
-1. An uninvited address gets an identical response, a link, and **no account**.
-2. The admin can invite through the UI and the mail arrives.
-3. The invitee registers through the link, lands signed in, and the account is
-   stamped from the invite (role, initials, inviter) rather than the request.
-4. The link is single-use.
-5. A client gets 404 on the admin surface and cannot drive its actions.
-6. Posted `role`/`initials` are ignored.
-7. The database itself rejects a second admin.
-
-It is destructive — point it at a development database only.
-
-**Not covered**: the WebAuthn ceremonies themselves, which need a real
-authenticator. The endpoints are live and return correct options (right rpID,
-rpName and `userVerification`), but registering and signing in with a passkey
-has only been exercised at the protocol boundary, not with a device.
-
-## Running it in containers
-
-The dev stack (`docker-compose.yml`) runs Postgres, MinIO and Mailpit while the
-app runs on the host under `npm run dev`. That is the loop for building.
-
-`docker-compose.prod.yml` runs **everything**, including the app, and is also
-the basis for deployment:
-
-```bash
-cp .env.docker.example .env.docker      # then fill in the secrets
-docker compose --env-file .env.docker \
-  -f docker-compose.prod.yml -f docker-compose.build.yml \
-  -f docker-compose.test.yml --profile mailcatcher up -d --build
-```
-
-App on :3000, Mailpit on :8025 — every invitation and sign-in link lands there,
-so the whole flow is clickable without a mail server.
-
-Five compose files, each with one job:
-
-| File | Job |
-| --- | --- |
-| `docker-compose.yml` | dev infrastructure only — the app runs on the host under `npm run dev` |
-| `docker-compose.prod.yml` | the full stack, **consuming published images**. Publishes no host ports. |
-| `docker-compose.build.yml` | puts the build context back, for local work and CI |
-| `docker-compose.test.yml` | publishes the ports a local run and the host-side suites need |
-| `docker-compose.truenas.yml` | the proxy network, for a deployment behind Nginx Proxy Manager alone |
-| `docker-compose.cf.yml` | the same, but with Cloudflare proxying in front of NPM |
-
-`prod` consumes rather than builds on purpose: a deployment then needs no
-source tree and no toolchain, and what runs there is byte-for-byte what CI
-tested. It also publishes **no host ports at all** — each context adds only
-what it needs, so nothing is exposed by default.
-
-`--env-file` is not optional — compose reads `.env` for `${...}` interpolation,
-and `.env` here belongs to the host-side dev workflow.
-
-Three images come out of one `Dockerfile`. The **migrator** runs
-`prisma migrate deploy` and the seed, then exits; the app waits on
-`service_completed_successfully`, so a deploy can never serve against an
-unmigrated schema. The **runner** is the slim runtime — standalone Next output,
-non-root, with a healthcheck.
-
-To run the verification suites against the containerised app, add
-`-f docker-compose.test.yml`, which publishes Postgres, MinIO and Mailpit's
-SMTP port so the host-side scripts can reach them. **Never apply that overlay
-on a deployed host** — those are internal services.
-
-## Deploying to TrueNAS SCALE, behind Nginx Proxy Manager
-
-Bind mounts under a dataset rather than named volumes, following the pattern
-already used by `manyfold-truenas`, so snapshots and replication see ordinary
-files.
-
-**One-time**, so the proxy and the app can see each other:
-
-```bash
-docker network create npm-proxy
-docker network connect npm-proxy <your-nginx-proxy-manager-container>
-```
-
-**Authenticate to the registry once**, so the NAS can pull what CI publishes:
-
-```bash
-docker login ghcr.io -u <your-github-user> -p <PAT with read:packages>
-```
-
-**In `.env.docker`:**
-
-```bash
-DATA_ROOT=/mnt/tank/ppp
-APP_URL=https://print.example.org
-PASSKEY_RP_ID=print.example.org        # permanent — see below
-TRUST_PROXY_HEADERS=true
-SMTP_URL=smtp://user:pass@mail.example.org:587
-
-PPP_REGISTRY=ghcr.io/danileau
-PPP_TAG=a1b2c3d                        # a commit SHA, not `latest`
-```
-
-Pin `PPP_TAG` to a SHA rather than `latest`. It is what makes a deploy
-reproducible, and **it is also how you roll back** — set the previous SHA and
-bring the stack up again.
-
-**Bring it up** — without `--profile mailcatcher`, which exists to catch mail
-in development and has no business on a deployed host:
-
-```bash
-docker compose --env-file .env.docker \
-  -f docker-compose.prod.yml -f docker-compose.truenas.yml pull
-docker compose --env-file .env.docker \
-  -f docker-compose.prod.yml -f docker-compose.truenas.yml up -d
-```
-
-Deploying is a human action by design. Nothing in CI reaches into the NAS.
-
-### The deploy wizard
-
-`scripts/deploy-wizard.sh` is the single entry point for a deploy. Copy it next
-to `docker-compose.prod.yml` on the NAS and run it there — it needs `docker`,
-`curl` and `python3`, and deliberately not `git`, `gh` or a checkout, because
-the NAS is a consumer of images and should stay one.
-
-```bash
-./deploy-wizard.sh            # interactive
-./deploy-wizard.sh --status   # read-only: what is live, and what is newer
-```
-
-It answers what a bare `sed PPP_TAG && docker compose up -d` does not:
-
-1. **Which image?** It asks ghcr.io what is actually published, newest first,
-   with build dates and the live one marked, so you pick from a menu instead of
-   copying a SHA out of a CI log. It filters to 7-hex-char tags — the cosign
-   `.sig` and SBOM `.att` tags live in the same package and are not runnable
-   images — and sorts by `created_at`, because re-pointing `latest` touches the
-   *previous* version's `updated_at` and would otherwise reshuffle history.
-2. **Is it intact?** It `cosign verify`s both images against the identity of
-   this repo's `release-images` workflow before anything is swapped. If cosign
-   is missing it says so and asks, rather than skipping quietly.
-3. **Did it work?** It polls the public health URL after the swap and **rolls
-   back to the previous tag automatically** if health does not stabilise —
-   then tells you whether the rollback is healthy, which distinguishes "bad
-   image" from "the proxy or the database is down".
-
-The registry token is borrowed and returned: read from a hidden prompt, used
-for the pull, then `docker logout` on exit including on failure. Nothing
-long-lived is left on the NAS, which costs nothing — the images are local
-afterwards, and `restart: unless-stopped` brings them back after a reboot with
-no registry access at all.
-
-Rollback is the same menu: pick the older tag.
-
-**In Nginx Proxy Manager**, add a Proxy Host:
-
-| | |
-| --- | --- |
-| Domain Names | `print.example.org` |
-| Scheme | `http` |
-| Forward Hostname | `ppp-app` — the container name, not an IP |
-| Forward Port | `3000` |
-| Block Common Exploits | on |
-| Websockets Support | off — this app opens none |
-| SSL | request a Let's Encrypt certificate, **Force SSL** on, HTTP/2 on |
-| HSTS | off — the app sends its own |
-
-The app publishes no host port, so `ppp-app:3000` over the shared network is
-the only way in. Nothing on the LAN can reach it in cleartext and bypass TLS.
-
-### Why `TRUST_PROXY_HEADERS` is a separate switch
-
-The audit trail records the client address, and that address comes from
-`X-Forwarded-For` — a header set by whoever spoke to us last. Behind a proxy
-that is the proxy, and the value is real. Reachable directly, it is whatever
-the caller typed, and believing it would let someone put chosen strings in the
-audit log and pin their own refused attempts on another address.
-
-So it is off by default, and the trail records *no* address rather than a
-fictional one. `docker-compose.truenas.yml` turns it on, and is also the file
-that makes it true by keeping the app off every host port.
-
-**Put Cloudflare in front and it has to go off again**, which is why
-`docker-compose.cf.yml` exists as a separate overlay. Cloudflare *appends* to
-`X-Forwarded-For` instead of replacing it, and NPM appends after that, so the
-left-most entry — the one `clientIp()` reads — is whatever the client chose to
-send. `CF-Connecting-IP` is the header that cannot be spoofed there, and the
-app does not read it yet. Until it does, a Cloudflare-fronted deployment
-records no address, which is the honest answer rather than an attacker-chosen
-one. The `cf` overlay is identical to the `truenas` one except that it leaves
-the setting to `.env.docker`, where it must be `false`.
-
-### HTTPS is not optional, and here is why
-
-Two independent reasons:
-
-1. **WebAuthn requires a secure context.** Browsers refuse to create or use a
-   passkey over plain HTTP, with the single exception of `localhost`. On
-   `http://nas.local:3000`, passkeys simply do not work — everyone falls back
-   to a username and a password, which still function.
-2. **The app refuses to start.** `src/lib/auth.ts` throws in production when
-   `BETTER_AUTH_URL` is not `https://`, unless it is loopback. Session cookies
-   carry `Secure`, and a cookie the browser discards is an app nobody can sign
-   in to — failing at boot is better than failing mysteriously at sign-in.
-
-Put it behind whatever already terminates TLS for you, and make sure the proxy
-forwards the original `Host` and sets `X-Forwarded-For` — the audit trail
-records that address.
-
-### `PASSKEY_RP_ID` is permanent
-
-It is the registrable domain with no scheme and no port
-(`print.example.org`, not `https://print.example.org:443`). Passkeys are bound
-to it cryptographically. **Change it later and every passkey already
-registered stops working**, with no migration path — everyone signs in with
-their password and re-enrols. Pick the hostname you intend to keep.
-
-### First run
-
-`migrate` seeds exactly one admin from `ADMIN_EMAIL` / `ADMIN_NAME` and prints
-a one-use link for setting a username and a password:
-
-```bash
-docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
-```
-
-Open it within thirty minutes, then invite the office from `/admin/invites`.
-The seed is an upsert, so it is safe on every start and keeps the admin's name
-in step with the environment — but it will refuse to create a *second* admin,
-and so will the database, and it never resets a password that already exists.
-
-### What to back up
-
-Everything is under `DATA_ROOT`: `db/` (Postgres) and `models/` (the uploaded
-files). A ZFS snapshot of the dataset captures both. `.env.docker` holds the
-secrets and is not in the repo — keep it somewhere you will still have it after
-a rebuild, because losing `BETTER_AUTH_SECRET` invalidates every session and
-losing `DB_PASSWORD` locks you out of the database.
-
-## Continuous integration
-
-`.github/workflows/ci.yml` runs on every pull request and every push to main,
-as four gates that can be required by name in branch protection:
-
-| Gate | What it does |
-| --- | --- |
-| `guard` | typecheck, and the secret scanner over every tracked file |
-| `models` | the upload validator against hostile fixtures — no server needed |
-| `verify` | raises the real compose stack and runs all five integration suites against the built image, **including the WebAuthn ceremonies in a headless Chrome** |
-| `trivy` | filesystem scan for vulnerabilities, secrets and misconfiguration; HIGH/CRITICAL fail |
-
-`verify` uses docker compose rather than GitHub `services:` for two reasons:
-`services:` cannot override a container's command, which MinIO needs, and
-running the same command a developer runs puts **the compose files themselves
-under test**. A broken overlay fails in CI rather than on the NAS.
-
-Two more workflows:
-
-- **`release-images.yml`** — every merge to main builds `ppp-app` and
-  `ppp-migrate`, pushes them to ghcr.io tagged with the commit SHA and
-  `latest`, signs them with cosign (keyless, via GitHub OIDC), and scans the
-  *published* image. A base image can carry a CVE that no scan of this
-  checkout would ever see.
-- **`security-scan.yml`** — daily, against a fresh scanner and a fresh
-  database, over the repo *and* the published images. This closes the gap the
-  PR gate cannot: a CVE published after the last commit still lands in the
-  committed lockfile and in the base layers already running on the NAS.
-
-## Security
-
-Validated against the OWASP Top 10 (2021) with SAST (Semgrep), SCA (npm audit,
-Trivy, Syft+Grype) and DAST (OWASP ZAP plus 50 app-specific probes). Findings,
-fixes and the remaining gaps — including an honest **A09 logging gap** — are
-in [SECURITY.md](SECURITY.md).
-
-`package.json` carries `overrides` for `postcss`, `sharp` and `deepmerge-ts`.
-They are not cosmetic: they clear six high-severity advisories without a
-Next.js major bump or a Prisma downgrade. Re-check them when you next move
-framework versions, and drop any that upstream has caught up with.
-
-## Layout
-
-```
-prisma/
-  schema.prisma          auth tables (Better Auth's shapes) + domain models
-  seed.ts                bootstraps the single admin, prints its setup link
-  reset-token.ts         set-password token format, shared with the app
-src/lib/
-  auth.ts                Better Auth config — the invite gate lives here
-  auth-client.ts         browser client (username, passkey, admin)
-  auth-rules.ts          username and password rules, shared with the forms
-  password-reset.ts      minting, reading and restoring set-password links
-  authz.ts               requireUser/requireAdmin/storyScope + status flow
-  invites.ts             invite lifecycle: mint, resend, revoke, consume
-  email.ts               Resend → SMTP → console, plus templates
-  tokens.ts              CSPRNG tokens, digests, initials
-src/app/
-  signin/                passkey button over a username/password form
-  invite/[token]/        the registration page and its server action
-  set-password/          where a reset link lands; sets no session
-  welcome/               passkey enrolment after registration
-  admin/invites/         the guest list (admin only)
-  scope.ts               pure authorisation predicates (no server-only)
-  csp.ts                 Content-Security-Policy builder + nonce
-  audit.ts               the append-only trail
-  models.ts              upload validation + mesh measurement
-  storage.ts             S3/MinIO, signed URLs, generated keys
-  catalog.ts             the fixed choices a request is made from
-src/app/
-  board/                 the kanban backlog, scoped per role
-  upload/                dropzone, wish form, XHR progress
-  story/[id]/            story detail (read half)
-  api/upload/            validation, storage, story creation
-scripts/
-  deploy-wizard.sh       pick an image, verify it, deploy, auto-rollback
-  verify-models.ts       validator vs. hostile fixtures
-  verify-auth.ts         registration, sign-in and password reset
-  verify-upload.ts       upload -> board -> story
-  verify-passkey.ts      WebAuthn in a real browser
-  security-probe.ts      OWASP-mapped security probes
-src/app/admin/
-  invites/               the guest list
-  audit/                 the audit log, admin only
-```
+Built from the design handoff in `Print That for Me/`, which is why story refs
+read `PPP-104` and the copy sounds like a diner.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,306 +1,66 @@
-# Security validation
+# Security policy
 
-Scope: Pretty Please Print (formerly Print That For Me), assessed against the **OWASP Top 10 (2021)** with
-SAST, SCA and DAST. Everything below was run against the production build
-(`npm run build && npm start`) on 2026-08-23.
+## Reporting a vulnerability
 
-Covers the authentication and invitation slice and the upload → board → story
-slice. Re-run after every slice; the numbers below are current.
+Please report security issues **privately**, not as a public issue.
 
-**Re-run on 2026-08-23** after authentication changed shape: invitation links
-now *register* an account with a username and a password, and people sign in
-with those. A07 is the category that moves — see
-[A07 with passwords in the picture](#a07-with-passwords-in-the-picture) below,
-which is the honest accounting of what got better and what got worse.
+- **Preferred:** [open a private advisory](https://github.com/danileau/ppp/security/advisories/new)
+  on this repository. It is visible only to the maintainers until a fix ships.
+- **Otherwise:** email <danilo.licitra@gmail.com> with `[ppp security]` in the
+  subject.
 
-Reproduce with:
+Please include what you need to make the problem reproducible: the version or
+commit, the request or steps, and what you expected to happen instead. A proof
+of concept is welcome and never required — a clear description of the flaw is
+worth more than a working exploit.
 
-```bash
-npm audit                                  # SCA
-trivy fs --scanners vuln,secret,misconfig .
-docker run --rm -v "$PWD:/src:ro" semgrep/semgrep semgrep scan \
-  --config=p/owasp-top-ten --config=p/security-audit --config=p/nextjs /src/src
-docker run --rm --network host ghcr.io/zaproxy/zaproxy:stable \
-  zap-baseline.py -t http://localhost:3000        # DAST
-npm run probe:security                     # DAST, app-specific (62 probes)
-```
+### What to expect
 
-## Result
+This is a small project maintained by one person in their own time, so the
+honest answer is that response times are best-effort rather than contractual:
 
-| Tool | Coverage | Before | After |
-| --- | --- | --- | --- |
-| `npm audit` | dependency advisories | **6 high** | 0 |
-| Trivy | vulns, secrets, misconfig | 0 | 0 |
-| Syft + Grype | SBOM, binary contents | **92 (2 crit, 46 high)** | 0 |
-| Semgrep | 153 rules, 37 files | 1 (false positive) | 0 |
-| OWASP ZAP baseline | passive DAST | **1 medium, 3 low** | 0 fail / 63 pass |
-| `probe:security` | 62 app-specific probes | **2 real, 4 artifacts** | 62 pass |
-| `verify:models` | 29 upload-validator checks | — | 29 pass |
-| `verify:passkey` | WebAuthn in a real browser | *unverified* | 13 pass |
+| | |
+| --- | --- |
+| First reply | within 7 days |
+| Assessment, and whether a fix is planned | within 30 days |
+| Credit | offered in the advisory and the release notes, declined on request |
 
-A generic scanner cannot reason about *this* app's authority model, so the
-probe suite in [`scripts/security-probe.ts`](scripts/security-probe.ts) covers
-what ZAP structurally cannot: whether a client can call the admin API, whether
-an invite is single-use, whether a role can be set from outside, whether a
-captured cookie survives sign-out.
+You will be told either that a fix is coming, or plainly that it is not and
+why — a report that gets no answer is worse than one that gets a no.
 
-## Findings that were real
+Please give a reasonable window to ship a fix before disclosing publicly.
+There is no bug bounty; there is gratitude and an acknowledgement.
 
-### 1. Session revocation lagged sign-out — *moderate, fixed*
+## Supported versions
 
-`session.cookieCache` was enabled with a 60-second lifetime. It stores a
-signed snapshot of the session in a second cookie and trusts it **without
-touching the database**. Sign-out deleted the session row correctly — a
-captured `session_token` alone was properly rejected — but a captured
-`session_data` cookie kept authenticating until the snapshot expired.
+The `main` branch is the only supported version. Deployments pin a commit SHA
+(`PPP_TAG`), so "upgrade" means moving that pin forward — see
+[docs/deployment.md](docs/deployment.md).
 
-On a shared office machine that is precisely the case sign-out exists to
-cover. Cookie caching is now off; the cost is one indexed lookup per request,
-which for a handful of users is not a trade worth making.
+## Scope
 
-Caught by probe `A07-logout`. Worth noting *how* it was caught: an earlier
-probe run had this passing, because the same cache was serving a stale display
-name and masking a second probe too. Turning the cache off made both probes
-meaningful.
+**In scope:** this application's code, its container images, its authentication
+and authorisation model, and its default configuration.
 
-### 2. No Content-Security-Policy — *medium, fixed*
+**Out of scope:** vulnerabilities in upstream dependencies with no
+project-specific exploit path (report those upstream — Dependabot and Trivy
+already watch them here), findings that require an already-compromised host or
+database, denial of service by volume against a self-hosted instance, and
+anything that depends on a deployment ignoring the documented requirements —
+notably serving the app over plain HTTP, or setting `TRUST_PROXY_HEADERS=true`
+where the app is reachable without passing through the proxy.
 
-ZAP flagged the missing header. Adding one naively would have been decorative:
-Next.js hydrates from an inline bootstrap script, so a nonce-less policy has
-to allow `'unsafe-inline'` in `script-src`.
+## What has already been assessed
 
-Instead [`src/middleware.ts`](src/middleware.ts) mints a per-request nonce and
-Next stamps it onto its own scripts. Verified on the built output: **every
-`<script>` tag carries the nonce, zero do not, and the nonce differs per
-request.**
+The app has been through SAST, SCA and DAST against the OWASP Top 10 (2021),
+including an app-specific probe suite covering things a generic scanner cannot
+reason about — whether a client can call the admin API, whether an invitation
+is single-use, whether a role can be set from outside, whether a captured
+cookie survives sign-out.
 
-`style-src` needs no `'unsafe-inline'` either — `next/font` self-hosts its
-webfonts into `/_next/static` at build time, so the page has no inline
-`<style>` block and makes no request to `fonts.googleapis.com`. The inline
-`style=""` attributes that do exist are handled by a separate
-`style-src-attr`.
+That report, including the findings that were real and the residual risk that
+was accepted, is in **[docs/security-audit.md](docs/security-audit.md)**.
 
-```
-default-src 'self'; script-src 'self' 'nonce-<per-request>' 'strict-dynamic';
-style-src 'self'; style-src-attr 'unsafe-inline'; font-src 'self';
-img-src 'self' data: blob:; connect-src 'self'; form-action 'self';
-frame-ancestors 'none'; base-uri 'none'; object-src 'none';
-worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests
-```
-
-### 3. Missing cross-origin isolation headers — *low, fixed*
-
-COOP, COEP and CORP were absent. Now `same-origin`, `credentialless` and
-`same-origin` respectively. COEP is `credentialless` rather than
-`require-corp` deliberately — model files will be fetched from object storage
-over signed URLs, and `require-corp` would demand CORP headers on every one.
-
-### 4. Six dependency advisories — *high, fixed*
-
-`postcss` (4 advisories, incl. two path-traversal CVSS 7.5), `sharp`
-(libvips CVEs) and `deepmerge-ts` (stack exhaustion), reached through `next`
-and `prisma`.
-
-npm's suggested remedy was a Next.js major bump and a Prisma *downgrade*.
-Neither was necessary: the top-level `postcss` was already patched and only
-Next's pinned `8.4.31` was vulnerable, so `overrides` in `package.json` lift
-all three without moving frameworks. Verified afterwards that the Prisma CLI,
-the typecheck, the build and both test suites still pass.
-
-### 5. 92 CVEs inside the `esbuild` binary — *not shipped, fixed anyway*
-
-Grype found 2 critical and 46 high Go stdlib CVEs — all inside the prebuilt
-`esbuild` binary pulled in by `tsx`. Confirmed **not** in the production
-dependency tree (`npm ls esbuild --omit=dev` is empty) and not referenced in
-`.next/server`, so it was never exposed. Bumping `tsx` cleared it regardless.
-
-### 6. API routes redirected instead of answering — *low, fixed*
-
-Middleware redirected any request without a session cookie to `/signin`,
-including `POST /api/upload`. An unauthenticated API call therefore got a
-**307 to an HTML page** rather than a 401 with a JSON body — an XHR upload
-following that redirect would have reported a mystifying success instead of
-an auth failure.
-
-Middleware now redirects pages only and lets `/api/*` through, which means
-every route handler owes its own check. `currentUser()` / `requireAdmin()` is
-how, and probe `A01-anon-api` asserts that an unauthenticated upload comes
-back 401.
-
-Nothing was exposed by this — the request was still blocked — but the wrong
-answer to the wrong audience is how auth bugs hide.
-
-### 7. `*.tsbuildinfo` was not gitignored — *hygiene, fixed*
-
-A build artifact would have been committed. Found indirectly: Semgrep's only
-hit was a false positive *inside* that generated file.
-
-## Findings correctly dismissed
-
-- **Semgrep "Facebook OAuth detected"** in `tsconfig.tsbuildinfo` — a regex
-  matching hex hashes in a TypeScript build cache. This app has no OAuth.
-- **ZAP "Sensitive Information in URL"** — ZAP's own injected
-  `?email=zaproxy@example.com`. The app never puts an address in a URL.
-- **ZAP "Content-Type Header Missing"** — on 307 redirects, which have no body.
-- **My own probe's stored-XSS check** reported a false positive: it matched
-  `onerror=alert(1)` inside an already-escaped string. React escapes the name
-  to `&lt;img …` in the DOM, and Next encodes the `<` as a `\u003c` escape in
-  the RSC flight payload, so it cannot break out of the script tag. `<script>alert(2)</script>`
-  appears zero times raw. The probe now asserts escaping positively.
-
-## OWASP Top 10 (2021) verdicts
-
-| | Category | Verdict |
-| --- | --- | --- |
-| **A01** | Broken Access Control | **Pass.** Client refused on the admin page (404, not 403 — a 403 confirms existence) and on all six admin-plugin endpoints (`list-users`, `set-role`, `create-user`, `impersonate-user`, `remove-user`, `list-user-sessions`). Role unchanged after escalation attempts; no back-door account. `storyScope` hides another client's story. A forged session cookie reaches nothing. |
-| **A02** | Cryptographic Failures | **Pass.** Session cookie `HttpOnly`, `SameSite=Lax`, `Secure`, `__Secure-` prefixed. Invite tokens stored as SHA-256 only; set-password tokens hashed at rest (`verification.storeIdentifier: "hashed"`) — both verified against the live database. Passwords are stored as Better Auth's scrypt digest, asserted against the live `account` row rather than assumed. |
-| **A03** | Injection | **Pass.** SQL metacharacters in the username field handled (Prisma parameterises); no 5xx, table intact. Stored XSS via display name escaped in both DOM and flight payload. Reflected XSS via `?error=` and via the invite-token path segment both escaped. CRLF in the email field does not reach the mailer. Uploads are validated against their bytes, not their filename — a PDF, an ELF binary and an HTML page renamed `.stl` are all refused, as is an STL that lies about its triangle count. |
-| **A04** | Insecure Design | **Pass.** No public registration route: `/signup` and `/register` do not exist, and the sign-up endpoint that *does* exist — the one an invitation link posts to — answers 403 to anybody without a pending invite, leaving no row. Invite-only enforced in one hook across every auth method. Invites single-use, expiring, revocable, rotated on resend. Password guessing rate-limited and confirmed firing. |
-| **A05** | Security Misconfiguration | **Pass, after fixes 2 and 3.** Full header set; `X-Powered-By` suppressed; `.env`, `.git/config`, `package.json` and the Prisma schema all unreachable; malformed input returns no stack trace. |
-| **A06** | Vulnerable Components | **Pass, after fixes 4 and 5.** Zero across three independent scanners. |
-| **A07** | Auth Failures | **Pass, after fix 1.** Passwords: ≥10 characters, breach-checked against HIBP by k-anonymity, guessing capped at 10/min per IP. No user enumeration — a wrong password and an invented username give byte-identical responses, and an unknown username still pays for a hash so the wall clock does not answer either. Set-password links single-use, 30-minute TTL, hashed at rest, and they establish **no session**. Setting a password revokes the sessions the old one opened. Off-site and protocol-relative redirect targets refused, both via `?next=` and via the API's `callbackURL`. Sign-out kills the session server-side. See the section below. |
-| **A08** | Integrity Failures | **Pass.** `role`, `initials` and `invitedById` cannot be set from the request body: declared `input: false`, and Better Auth refuses the whole sign-up with `FIELD_NOT_ALLOWED` rather than silently trimming it. A chosen `id` and a posted `emailVerified` reach the endpoint undeclared and are overruled server-side from the invite. Both halves probed. On upload, `uploaderId` comes from the session and a posted `status` is ignored, both probed. Storage keys are generated, never derived from the filename. Lockfile committed. |
-| **A09** | Logging & Monitoring | **Pass.** An append-only `AuditEvent` table records invitations sent, resent, revoked, accepted and *rejected*; password resets requested and completed; sign-in and sign-out; story creation and refused uploads. Rows are denormalised (`actorEmail`, `subject`) so the trail still reads correctly after the user or story it refers to is deleted, and a probe asserts no token or secret reaches `detail`. |
-| **A10** | SSRF | **Pass (low exposure).** The app makes no outbound request from user input. A link-local `callbackURL` (`169.254.169.254`) is refused. |
-
-## A07 with passwords in the picture
-
-The previous version of this report leaned on a sentence that is no longer
-true: *"No passwords exist to mishandle."* That was a real property and it is
-worth being honest about giving it up, so here is what actually changed.
-
-**What got worse.** There is now a secret people choose, which means there is
-something to guess, something to reuse across sites, and something to phish.
-None of those existed before. Specifically:
-
-- **Online guessing** is a live attack surface where it was not. Mitigated by a
-  10-character floor, a breach-corpus refusal, and a 10/min per-IP cap on
-  `/sign-in/username` — probed by `A04-ratelimit`. Ten a minute against ten
-  characters is not a threat; ten a minute against `hunter2` would be, which is
-  why the breach check matters more than the rate limit does.
-- **Reuse.** A password chosen here may already be a password somewhere else.
-  The HIBP check catches the ones already published; it cannot catch a fresh
-  reuse. The passkey nudge is the real answer, and it is why enrolment is
-  pushed at three separate points.
-- **Phishing.** A password can be typed into a fake page; a magic link could
-  also be forwarded to one, so this is less of a regression than it looks, but
-  it is not nothing. Passkeys are unphishable and remain one click away.
-- **Storage.** There is now a credential at rest. scrypt, `N=16384, r=16, p=1,
-  dkLen=64`, per-password salt, stored `salt:hash` — Better Auth's default via
-  `node:crypto`. `A02-password-hash` asserts against the live row that what is
-  stored is not the password.
-
-**What got better.** Not a consolation prize — these are real:
-
-- **Recovery no longer means impersonation.** The old "Lost access?" minted a
-  link that signed its holder in *as* that person. The replacement mints a link
-  that lets them *set a password*, which they then have to use. An admin who
-  keeps the link is locking someone out, not quietly becoming them. `A07-reset-nosession`
-  asserts the link establishes no session.
-- **The mail server left the critical path.** Sign-in used to depend on message
-  delivery. A mail outage is now a nuisance for invitations, not a lockout for
-  the whole office — and a token that sits in an inbox indefinitely is a
-  standing key that no longer exists.
-- **The enumeration oracle got narrower.** The old form had to answer
-  identically whether or not an address existed *and still send mail*, which
-  made "did a message arrive" the oracle. Now a wrong password and an invented
-  username produce byte-identical responses (`A07-enum`), and the unknown
-  username still pays for a scrypt hash so the wall clock does not answer
-  either (`A07-enum-timing`).
-- **Session revocation on reset.** Setting a password kills every session the
-  old one opened (`A07-reset-revokes`). The old model had no equivalent —
-  a compromised account stayed compromised until someone deleted rows by hand.
-- **One less piece of machinery.** The `AsyncLocalStorage` trick that redeemed
-  a magic link in-process at invite acceptance is gone. It was sound but it
-  existed only to paper over the absence of a password, and code that does not
-  exist cannot be got wrong.
-
-**Net.** A07 stays a pass, on a broader base of evidence: 11 probes where there
-were 7, plus the registration, login, duplicate-username, breached-password,
-rate-limit and full reset cycle checks in `verify:auth`.
-
-### Reset tokens, and one deliberate deviation
-
-Reset tokens live in `verification` under a **digest** of their identifier
-(`verification.storeIdentifier: "hashed"`), so a database reader gets no link
-they can paste into a URL — `A02-reset-hash` checks that against the live
-table. They last 30 minutes and work once.
-
-The deviation: Better Auth consumes the token *before* it hashes the new
-password, so a password rejected by the breach check would spend the link on
-its way out. `setPassword` puts the row back — same identifier, same original
-expiry — when the failure happened after consumption. This extends nothing and
-weakens nothing: whoever is retrying already held the token. It makes the link
-spent when a password is actually set, which is what "single use" is for.
-`verify:auth` asserts both halves: a refused password leaves the link working,
-and a successful one kills it.
-
-### Residual risk accepted
-
-- **The breach check is an outbound dependency.** It fails closed, so if
-  `api.pwnedpasswords.com` is unreachable, nobody can *set* a password —
-  registration and reset stop, sign-in does not. `HIBP_DISABLED=true` exists
-  for an air-gapped deployment and is off by default. This is a deliberate
-  availability-for-integrity trade at this size; a cached local corpus would be
-  the answer if it ever bit.
-- **No second factor.** A password plus an optional passkey is the whole set.
-  TOTP would be the next thing to add if this were ever exposed beyond an
-  office, and Better Auth's `twoFactor` plugin is the path.
-- **No password-change screen for a signed-in user.** Today changing a password
-  means asking the admin for a reset link. That is a gap in convenience rather
-  than in security, and `/api/auth/change-password` is already served by the
-  catch-all if it is ever wired to a form.
-
-## Closed since the first pass
-
-- **A09** now has an audit trail (`src/lib/audit.ts`) *and* a place to read it:
-  `/admin/audit`, admin-only, with a count of refusals in the last day called
-  out at the top. A page a human glances at was chosen over threshold alerts
-  on the grounds that one printer and five colleagues do not generate enough
-  traffic to tune a threshold against — and an untuned alert is one people
-  learn to ignore. Two probes assert a client gets 404 there and that no audit
-  rows leak.
-- **The WebAuthn ceremonies are verified.** `npm run verify:passkey` drives a
-  real Chromium with a CDP virtual authenticator: it signs in with a username
-  and a password, registers a passkey, confirms the credential persists with a
-  public key and no private material, signs out, and signs back in. Conditional
-  UI signs the returning user in with no click at all, which is the intended
-  experience. Passwords and passkeys are verified working side by side, which
-  is the whole point of keeping both.
-- **Recovery stopped being impersonation.** `access.reissued` — a link that
-  signed its holder in as somebody else — is gone, replaced by
-  `password.reset_requested` / `password.reset_completed` and a link that sets
-  a password and nothing more.
-
-## Open items
-
-- **Nothing alerts automatically.** `/admin/audit` surfaces refusals but
-  someone has to look. That is a deliberate choice at this size, not an
-  oversight — revisit if the group grows or the app is ever exposed beyond
-  the office.
-- **No authenticated active scan.** ZAP ran a passive baseline against the
-  unauthenticated surface. The authenticated surface is covered by the 62
-  custom probes instead, which is better for authorisation logic and worse for
-  generic injection classes. Once the board and upload screens land, an
-  authenticated ZAP active scan is worth configuring.
-- **CSP verified against served markup, not a live browser.** Every script is
-  nonced and there are no external subresources, but a browser smoke test
-  should confirm nothing is blocked at runtime.
-- **Signed model URLs are minted but nothing serves them yet.**
-  `signedModelUrl` exists with a 10-minute expiry and the ownership check
-  gates it, but the download route lands with the 3D viewer. When it does,
-  `connect-src` has to widen to the storage origin — it is `'self'` today,
-  which will block the fetch.
-- **The upload buffers the whole file in memory** to measure its bounding
-  box. That is inherent to computing the box, and fine at 50 MB for five
-  people, but it is a denial-of-service lever if this ever faces a wider
-  audience. A streaming parse, or a size-based queue, is the answer then.
-- ~~Print-time estimates~~ — removed rather than kept. The app now shows only
-  what it measured. See the README for the reasoning and the path to a real
-  slicer-derived figure.
-- **CSRF rests on Origin checking plus `SameSite=Lax`**, which is Better
-  Auth's model and is sound for this threat profile. There are no
-  per-form tokens; if the app ever needs to accept cross-site POSTs, that
-  changes.
-- **No second factor, and no self-service password change.** Both are in
-  [Residual risk accepted](#residual-risk-accepted) above with the reasoning.
+It is worth reading before reporting: several plausible-looking behaviours are
+deliberate and documented there, and the "Residual risk accepted" section
+already names the gaps that are known.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,160 @@
+# Architecture and design decisions
+
+[← back to the README](../README.md)
+
+How the pieces work, and the places where this app deliberately departs from
+the design handoff it was built from.
+
+## The viewer
+
+Story detail renders the actual uploaded geometry with three.js — `STLLoader`
+for `.stl`, `ThreeMFLoader` for `.3mf` — auto-framed, drag to rotate, with an
+idle spin that stops on first touch and never starts under
+`prefers-reduced-motion`.
+
+The handoff's lighting rig is kept exactly: hemisphere, a key at (3,5,4) and a
+cool rim behind. It reads well on filament colours from near-black to bone
+white, which is the whole job. The ground and grid moved to this palette,
+because the print bed should look like the app it sits in.
+
+Three details worth knowing:
+
+- **The bytes are proxied, not signed.** `/api/models/[id]` streams from
+  object storage through the app. That is not the elegant option, it is the
+  only correct one here: the deployment publishes no port for MinIO, so a
+  signed URL would point at something the browser cannot reach. Proxying also
+  keeps `connect-src` at `'self'`, so the viewer needs no CSP relaxation —
+  verified with zero violations in a real browser.
+- **It is scoped like the story.** Same `storyScope` fragment, so a client
+  asking for someone else's model gets 404, not 403.
+- **three.js is imported dynamically**, inside the effect. It is fetched when
+  someone opens a ticket and never on the board or the queue.
+
+The trade: every viewer load moves the whole file through Next. At 50 MB and a
+handful of people that is fine. If this ever faces a wider audience, put
+storage behind the same reverse proxy, hand out a signed URL, and widen
+`connect-src` to that origin.
+
+## Uploads
+
+`POST /api/upload` is a route handler rather than a server action, so the
+browser can watch a real XHR progress bar — a 50 MB model over office wifi is
+too long for a spinner.
+
+Nothing is written to storage until the bytes have been inspected, and no
+story row exists until the object is in place: a rejected file leaves nothing
+behind, and a story never points at an object that was not stored.
+
+`src/lib/models.ts` decides what is acceptable, against the bytes rather than
+the filename:
+
+- **Binary STL is identified structurally** — 80-byte header, uint32 triangle
+  count, exactly 50 bytes per triangle. If `84 + count × 50` does not equal
+  the file length it is not a binary STL. This check runs *first*, because
+  some tools write the word `solid` into a binary STL's header and a naive
+  sniffer reads that as the ASCII format.
+- **3MF must be a zip containing a model part**, and the archive is guarded
+  against inflating to an implausible size.
+- **Extension and content must agree.** An STL renamed `.3mf` is refused even
+  though both are printable.
+- **Storage keys are generated, never derived from the filename** — that is
+  how path traversal and object overwrites happen. The display name lives in
+  a database column.
+
+Bounding boxes are measured from the actual mesh, honouring the 3MF `unit`
+attribute. Nothing is inferred beyond that — see the estimate decision above.
+
+`npm run verify:models` covers all of this with 29 checks, including a PDF and
+an ELF binary renamed `.stl`, an STL that lies about its triangle count, a
+traversal path inside a 3MF, and a zip bomb.
+
+## Decisions taken against the handoff
+
+The handoff contradicts itself in two places and leaves three things open.
+All five are settled, and recorded here so nobody has to re-derive them:
+
+| Question | Decision |
+| --- | --- |
+| Tip pill radius — README §3 says `8px`, the prototype renders `999px` | **8px.** The tokens reserve `999px` for "avatars, dots and status chips only", so two written sources beat the render. |
+| *Printing* column label — README §2 says amber `#79541a`, the prototype uses teal `#0b4340` | **Amber.** The tokens call amber "warning / in-progress only", and Printing is the in-progress state. It also makes the live column findable. |
+| Where declined stories go — `Declined` is not in the flow, so it has no column | **Off the board entirely.** The board is for work that is still moving; the profile at `/me` carries the whole history, declined included. |
+| The whole-board empty state, which the handoff says to ask about | **Minimal.** One quiet panel saying what is true, with the Upload button already above it. No invented onboarding. |
+| Print-time estimates | **Dropped.** See below. |
+
+### The one stat that changed
+
+The handoff's admin profile card is "Printer time given". There is no honest
+number behind it once print-time estimates are gone, so rather than invent
+one it counts something real — how much geometry has actually come off the
+plate, in bytes. Swap it back the day a slicer is wired in and the hours are
+known rather than assumed.
+
+### Why there is no print-time estimate
+
+A figure derived from the bounding box is a guess dressed as a measurement —
+it cannot know infill, layer height, wall count or the printer's speeds, and
+it is worst on exactly the models people care about. The handoff's definition
+of done says nothing should claim to know what the printer is doing, and a
+number someone might plan their afternoon around is the kind of claim it warns
+about.
+
+So the app shows only what it measured: **dimensions and file size**. A story
+in *Printing* says `on the bed` and nothing more.
+
+To add a real one, run `prusa-slicer --export-gcode` in a background job after
+upload and read `; estimated printing time` out of the G-code. `src/lib/models.ts`
+says so at the point where the old heuristic used to live.
+
+## What is deliberately not built
+
+- **Email/Slack notification delivery.** `Notification` rows and the `notify()`
+  helper exist and the Activity panel reads them; only the in-app record is
+  written so far.
+- **A designed whole-board empty state.** There is a minimal one that says what
+  is true rather than showing a blank page, but the handoff asks for a design
+  decision here — treat it as a placeholder.
+
+## Layout
+
+```
+prisma/
+  schema.prisma          auth tables (Better Auth's shapes) + domain models
+  seed.ts                bootstraps the single admin, prints its setup link
+  reset-token.ts         set-password token format, shared with the app
+src/lib/
+  auth.ts                Better Auth config — the invite gate lives here
+  auth-client.ts         browser client (username, passkey, admin)
+  auth-rules.ts          username and password rules, shared with the forms
+  password-reset.ts      minting, reading and restoring set-password links
+  authz.ts               requireUser/requireAdmin/storyScope + status flow
+  invites.ts             invite lifecycle: mint, resend, revoke, consume
+  email.ts               Resend → SMTP → console, plus templates
+  tokens.ts              CSPRNG tokens, digests, initials
+src/app/
+  signin/                passkey button over a username/password form
+  invite/[token]/        the registration page and its server action
+  set-password/          where a reset link lands; sets no session
+  welcome/               passkey enrolment after registration
+  admin/invites/         the guest list (admin only)
+  scope.ts               pure authorisation predicates (no server-only)
+  csp.ts                 Content-Security-Policy builder + nonce
+  audit.ts               the append-only trail
+  models.ts              upload validation + mesh measurement
+  storage.ts             S3/MinIO, signed URLs, generated keys
+  catalog.ts             the fixed choices a request is made from
+src/app/
+  board/                 the kanban backlog, scoped per role
+  upload/                dropzone, wish form, XHR progress
+  story/[id]/            story detail (read half)
+  api/upload/            validation, storage, story creation
+scripts/
+  deploy-wizard.sh       pick an image, verify it, deploy, auto-rollback
+  verify-models.ts       validator vs. hostile fixtures
+  verify-auth.ts         registration, sign-in and password reset
+  verify-upload.ts       upload -> board -> story
+  verify-passkey.ts      WebAuthn in a real browser
+  security-probe.ts      OWASP-mapped security probes
+src/app/admin/
+  invites/               the guest list
+  audit/                 the audit log, admin only
+```

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,254 @@
+# How authentication works
+
+[← back to the README](../README.md)
+
+**An invitation link registers you; after that you sign in with a username and
+a password.** No inbox round trip, and nothing in the running system depends on
+a mail server.
+
+Two ways in:
+
+- **Username and password** — the way in, and the one that always works. At
+  least 10 characters, capped at 128, and refused outright if the password
+  already appears in a known breach corpus.
+- **Passkey** (WebAuthn) — optional, stronger, and faster. Offered through
+  browser conditional UI, so it can sign someone in from the username field
+  with no click at all.
+
+The passkey is an accelerator, not the way in. That is the correction this
+model makes over the one before it: an emailed link was doing the job of a
+password while being harder to use and impossible to use at all when mail was
+down.
+
+### Why ten characters, and why a breach check
+
+Length is the control that does the work. Composition rules — a digit, a
+symbol, a capital — mostly move people to `Password1!`, which is in every
+corpus there is. So the rules here are: ten characters minimum, and
+[Have I Been Pwned](https://haveibeenpwned.com) says no.
+
+The breach lookup is k-anonymity: five characters of a SHA-1 prefix go to
+`api.pwnedpasswords.com`, and the password itself never leaves the machine. It
+**fails closed** — if that service cannot be reached, setting a password fails
+rather than quietly skipping the check. Only registration and reset set a
+password, so an outage cannot lock out anybody who already has one.
+
+`HIBP_DISABLED=true` turns it off, and exists for exactly one case: a
+deployment with no outbound internet at all, where failing closed would mean
+nobody could ever register.
+
+### Getting people onto passkeys
+
+The thing that decides whether people get there is not the technology, it is
+whether anyone ever asks them twice. Registration offers a passkey once; the
+first version let people tap "Skip for now" and then never mentioned it again,
+which left them typing a password every time without having chosen that.
+
+So there are three prompts, and two tests holding them in place:
+
+- A banner for anyone with zero passkeys, dismissible **for the session only** —
+  closing it means "not right now", not "never".
+- A line in the account menu saying how you currently sign in, with a way to
+  change it.
+- Honest copy on the skip: "Not now — keep typing my password", rather than
+  implying it is a postponement.
+
+All three disappear the moment a passkey exists.
+
+### Mail is optional — genuinely
+
+**Nothing in the running system needs a mail server.** People sign in with a
+password, and notifications are in-app, written by `notify()` and read by the
+Activity panel. Mail is called in exactly three places, and every one of them
+is delivering a *link*: sending an invitation, resending one, and sending a
+password reset.
+
+With `SMTP_URL` or `RESEND_API_KEY` set, those links are emailed. With neither,
+the admin gets the link on screen to hand over directly, and the app boots
+normally rather than refusing to start. Same token, same single use, same
+expiry either way.
+
+For a group that shares an office, handing a link over is arguably the safer
+channel: a token in an inbox sits there indefinitely and can be forwarded,
+where one passed over in person cannot. When mail *is* configured the raw
+token is still withheld from the admin — it exists only inside the message —
+because that property is worth keeping wherever it can be kept.
+
+### Forgotten passwords
+
+**"Forgotten password?"** sits against each member on the guest list. The admin
+presses it; a single-use, thirty-minute token is minted, emailed if there is a
+transport and shown to the admin to hand over if there is not.
+
+The link opens a set-password form. It does **not** sign anyone in — that is
+the whole difference from the sign-in link it replaces, which signed whoever
+held it in *as* that person. Here they choose a password and then have to use
+it, and setting it revokes every session the old password opened. Both halves
+are audited: `password.reset_requested` names the admin, `password.reset_completed`
+names the member.
+
+There is no self-service "forgot password" form. With no `sendResetPassword`
+configured, Better Auth's `/request-password-reset` refuses outright — resets
+are admin-minted so the flow cannot depend on a mail server that may not exist.
+
+One detail worth knowing, because it is a deliberate deviation: Better Auth
+consumes the reset token *before* it hashes the new password, so a password
+refused by the breach check would burn the link on its way out and send someone
+back to the admin over a password they were about to correct. `setPassword`
+puts the row back — with its original expiry — when the failure happened after
+consumption. The link is spent when a password is actually set, which is what
+"single use" was ever meant to mean.
+
+### Bootstrapping the admin
+
+The printer owner is the one account nobody invites, so `prisma/seed.ts` writes
+the row directly. A row cannot sign in on its own, so when the admin has no
+password the seed mints a set-password link and **prints it**:
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
+```
+
+Open it within thirty minutes to choose a username and a password. Lost it?
+Re-run the migrator and it prints a fresh one — but only while no password has
+been set. Re-seeding never resets an existing one.
+
+There is deliberately no `ADMIN_PASSWORD`. It would sit in `.env.docker`, in
+`docker inspect`, in the shell history that wrote the file and in every backup
+of the host, still valid months later. A link that expires in half an hour is a
+smaller thing to leak.
+
+### Invite-only, enforced in one place
+
+A `User` row can only come into existence when a pending invite matches the
+address. That decision lives in a single hook, `user.validateUserInfo` in
+[`src/lib/auth.ts`](../src/lib/auth.ts):
+
+```ts
+async validateUserInfo({ user, source }) {
+  if (source.action !== "create-user") return;
+  if (!(await pendingInviteFor(user.email)))
+    return { error: "invite_required", ... };
+}
+```
+
+Better Auth calls it before provisioning an identity **by any method**, from
+`internalAdapter.createUser`. Password sign-up goes through that path with
+`{ method: "email-password" }` exactly as passkey enrolment does, so adding
+passwords neither moved this rule nor added a second copy of it in a route
+handler to drift out of sync. `verify:auth` asserts it directly: registering an
+address with no pending invite is answered 403 and leaves no row.
+
+### The invitation link
+
+1. The admin submits an address at `/admin/invites`.
+2. `createInvite` mints 32 bytes of CSPRNG output, stores **only its SHA-256
+   digest**, and emails the raw token inside the link. The raw token is never
+   returned to the admin either — it exists in the email and nowhere else.
+3. The invitee opens `/invite/<token>`, sees who invited them and which
+   address the invite is bound to, and picks a display name, a **username** and
+   a **password**.
+4. Submitting calls Better Auth's sign-up, which runs the invite gate and the
+   stamping hook, creates the account and returns a session. They land on
+   `/welcome`, which offers a passkey.
+5. `databaseHooks.user.create.after` burns every open invite for that address,
+   so the link cannot mint a second account.
+
+Invites expire after 7 days, can be withdrawn, and can be re-sent — re-sending
+**rotates the token**, so a previously leaked email stops working.
+
+#### Why registering does not send a second email
+
+The invite token was delivered to that mailbox and nowhere else, so following
+the link already proves control of it. Making someone read a *second* email to
+finish registering adds a hop without adding assurance — and it would put a
+mail server back on the critical path for getting in, which is precisely what
+this model exists to remove.
+
+So registration creates the session directly. There is no in-process link to
+redeem and no `AsyncLocalStorage` machinery holding one; the previous version
+had both, and they existed only to work around the absence of a password.
+
+#### Usernames
+
+3–32 characters of letters, digits, `-` and `_`. Case is accepted but not kept:
+the value is folded to lower case on write and looked up folded, so `Ayla_B` is
+stored as `ayla_b`, signs in as either, and cannot be registered twice in
+different clothes. `displayUsername` keeps whatever was typed.
+
+Matching case-insensitively rather than refusing capitals is the friendlier
+half of that: somebody whose phone capitalises the first letter should be told
+the username is taken, not that it is malformed.
+
+### Privileged fields cannot be set over the wire
+
+`role`, `initials` and `invitedById` are declared `input: false`. Better Auth
+does not quietly strip them — it **refuses the whole request** with
+`FIELD_NOT_ALLOWED`, which is the better failure: a sign-up that half-worked
+would be harder to notice than one that did not. They are written server-side
+in `databaseHooks.user.create.before`, read out of the invite row.
+
+Fields that are not declared at all — a chosen `id`, a posted `emailVerified` —
+reach the endpoint and are simply overruled. There are tests for both halves.
+
+### Exactly one admin
+
+Application code refuses to seed a second admin, but application code is one
+bug away from being wrong, so the storage layer enforces it too:
+
+```sql
+CREATE UNIQUE INDEX "user_single_admin" ON "user" (role) WHERE role = 'admin';
+```
+
+The index covers only admin rows, so it permits any number of clients and
+exactly one admin.
+
+### Authorisation
+
+[`src/lib/authz.ts`](../src/lib/authz.ts) holds the handoff's core rule as one
+exported fragment that every query composes:
+
+```ts
+export function storyScope(actor: Actor): Prisma.StoryWhereInput {
+  return actor.role === "admin" ? {} : { uploaderId: actor.id };
+}
+```
+
+`getStoryOr404` answers **404, not 403**, for a client asking after somebody
+else's story — a 403 would confirm the story exists. `requireAdmin` does the
+same for admin-only routes.
+
+`src/middleware.ts` only checks that a session cookie is *present*, to redirect
+early instead of flashing a shell. It is deliberately not the boundary: a
+forged cookie gets past it and no further. The real checks run in every page
+and every server action.
+
+### Other decisions worth knowing
+
+- **Cookies** are `HttpOnly`, `SameSite=Lax`, `__Secure-` prefixed, and keyed
+  on the *URL scheme* rather than `NODE_ENV` — a production boot over plain
+  HTTP throws unless it is loopback, and an HTTPS deployment always gets the
+  flag regardless of how the env is set.
+- **Session cookie caching is off.** It would trust a signed snapshot without
+  a database lookup, which makes sign-out lag by the cache lifetime. A DAST
+  probe caught exactly that; see [the security audit](security-audit.md).
+- **CSP carries a per-request nonce** minted in `src/middleware.ts`, so
+  `script-src` needs no `'unsafe-inline'`. Every script tag on a rendered page
+  carries it.
+- **Rate limiting** is on, in Postgres, with the password paths capped well
+  below the blanket rule: `/sign-in/username`, `/sign-up/email` and
+  `/reset-password` get 10 a minute per IP. Ten rather than three *because an
+  office sits behind one NAT address* — a tighter limit would lock out the
+  colleague at the next desk. Ten a minute still puts online guessing several
+  thousand years away from a ten-character password, which is the number that
+  matters.
+- **No user enumeration**: a wrong password and an invented username get
+  byte-identical responses, and an unknown username still pays for a password
+  hash so the wall clock does not answer either. Both are probed.
+- `SameSite=Lax`, not `Strict`, because `Strict` would drop the cookie on the
+  hop from a set-password link and the sign-in would appear to silently fail.
+- **Reset tokens are hashed at rest.** `verification.storeIdentifier: "hashed"`
+  means the table holds a digest, not a link anyone could paste into a URL.
+  `prisma/reset-token.ts` reproduces that digest for the two places that mint a
+  row directly — the admin control and the seed — and is the single definition
+  of the format, because the migrator image ships `prisma/` and nothing else.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,220 @@
+# Running and deploying
+
+[← back to the README](../README.md)
+
+## Running it in containers
+
+The dev stack (`docker-compose.yml`) runs Postgres, MinIO and Mailpit while the
+app runs on the host under `npm run dev`. That is the loop for building.
+
+`docker-compose.prod.yml` runs **everything**, including the app, and is also
+the basis for deployment:
+
+```bash
+cp .env.docker.example .env.docker      # then fill in the secrets
+docker compose --env-file .env.docker \
+  -f docker-compose.prod.yml -f docker-compose.build.yml \
+  -f docker-compose.test.yml --profile mailcatcher up -d --build
+```
+
+App on :3000, Mailpit on :8025 — every invitation and sign-in link lands there,
+so the whole flow is clickable without a mail server.
+
+Five compose files, each with one job:
+
+| File | Job |
+| --- | --- |
+| `docker-compose.yml` | dev infrastructure only — the app runs on the host under `npm run dev` |
+| `docker-compose.prod.yml` | the full stack, **consuming published images**. Publishes no host ports. |
+| `docker-compose.build.yml` | puts the build context back, for local work and CI |
+| `docker-compose.test.yml` | publishes the ports a local run and the host-side suites need |
+| `docker-compose.truenas.yml` | the proxy network, for a deployment behind Nginx Proxy Manager alone |
+| `docker-compose.cf.yml` | the same, but with Cloudflare proxying in front of NPM |
+
+`prod` consumes rather than builds on purpose: a deployment then needs no
+source tree and no toolchain, and what runs there is byte-for-byte what CI
+tested. It also publishes **no host ports at all** — each context adds only
+what it needs, so nothing is exposed by default.
+
+`--env-file` is not optional — compose reads `.env` for `${...}` interpolation,
+and `.env` here belongs to the host-side dev workflow.
+
+Three images come out of one `Dockerfile`. The **migrator** runs
+`prisma migrate deploy` and the seed, then exits; the app waits on
+`service_completed_successfully`, so a deploy can never serve against an
+unmigrated schema. The **runner** is the slim runtime — standalone Next output,
+non-root, with a healthcheck.
+
+To run the verification suites against the containerised app, add
+`-f docker-compose.test.yml`, which publishes Postgres, MinIO and Mailpit's
+SMTP port so the host-side scripts can reach them. **Never apply that overlay
+on a deployed host** — those are internal services.
+
+## Deploying to TrueNAS SCALE, behind Nginx Proxy Manager
+
+Bind mounts under a dataset rather than named volumes, following the pattern
+already used by `manyfold-truenas`, so snapshots and replication see ordinary
+files.
+
+**One-time**, so the proxy and the app can see each other:
+
+```bash
+docker network create npm-proxy
+docker network connect npm-proxy <your-nginx-proxy-manager-container>
+```
+
+**Authenticate to the registry once**, so the NAS can pull what CI publishes:
+
+```bash
+docker login ghcr.io -u <your-github-user> -p <PAT with read:packages>
+```
+
+**In `.env.docker`:**
+
+```bash
+DATA_ROOT=/mnt/tank/ppp
+APP_URL=https://print.example.org
+PASSKEY_RP_ID=print.example.org        # permanent — see below
+TRUST_PROXY_HEADERS=true
+SMTP_URL=smtp://user:pass@mail.example.org:587
+
+PPP_REGISTRY=ghcr.io/danileau
+PPP_TAG=a1b2c3d                        # a commit SHA, not `latest`
+```
+
+Pin `PPP_TAG` to a SHA rather than `latest`. It is what makes a deploy
+reproducible, and **it is also how you roll back** — set the previous SHA and
+bring the stack up again.
+
+**Bring it up** — without `--profile mailcatcher`, which exists to catch mail
+in development and has no business on a deployed host:
+
+```bash
+docker compose --env-file .env.docker \
+  -f docker-compose.prod.yml -f docker-compose.truenas.yml pull
+docker compose --env-file .env.docker \
+  -f docker-compose.prod.yml -f docker-compose.truenas.yml up -d
+```
+
+Deploying is a human action by design. Nothing in CI reaches into the NAS.
+
+### The deploy wizard
+
+`scripts/deploy-wizard.sh` is the single entry point for a deploy. Copy it next
+to `docker-compose.prod.yml` on the NAS and run it there — it needs `docker`,
+`curl` and `python3`, and deliberately not `git`, `gh` or a checkout, because
+the NAS is a consumer of images and should stay one.
+
+```bash
+./deploy-wizard.sh            # interactive
+./deploy-wizard.sh --status   # read-only: what is live, and what is newer
+```
+
+It answers what a bare `sed PPP_TAG && docker compose up -d` does not:
+
+1. **Which image?** It asks ghcr.io what is actually published, newest first,
+   with build dates and the live one marked, so you pick from a menu instead of
+   copying a SHA out of a CI log. It filters to 7-hex-char tags — the cosign
+   `.sig` and SBOM `.att` tags live in the same package and are not runnable
+   images — and sorts by `created_at`, because re-pointing `latest` touches the
+   *previous* version's `updated_at` and would otherwise reshuffle history.
+2. **Is it intact?** It `cosign verify`s both images against the identity of
+   this repo's `release-images` workflow before anything is swapped. If cosign
+   is missing it says so and asks, rather than skipping quietly.
+3. **Did it work?** It polls the public health URL after the swap and **rolls
+   back to the previous tag automatically** if health does not stabilise —
+   then tells you whether the rollback is healthy, which distinguishes "bad
+   image" from "the proxy or the database is down".
+
+The registry token is borrowed and returned: read from a hidden prompt, used
+for the pull, then `docker logout` on exit including on failure. Nothing
+long-lived is left on the NAS, which costs nothing — the images are local
+afterwards, and `restart: unless-stopped` brings them back after a reboot with
+no registry access at all.
+
+Rollback is the same menu: pick the older tag.
+
+**In Nginx Proxy Manager**, add a Proxy Host:
+
+| | |
+| --- | --- |
+| Domain Names | `print.example.org` |
+| Scheme | `http` |
+| Forward Hostname | `ppp-app` — the container name, not an IP |
+| Forward Port | `3000` |
+| Block Common Exploits | on |
+| Websockets Support | off — this app opens none |
+| SSL | request a Let's Encrypt certificate, **Force SSL** on, HTTP/2 on |
+| HSTS | off — the app sends its own |
+
+The app publishes no host port, so `ppp-app:3000` over the shared network is
+the only way in. Nothing on the LAN can reach it in cleartext and bypass TLS.
+
+### Why `TRUST_PROXY_HEADERS` is a separate switch
+
+The audit trail records the client address, and that address comes from
+`X-Forwarded-For` — a header set by whoever spoke to us last. Behind a proxy
+that is the proxy, and the value is real. Reachable directly, it is whatever
+the caller typed, and believing it would let someone put chosen strings in the
+audit log and pin their own refused attempts on another address.
+
+So it is off by default, and the trail records *no* address rather than a
+fictional one. `docker-compose.truenas.yml` turns it on, and is also the file
+that makes it true by keeping the app off every host port.
+
+**Put Cloudflare in front and it has to go off again**, which is why
+`docker-compose.cf.yml` exists as a separate overlay. Cloudflare *appends* to
+`X-Forwarded-For` instead of replacing it, and NPM appends after that, so the
+left-most entry — the one `clientIp()` reads — is whatever the client chose to
+send. `CF-Connecting-IP` is the header that cannot be spoofed there, and the
+app does not read it yet. Until it does, a Cloudflare-fronted deployment
+records no address, which is the honest answer rather than an attacker-chosen
+one. The `cf` overlay is identical to the `truenas` one except that it leaves
+the setting to `.env.docker`, where it must be `false`.
+
+### HTTPS is not optional, and here is why
+
+Two independent reasons:
+
+1. **WebAuthn requires a secure context.** Browsers refuse to create or use a
+   passkey over plain HTTP, with the single exception of `localhost`. On
+   `http://nas.local:3000`, passkeys simply do not work — everyone falls back
+   to a username and a password, which still function.
+2. **The app refuses to start.** `src/lib/auth.ts` throws in production when
+   `BETTER_AUTH_URL` is not `https://`, unless it is loopback. Session cookies
+   carry `Secure`, and a cookie the browser discards is an app nobody can sign
+   in to — failing at boot is better than failing mysteriously at sign-in.
+
+Put it behind whatever already terminates TLS for you, and make sure the proxy
+forwards the original `Host` and sets `X-Forwarded-For` — the audit trail
+records that address.
+
+### `PASSKEY_RP_ID` is permanent
+
+It is the registrable domain with no scheme and no port
+(`print.example.org`, not `https://print.example.org:443`). Passkeys are bound
+to it cryptographically. **Change it later and every passkey already
+registered stops working**, with no migration path — everyone signs in with
+their password and re-enrols. Pick the hostname you intend to keep.
+
+### First run
+
+`migrate` seeds exactly one admin from `ADMIN_EMAIL` / `ADMIN_NAME` and prints
+a one-use link for setting a username and a password:
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
+```
+
+Open it within thirty minutes, then invite the office from `/admin/invites`.
+The seed is an upsert, so it is safe on every start and keeps the admin's name
+in step with the environment — but it will refuse to create a *second* admin,
+and so will the database, and it never resets a password that already exists.
+
+### What to back up
+
+Everything is under `DATA_ROOT`: `db/` (Postgres) and `models/` (the uploaded
+files). A ZFS snapshot of the dataset captures both. `.env.docker` holds the
+secrets and is not in the repo — keep it somewhere you will still have it after
+a rebuild, because losing `BETTER_AUTH_SECRET` invalidates every session and
+losing `DB_PASSWORD` locks you out of the database.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,92 @@
+# Development
+
+[← back to the README](../README.md)
+
+## Stack
+
+| | |
+| --- | --- |
+| Framework | Next.js 15 (App Router), React 19, TypeScript |
+| Auth | [Better Auth](https://better-auth.com) 1.7 — username/password, passkeys, breach check, admin plugin |
+| Data | Prisma 6 → PostgreSQL 17 |
+| Styling | Tailwind v4, design tokens from the handoff as CSS variables |
+| Local infra | Docker Compose: Postgres, MinIO (model files), Mailpit (mail) |
+
+Chosen to match the existing house style (`huere-siech` is Next 15 + Prisma,
+`danileau.com` is React + TS + Tailwind) and the handoff's own suggested stack.
+
+## Getting started
+
+```bash
+cp .env.example .env          # then set BETTER_AUTH_SECRET: openssl rand -base64 32
+docker compose up -d          # postgres :5432, minio :9000, mailpit :8025
+npm install
+npm run db:migrate
+npm run db:seed               # creates the one admin from ADMIN_EMAIL/ADMIN_NAME
+npm run dev
+```
+
+`npm run db:seed` prints a one-use link for the admin to choose a username and
+a password — open it, then invite people from `/admin/invites`. In development
+every outgoing email is caught by **Mailpit at http://localhost:8025**, so
+invitation and reset links are clickable there.
+
+```bash
+npm run verify:models         # upload validator vs. hostile fixtures (no server needed)
+npm run verify:auth           # registration, sign-in and password reset, end to end
+npm run verify:upload         # upload -> board -> story, end to end
+npm run verify:queue          # the admin queue, status flow and conversation
+npm run verify:passkey        # WebAuthn ceremonies in a real browser
+npm run probe:security        # 62 OWASP-mapped security probes
+```
+
+## Verifying it
+
+`npm run verify:auth` drives the real HTTP surface — including submitting the
+server-action forms the way a browser with JavaScript disabled does — and reads
+delivered mail out of Mailpit. Nothing is stubbed. It checks that:
+
+1. An uninvited address gets an identical response, a link, and **no account**.
+2. The admin can invite through the UI and the mail arrives.
+3. The invitee registers through the link, lands signed in, and the account is
+   stamped from the invite (role, initials, inviter) rather than the request.
+4. The link is single-use.
+5. A client gets 404 on the admin surface and cannot drive its actions.
+6. Posted `role`/`initials` are ignored.
+7. The database itself rejects a second admin.
+
+It is destructive — point it at a development database only.
+
+**Not covered**: the WebAuthn ceremonies themselves, which need a real
+authenticator. The endpoints are live and return correct options (right rpID,
+rpName and `userVerification`), but registering and signing in with a passkey
+has only been exercised at the protocol boundary, not with a device.
+
+## Continuous integration
+
+`.github/workflows/ci.yml` runs on every pull request and every push to main,
+as four gates that can be required by name in branch protection:
+
+| Gate | What it does |
+| --- | --- |
+| `guard` | typecheck, and the secret scanner over every tracked file |
+| `models` | the upload validator against hostile fixtures — no server needed |
+| `verify` | raises the real compose stack and runs all five integration suites against the built image, **including the WebAuthn ceremonies in a headless Chrome** |
+| `trivy` | filesystem scan for vulnerabilities, secrets and misconfiguration; HIGH/CRITICAL fail |
+
+`verify` uses docker compose rather than GitHub `services:` for two reasons:
+`services:` cannot override a container's command, which MinIO needs, and
+running the same command a developer runs puts **the compose files themselves
+under test**. A broken overlay fails in CI rather than on the NAS.
+
+Two more workflows:
+
+- **`release-images.yml`** — every merge to main builds `ppp-app` and
+  `ppp-migrate`, pushes them to ghcr.io tagged with the commit SHA and
+  `latest`, signs them with cosign (keyless, via GitHub OIDC), and scans the
+  *published* image. A base image can carry a CVE that no scan of this
+  checkout would ever see.
+- **`security-scan.yml`** — daily, against a fresh scanner and a fresh
+  database, over the repo *and* the published images. This closes the gap the
+  PR gate cannot: a CVE published after the last commit still lands in the
+  committed lockfile and in the base layers already running on the NAS.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,306 @@
+# Security validation
+
+Scope: Pretty Please Print (formerly Print That For Me), assessed against the **OWASP Top 10 (2021)** with
+SAST, SCA and DAST. Everything below was run against the production build
+(`npm run build && npm start`) on 2026-08-23.
+
+Covers the authentication and invitation slice and the upload → board → story
+slice. Re-run after every slice; the numbers below are current.
+
+**Re-run on 2026-08-23** after authentication changed shape: invitation links
+now *register* an account with a username and a password, and people sign in
+with those. A07 is the category that moves — see
+[A07 with passwords in the picture](#a07-with-passwords-in-the-picture) below,
+which is the honest accounting of what got better and what got worse.
+
+Reproduce with:
+
+```bash
+npm audit                                  # SCA
+trivy fs --scanners vuln,secret,misconfig .
+docker run --rm -v "$PWD:/src:ro" semgrep/semgrep semgrep scan \
+  --config=p/owasp-top-ten --config=p/security-audit --config=p/nextjs /src/src
+docker run --rm --network host ghcr.io/zaproxy/zaproxy:stable \
+  zap-baseline.py -t http://localhost:3000        # DAST
+npm run probe:security                     # DAST, app-specific (62 probes)
+```
+
+## Result
+
+| Tool | Coverage | Before | After |
+| --- | --- | --- | --- |
+| `npm audit` | dependency advisories | **6 high** | 0 |
+| Trivy | vulns, secrets, misconfig | 0 | 0 |
+| Syft + Grype | SBOM, binary contents | **92 (2 crit, 46 high)** | 0 |
+| Semgrep | 153 rules, 37 files | 1 (false positive) | 0 |
+| OWASP ZAP baseline | passive DAST | **1 medium, 3 low** | 0 fail / 63 pass |
+| `probe:security` | 62 app-specific probes | **2 real, 4 artifacts** | 62 pass |
+| `verify:models` | 29 upload-validator checks | — | 29 pass |
+| `verify:passkey` | WebAuthn in a real browser | *unverified* | 13 pass |
+
+A generic scanner cannot reason about *this* app's authority model, so the
+probe suite in [`scripts/security-probe.ts`](../scripts/security-probe.ts) covers
+what ZAP structurally cannot: whether a client can call the admin API, whether
+an invite is single-use, whether a role can be set from outside, whether a
+captured cookie survives sign-out.
+
+## Findings that were real
+
+### 1. Session revocation lagged sign-out — *moderate, fixed*
+
+`session.cookieCache` was enabled with a 60-second lifetime. It stores a
+signed snapshot of the session in a second cookie and trusts it **without
+touching the database**. Sign-out deleted the session row correctly — a
+captured `session_token` alone was properly rejected — but a captured
+`session_data` cookie kept authenticating until the snapshot expired.
+
+On a shared office machine that is precisely the case sign-out exists to
+cover. Cookie caching is now off; the cost is one indexed lookup per request,
+which for a handful of users is not a trade worth making.
+
+Caught by probe `A07-logout`. Worth noting *how* it was caught: an earlier
+probe run had this passing, because the same cache was serving a stale display
+name and masking a second probe too. Turning the cache off made both probes
+meaningful.
+
+### 2. No Content-Security-Policy — *medium, fixed*
+
+ZAP flagged the missing header. Adding one naively would have been decorative:
+Next.js hydrates from an inline bootstrap script, so a nonce-less policy has
+to allow `'unsafe-inline'` in `script-src`.
+
+Instead [`src/middleware.ts`](../src/middleware.ts) mints a per-request nonce and
+Next stamps it onto its own scripts. Verified on the built output: **every
+`<script>` tag carries the nonce, zero do not, and the nonce differs per
+request.**
+
+`style-src` needs no `'unsafe-inline'` either — `next/font` self-hosts its
+webfonts into `/_next/static` at build time, so the page has no inline
+`<style>` block and makes no request to `fonts.googleapis.com`. The inline
+`style=""` attributes that do exist are handled by a separate
+`style-src-attr`.
+
+```
+default-src 'self'; script-src 'self' 'nonce-<per-request>' 'strict-dynamic';
+style-src 'self'; style-src-attr 'unsafe-inline'; font-src 'self';
+img-src 'self' data: blob:; connect-src 'self'; form-action 'self';
+frame-ancestors 'none'; base-uri 'none'; object-src 'none';
+worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests
+```
+
+### 3. Missing cross-origin isolation headers — *low, fixed*
+
+COOP, COEP and CORP were absent. Now `same-origin`, `credentialless` and
+`same-origin` respectively. COEP is `credentialless` rather than
+`require-corp` deliberately — model files will be fetched from object storage
+over signed URLs, and `require-corp` would demand CORP headers on every one.
+
+### 4. Six dependency advisories — *high, fixed*
+
+`postcss` (4 advisories, incl. two path-traversal CVSS 7.5), `sharp`
+(libvips CVEs) and `deepmerge-ts` (stack exhaustion), reached through `next`
+and `prisma`.
+
+npm's suggested remedy was a Next.js major bump and a Prisma *downgrade*.
+Neither was necessary: the top-level `postcss` was already patched and only
+Next's pinned `8.4.31` was vulnerable, so `overrides` in `package.json` lift
+all three without moving frameworks. Verified afterwards that the Prisma CLI,
+the typecheck, the build and both test suites still pass.
+
+### 5. 92 CVEs inside the `esbuild` binary — *not shipped, fixed anyway*
+
+Grype found 2 critical and 46 high Go stdlib CVEs — all inside the prebuilt
+`esbuild` binary pulled in by `tsx`. Confirmed **not** in the production
+dependency tree (`npm ls esbuild --omit=dev` is empty) and not referenced in
+`.next/server`, so it was never exposed. Bumping `tsx` cleared it regardless.
+
+### 6. API routes redirected instead of answering — *low, fixed*
+
+Middleware redirected any request without a session cookie to `/signin`,
+including `POST /api/upload`. An unauthenticated API call therefore got a
+**307 to an HTML page** rather than a 401 with a JSON body — an XHR upload
+following that redirect would have reported a mystifying success instead of
+an auth failure.
+
+Middleware now redirects pages only and lets `/api/*` through, which means
+every route handler owes its own check. `currentUser()` / `requireAdmin()` is
+how, and probe `A01-anon-api` asserts that an unauthenticated upload comes
+back 401.
+
+Nothing was exposed by this — the request was still blocked — but the wrong
+answer to the wrong audience is how auth bugs hide.
+
+### 7. `*.tsbuildinfo` was not gitignored — *hygiene, fixed*
+
+A build artifact would have been committed. Found indirectly: Semgrep's only
+hit was a false positive *inside* that generated file.
+
+## Findings correctly dismissed
+
+- **Semgrep "Facebook OAuth detected"** in `tsconfig.tsbuildinfo` — a regex
+  matching hex hashes in a TypeScript build cache. This app has no OAuth.
+- **ZAP "Sensitive Information in URL"** — ZAP's own injected
+  `?email=zaproxy@example.com`. The app never puts an address in a URL.
+- **ZAP "Content-Type Header Missing"** — on 307 redirects, which have no body.
+- **My own probe's stored-XSS check** reported a false positive: it matched
+  `onerror=alert(1)` inside an already-escaped string. React escapes the name
+  to `&lt;img …` in the DOM, and Next encodes the `<` as a `\u003c` escape in
+  the RSC flight payload, so it cannot break out of the script tag. `<script>alert(2)</script>`
+  appears zero times raw. The probe now asserts escaping positively.
+
+## OWASP Top 10 (2021) verdicts
+
+| | Category | Verdict |
+| --- | --- | --- |
+| **A01** | Broken Access Control | **Pass.** Client refused on the admin page (404, not 403 — a 403 confirms existence) and on all six admin-plugin endpoints (`list-users`, `set-role`, `create-user`, `impersonate-user`, `remove-user`, `list-user-sessions`). Role unchanged after escalation attempts; no back-door account. `storyScope` hides another client's story. A forged session cookie reaches nothing. |
+| **A02** | Cryptographic Failures | **Pass.** Session cookie `HttpOnly`, `SameSite=Lax`, `Secure`, `__Secure-` prefixed. Invite tokens stored as SHA-256 only; set-password tokens hashed at rest (`verification.storeIdentifier: "hashed"`) — both verified against the live database. Passwords are stored as Better Auth's scrypt digest, asserted against the live `account` row rather than assumed. |
+| **A03** | Injection | **Pass.** SQL metacharacters in the username field handled (Prisma parameterises); no 5xx, table intact. Stored XSS via display name escaped in both DOM and flight payload. Reflected XSS via `?error=` and via the invite-token path segment both escaped. CRLF in the email field does not reach the mailer. Uploads are validated against their bytes, not their filename — a PDF, an ELF binary and an HTML page renamed `.stl` are all refused, as is an STL that lies about its triangle count. |
+| **A04** | Insecure Design | **Pass.** No public registration route: `/signup` and `/register` do not exist, and the sign-up endpoint that *does* exist — the one an invitation link posts to — answers 403 to anybody without a pending invite, leaving no row. Invite-only enforced in one hook across every auth method. Invites single-use, expiring, revocable, rotated on resend. Password guessing rate-limited and confirmed firing. |
+| **A05** | Security Misconfiguration | **Pass, after fixes 2 and 3.** Full header set; `X-Powered-By` suppressed; `.env`, `.git/config`, `package.json` and the Prisma schema all unreachable; malformed input returns no stack trace. |
+| **A06** | Vulnerable Components | **Pass, after fixes 4 and 5.** Zero across three independent scanners. |
+| **A07** | Auth Failures | **Pass, after fix 1.** Passwords: ≥10 characters, breach-checked against HIBP by k-anonymity, guessing capped at 10/min per IP. No user enumeration — a wrong password and an invented username give byte-identical responses, and an unknown username still pays for a hash so the wall clock does not answer either. Set-password links single-use, 30-minute TTL, hashed at rest, and they establish **no session**. Setting a password revokes the sessions the old one opened. Off-site and protocol-relative redirect targets refused, both via `?next=` and via the API's `callbackURL`. Sign-out kills the session server-side. See the section below. |
+| **A08** | Integrity Failures | **Pass.** `role`, `initials` and `invitedById` cannot be set from the request body: declared `input: false`, and Better Auth refuses the whole sign-up with `FIELD_NOT_ALLOWED` rather than silently trimming it. A chosen `id` and a posted `emailVerified` reach the endpoint undeclared and are overruled server-side from the invite. Both halves probed. On upload, `uploaderId` comes from the session and a posted `status` is ignored, both probed. Storage keys are generated, never derived from the filename. Lockfile committed. |
+| **A09** | Logging & Monitoring | **Pass.** An append-only `AuditEvent` table records invitations sent, resent, revoked, accepted and *rejected*; password resets requested and completed; sign-in and sign-out; story creation and refused uploads. Rows are denormalised (`actorEmail`, `subject`) so the trail still reads correctly after the user or story it refers to is deleted, and a probe asserts no token or secret reaches `detail`. |
+| **A10** | SSRF | **Pass (low exposure).** The app makes no outbound request from user input. A link-local `callbackURL` (`169.254.169.254`) is refused. |
+
+## A07 with passwords in the picture
+
+The previous version of this report leaned on a sentence that is no longer
+true: *"No passwords exist to mishandle."* That was a real property and it is
+worth being honest about giving it up, so here is what actually changed.
+
+**What got worse.** There is now a secret people choose, which means there is
+something to guess, something to reuse across sites, and something to phish.
+None of those existed before. Specifically:
+
+- **Online guessing** is a live attack surface where it was not. Mitigated by a
+  10-character floor, a breach-corpus refusal, and a 10/min per-IP cap on
+  `/sign-in/username` — probed by `A04-ratelimit`. Ten a minute against ten
+  characters is not a threat; ten a minute against `hunter2` would be, which is
+  why the breach check matters more than the rate limit does.
+- **Reuse.** A password chosen here may already be a password somewhere else.
+  The HIBP check catches the ones already published; it cannot catch a fresh
+  reuse. The passkey nudge is the real answer, and it is why enrolment is
+  pushed at three separate points.
+- **Phishing.** A password can be typed into a fake page; a magic link could
+  also be forwarded to one, so this is less of a regression than it looks, but
+  it is not nothing. Passkeys are unphishable and remain one click away.
+- **Storage.** There is now a credential at rest. scrypt, `N=16384, r=16, p=1,
+  dkLen=64`, per-password salt, stored `salt:hash` — Better Auth's default via
+  `node:crypto`. `A02-password-hash` asserts against the live row that what is
+  stored is not the password.
+
+**What got better.** Not a consolation prize — these are real:
+
+- **Recovery no longer means impersonation.** The old "Lost access?" minted a
+  link that signed its holder in *as* that person. The replacement mints a link
+  that lets them *set a password*, which they then have to use. An admin who
+  keeps the link is locking someone out, not quietly becoming them. `A07-reset-nosession`
+  asserts the link establishes no session.
+- **The mail server left the critical path.** Sign-in used to depend on message
+  delivery. A mail outage is now a nuisance for invitations, not a lockout for
+  the whole office — and a token that sits in an inbox indefinitely is a
+  standing key that no longer exists.
+- **The enumeration oracle got narrower.** The old form had to answer
+  identically whether or not an address existed *and still send mail*, which
+  made "did a message arrive" the oracle. Now a wrong password and an invented
+  username produce byte-identical responses (`A07-enum`), and the unknown
+  username still pays for a scrypt hash so the wall clock does not answer
+  either (`A07-enum-timing`).
+- **Session revocation on reset.** Setting a password kills every session the
+  old one opened (`A07-reset-revokes`). The old model had no equivalent —
+  a compromised account stayed compromised until someone deleted rows by hand.
+- **One less piece of machinery.** The `AsyncLocalStorage` trick that redeemed
+  a magic link in-process at invite acceptance is gone. It was sound but it
+  existed only to paper over the absence of a password, and code that does not
+  exist cannot be got wrong.
+
+**Net.** A07 stays a pass, on a broader base of evidence: 11 probes where there
+were 7, plus the registration, login, duplicate-username, breached-password,
+rate-limit and full reset cycle checks in `verify:auth`.
+
+### Reset tokens, and one deliberate deviation
+
+Reset tokens live in `verification` under a **digest** of their identifier
+(`verification.storeIdentifier: "hashed"`), so a database reader gets no link
+they can paste into a URL — `A02-reset-hash` checks that against the live
+table. They last 30 minutes and work once.
+
+The deviation: Better Auth consumes the token *before* it hashes the new
+password, so a password rejected by the breach check would spend the link on
+its way out. `setPassword` puts the row back — same identifier, same original
+expiry — when the failure happened after consumption. This extends nothing and
+weakens nothing: whoever is retrying already held the token. It makes the link
+spent when a password is actually set, which is what "single use" is for.
+`verify:auth` asserts both halves: a refused password leaves the link working,
+and a successful one kills it.
+
+### Residual risk accepted
+
+- **The breach check is an outbound dependency.** It fails closed, so if
+  `api.pwnedpasswords.com` is unreachable, nobody can *set* a password —
+  registration and reset stop, sign-in does not. `HIBP_DISABLED=true` exists
+  for an air-gapped deployment and is off by default. This is a deliberate
+  availability-for-integrity trade at this size; a cached local corpus would be
+  the answer if it ever bit.
+- **No second factor.** A password plus an optional passkey is the whole set.
+  TOTP would be the next thing to add if this were ever exposed beyond an
+  office, and Better Auth's `twoFactor` plugin is the path.
+- **No password-change screen for a signed-in user.** Today changing a password
+  means asking the admin for a reset link. That is a gap in convenience rather
+  than in security, and `/api/auth/change-password` is already served by the
+  catch-all if it is ever wired to a form.
+
+## Closed since the first pass
+
+- **A09** now has an audit trail (`src/lib/audit.ts`) *and* a place to read it:
+  `/admin/audit`, admin-only, with a count of refusals in the last day called
+  out at the top. A page a human glances at was chosen over threshold alerts
+  on the grounds that one printer and five colleagues do not generate enough
+  traffic to tune a threshold against — and an untuned alert is one people
+  learn to ignore. Two probes assert a client gets 404 there and that no audit
+  rows leak.
+- **The WebAuthn ceremonies are verified.** `npm run verify:passkey` drives a
+  real Chromium with a CDP virtual authenticator: it signs in with a username
+  and a password, registers a passkey, confirms the credential persists with a
+  public key and no private material, signs out, and signs back in. Conditional
+  UI signs the returning user in with no click at all, which is the intended
+  experience. Passwords and passkeys are verified working side by side, which
+  is the whole point of keeping both.
+- **Recovery stopped being impersonation.** `access.reissued` — a link that
+  signed its holder in as somebody else — is gone, replaced by
+  `password.reset_requested` / `password.reset_completed` and a link that sets
+  a password and nothing more.
+
+## Open items
+
+- **Nothing alerts automatically.** `/admin/audit` surfaces refusals but
+  someone has to look. That is a deliberate choice at this size, not an
+  oversight — revisit if the group grows or the app is ever exposed beyond
+  the office.
+- **No authenticated active scan.** ZAP ran a passive baseline against the
+  unauthenticated surface. The authenticated surface is covered by the 62
+  custom probes instead, which is better for authorisation logic and worse for
+  generic injection classes. Once the board and upload screens land, an
+  authenticated ZAP active scan is worth configuring.
+- **CSP verified against served markup, not a live browser.** Every script is
+  nonced and there are no external subresources, but a browser smoke test
+  should confirm nothing is blocked at runtime.
+- **Signed model URLs are minted but nothing serves them yet.**
+  `signedModelUrl` exists with a 10-minute expiry and the ownership check
+  gates it, but the download route lands with the 3D viewer. When it does,
+  `connect-src` has to widen to the storage origin — it is `'self'` today,
+  which will block the fetch.
+- **The upload buffers the whole file in memory** to measure its bounding
+  box. That is inherent to computing the box, and fine at 50 MB for five
+  people, but it is a denial-of-service lever if this ever faces a wider
+  audience. A streaming parse, or a size-based queue, is the answer then.
+- ~~Print-time estimates~~ — removed rather than kept. The app now shows only
+  what it measured. See the README for the reasoning and the path to a real
+  slicer-derived figure.
+- **CSRF rests on Origin checking plus `SameSite=Lax`**, which is Better
+  Auth's model and is sound for this threat profile. There are no
+  per-form tokens; if the app ever needs to accept cross-site POSTs, that
+  changes.
+- **No second factor, and no self-service password change.** Both are in
+  [Residual risk accepted](#residual-risk-accepted) above with the reasoning.


### PR DESCRIPTION
Two documentation problems that only start to matter once strangers arrive.

## `SECURITY.md` was the wrong document for its filename

GitHub renders `SECURITY.md` as the vulnerability-reporting policy. Someone who found a bug clicked "Security policy" and got a 300-line OWASP audit **with no reporting address anywhere in it**.

Split:

- **`SECURITY.md`** is now a disclosure policy — where to report (private advisory, or email), what to include, what response to expect and by when, what is in and out of scope. It is honest that this is one person in their spare time: best-effort, 7 days to first reply, and a plain no rather than silence when a fix isn't coming.
- **`docs/security-audit.md`** holds the assessment, linked from the policy. The audit is good work and stays — it was just filed under a name promising something else.

## The README opened like an internal build log

750 lines, engineering narrative first, and a `Not built:` line naming four things — the admin queue, the conversation thread, the 3D viewer and the profile screen — **that had all shipped**. Someone deciding whether to self-host met the `AsyncLocalStorage` reasoning before they met a description of what the app does.

Now 290 lines, answering a self-hoster's questions in the order they ask them:

| section | new? |
| --- | --- |
| What it does, requirements | rewritten |
| Quick start | condensed to one copy-pasteable path |
| **Configuration reference** | **new** — every env var, what it does, whether it's required |
| Deploying | summary + link |
| **Backup and *restore*** | **new** — restore is the half that mattered and was missing |
| **Troubleshooting** | **new** — this week's deployment, written down |
| Documentation index, Security, Contributing, Licence | new |

The troubleshooting section is everything the first real deployment cost: the 502 from a proxy container losing its Docker network attachment, `read:packages` versus `repo` token scopes, ACME dying against a DNS record still pointing at a web host, why audit rows have no IP behind Cloudflare, and the expiring bootstrap link.

The restore procedure documents the two things that bite: **`DB_PASSWORD` must be the one the restored data was created with** (Postgres stores it inside the data directory, so a mismatch looks like a config typo), and `BETTER_AUTH_SECRET` is unrecoverable but only costs everyone a fresh sign-in.

## The narrative is moved, not deleted

`docs/authentication.md`, `docs/architecture.md`, `docs/deployment.md`, `docs/development.md` — each linked from a table in the README. It is the best writing in the repo; it just wasn't the front door.

## Verification

Typecheck and secret scan clean, `verify:models` green. Every internal markdown link and heading anchor checked with a script using **GitHub's own slug rules** — which caught five relative links genuinely broken by the move into `docs/`, and taught me my first two "failures" were my slugifier eating underscores and collapsing the double hyphen an em dash produces.

## Still open, deliberately

Items 3–6 from the plan: committing screenshots (`shots/` is still gitignored), `CONTRIBUTING.md` and issue templates, a `v0.1.0` tag, repo topics, and a traffic-snapshot workflow if clone/view history should outlive GitHub's 14-day window.