### PR TITLE
Revoke access, offer the source, and fix a favicon nobody could see

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -69,6 +69,14 @@ TRUST_PROXY_HEADERS=false
 # no outbound internet at all — otherwise nobody would be able to register.
 HIBP_DISABLED=false
 
+# --- AGPL source offer ---
+# The app shows a "Source · AGPL-3.0" link in its footer. If you MODIFY the
+# code and serve it to anyone over a network, section 13 of the licence obliges
+# you to offer them your source — so point this at your own repository. Leaving
+# it on the upstream default while running modified code looks like compliance
+# and is not.
+# SOURCE_URL="https://github.com/you/ppp"
+
 # --- storage ---
 S3_BUCKET="ppp-models"
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ that: there is no multi-tenancy, no billing, and no queue theory.
   Delivery, one step at a time, forwards only. Or Declined, with a reason.
 - **Talk on the ticket** — a conversation thread per request, so "can you do it
   in teal" lives with the model rather than in a chat app.
+- **Revoke access when someone leaves** — suspends the account, signs them out
+  everywhere and refuses new sign-ins, while keeping their tickets, comments
+  and history. Reversible, and audited.
 - **See the actual geometry** — the uploaded mesh rendered in the browser,
   auto-framed, drag to rotate.
 - **An audit trail** of everything that changes who can get in or what happens
@@ -108,6 +111,7 @@ with commentary is [`.env.docker.example`](.env.docker.example).
 | `MAIL_FROM` | | Envelope sender. |
 | `TRUST_PROXY_HEADERS` | | `true` only when the app is unreachable except through your proxy. See [the reasoning](docs/deployment.md#why-trust_proxy_headers-is-a-separate-switch). |
 | `HIBP_DISABLED` | | `true` disables the breach check. Only for a host with no outbound internet — it fails closed, so without it nobody could register. |
+| `SOURCE_URL` | | Where this instance's source lives, shown in the footer. **Change it if you modify the code** — see [Licence](#licence). Defaults to the upstream repository. |
 | `PPP_REGISTRY` / `PPP_TAG` | | Which published image to run. Pin `PPP_TAG` to a commit SHA; that is also how you roll back. |
 
 ## Deploying
@@ -285,6 +289,11 @@ See [docs/development.md](docs/development.md) to get set up.
 
 [AGPL-3.0-or-later](LICENSE). Self-host it, fork it, change it, run it for your
 office — all of that is yes, and free.
+
+The app carries a **Source · AGPL-3.0** link in its footer. That is section 13
+made real: if you modify the code, point `SOURCE_URL` at your own repository.
+Leaving it aimed at upstream is worse than removing it, because it looks like
+compliance while offering source that is not what is running.
 
 The one condition is the point of the licence: **if you modify it and let people
 use your version over a network, you have to offer them your source.** Not a

--- a/scripts/verify-queue.ts
+++ b/scripts/verify-queue.ts
@@ -398,6 +398,96 @@ async function main() {
         "a client triggered a password reset");
 
   // ------------------------------------------------------------------
+  section("revoking a member's access");
+
+  const goner = await db.user.create({
+    data: { email: "goner@office.example", name: "Gwen Oner", initials: "GW",
+            role: "client", emailVerified: true, invitedById: admin.id },
+  });
+  const gonerB = await signIn(goner);
+  check("the member can reach the app",
+        rendered(await (await gonerB.go(`${APP}/board`)).text()).includes("backlog"));
+  check("and holds a live session",
+        (await db.session.count({ where: { userId: goner.id } })) > 0);
+
+  let guests = await (await ruben.go(`${APP}/admin/invites`)).text();
+  check("the guest list offers a revoke control", guests.includes("Revoke access?"));
+
+  const revokeIdx = formIndexContaining(guests, 'name="revoke"');
+  const revoked = await ruben.submit(`${APP}/admin/invites`, guests, revokeIdx, {
+    userId: goner.id, revoke: "true",
+  });
+  check("revoking is accepted", revoked.status < 400, `status ${revoked.status}`);
+  check("the account is suspended",
+        (await db.user.findUnique({ where: { id: goner.id } }))?.banned === true);
+  // The admin plugin refuses to CREATE a session for a suspended account but
+  // does nothing about one already held — so the sessions have to go too, or
+  // the control only closes the door they are already through.
+  check("their live sessions are revoked with it",
+        (await db.session.count({ where: { userId: goner.id } })) === 0);
+  check("the session they were holding stops working",
+        !rendered(await (await gonerB.go(`${APP}/board`)).text()).includes("backlog"));
+
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  const lockedOut = await signInWithPassword(new Browser(), APP, usernameFor(goner.email));
+  check("and they cannot sign back in", lockedOut.status >= 400, `status ${lockedOut.status}`);
+  check("revocation is audited",
+        (await db.auditEvent.count({
+          where: { action: "access.revoked", subject: goner.email } })) === 1);
+
+  // The printer owner is the only way into the admin surface; suspending them
+  // would lock the app with no way back.
+  guests = await (await ruben.go(`${APP}/admin/invites`)).text();
+  check("the admin session is still live (or the guard below proves nothing)",
+        guests.includes("The guest list"));
+  await ruben.submit(`${APP}/admin/invites`, guests,
+    formIndexContaining(guests, 'name="revoke"'), { userId: admin.id, revoke: "true" });
+  check("the printer owner cannot be suspended",
+        (await db.user.findUnique({ where: { id: admin.id } }))?.banned !== true);
+
+  const clientRevoke = new FormData();
+  clientRevoke.set("userId", admin.id);
+  clientRevoke.set("revoke", "true");
+  await client.raw(`${APP}/admin/invites`, { method: "POST", body: clientRevoke });
+  check("a client cannot revoke anybody",
+        (await db.auditEvent.count({ where: { action: "access.revoked" } })) === 1);
+
+  guests = await (await ruben.go(`${APP}/admin/invites`)).text();
+  check("a suspended member reads as suspended", guests.includes("Suspended"));
+  await ruben.submit(`${APP}/admin/invites`, guests,
+    formIndexContaining(guests, 'name="revoke"'), { userId: goner.id, revoke: "false" });
+  check("restoring clears the suspension",
+        (await db.user.findUnique({ where: { id: goner.id } }))?.banned === false);
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  check("and they sign in again with the password they already had",
+        (await signInWithPassword(new Browser(), APP, usernameFor(goner.email))).status === 200);
+  check("the restore is audited",
+        (await db.auditEvent.count({
+          where: { action: "access.restored", subject: goner.email } })) === 1);
+
+  // ------------------------------------------------------------------
+  section("the AGPL source offer, and the brand mark");
+
+  const anonPage = await (await new Browser().go(`${APP}/signin`)).text();
+  check("the source offer reaches signed-out visitors",
+        anonPage.includes("Source · AGPL-3.0"),
+        "AGPL section 13 wants it in front of anyone using the app over a network");
+  check("and signed-in ones",
+        (await (await ruben.go(`${APP}/board`)).text()).includes("Source · AGPL-3.0"));
+
+  const iconRes = await new Browser().raw(`${APP}/icon.svg`);
+  check("the favicon is served, not redirected to sign-in",
+        iconRes.status === 200 &&
+        (iconRes.headers.get("content-type") ?? "").includes("svg"),
+        `status ${iconRes.status} type ${iconRes.headers.get("content-type")}`);
+  const iconSvg = await iconRes.text();
+  const fills = [...iconSvg.matchAll(/fill="([^"]+)"/g)].map((m) => m[1]);
+  check("and paints the cherry mark, not the old teal disc",
+        fills.includes("#e4322f") && !fills.includes("#12645f"), fills.join(","));
+
+  await db.user.deleteMany({ where: { email: "goner@office.example" } });
+
+  // ------------------------------------------------------------------
   section("the uploader sees what happened");
   const feed = await (await client.go(`${APP}/board`)).text();
   check("their Activity count is not zero", /Activity[\s\S]{0,200}[1-9]/.test(feed));

--- a/src/app/admin/invites/actions.ts
+++ b/src/app/admin/invites/actions.ts
@@ -174,3 +174,63 @@ export async function resetPasswordAction(
   // message, so not even the admin who triggered it can replay it.
   return delivered ? { sent: target.email } : { sent: target.email, handoverUrl: url };
 }
+
+/**
+ * Revoke, or restore, a member's access.
+ *
+ * Suspension rather than deletion, deliberately. `Story.uploaderId` cascades,
+ * so removing the row would take their whole print history with it — tickets
+ * you finished, conversations you had, and the audit trail's actor links.
+ * Somebody leaving the office is not a reason to lose the record of what was
+ * printed for them.
+ *
+ * Two things have to happen together or the control is theatre. The admin
+ * plugin refuses to create a session for a suspended account, which shuts the
+ * door; it does nothing about the session they are already holding, which
+ * would keep working until it expired. So the sessions go too, and
+ * `currentUser()` refuses a suspended account besides.
+ */
+export async function setMemberAccessAction(
+  _prev: InviteFormState,
+  formData: FormData,
+): Promise<InviteFormState> {
+  const admin = await requireAdmin();
+  const userId = String(formData.get("userId") ?? "");
+  const revoke = String(formData.get("revoke") ?? "") === "true";
+
+  const target = await db.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, name: true, role: true, banned: true },
+  });
+  if (!target) return { error: "No such member." };
+
+  // The printer owner is the only way back into the admin surface. Suspending
+  // them locks the app permanently, so the guard is here rather than only in
+  // the UI, which renders no control for them anyway.
+  if (target.role === "admin") {
+    return { error: "The printer owner cannot be suspended — that would lock the app." };
+  }
+
+  await db.user.update({
+    where: { id: target.id },
+    data: revoke
+      ? { banned: true, banReason: `Access revoked by ${admin.name}`, banExpires: null }
+      : { banned: false, banReason: null, banExpires: null },
+  });
+
+  if (revoke) {
+    // Shut the door they are already through, not only the one they would
+    // come back to.
+    await db.session.deleteMany({ where: { userId: target.id } });
+  }
+
+  await record({
+    action: revoke ? "access.revoked" : "access.restored",
+    actor: admin,
+    subject: target.email,
+    detail: { forName: target.name },
+  });
+
+  revalidatePath("/admin/invites");
+  return { sent: target.email };
+}

--- a/src/app/admin/invites/page.tsx
+++ b/src/app/admin/invites/page.tsx
@@ -9,6 +9,7 @@ import { AppHeader } from "@/components/app-header";
 import { Kicker, StatusChip } from "@/components/ui";
 import { InviteForm } from "./invite-form";
 import { ResetPassword } from "@/components/reset-password";
+import { MemberAccess } from "@/components/member-access";
 import { resendInviteAction, revokeInviteAction } from "./actions";
 
 export const dynamic = "force-dynamic";
@@ -61,7 +62,7 @@ export default async function InvitesPage() {
     db.user.findMany({
       where: { role: "client" },
       orderBy: { name: "asc" },
-      select: { id: true, name: true, email: true, initials: true },
+      select: { id: true, name: true, email: true, initials: true, banned: true },
     }),
   ]);
   const members = memberList.length;
@@ -106,14 +107,28 @@ export default async function InvitesPage() {
                     {m.initials}
                   </span>
                   <div className="min-w-[180px] flex-[1_1_240px]">
-                    <p className="m-0 font-display text-[17px] text-ink">{m.name}</p>
+                    <p className="m-0 font-display text-[17px] text-ink">
+                      {m.name}
+                      {m.banned && (
+                        <span className="ml-[8px] rounded-chip border-2 border-ink bg-cream-3 px-[8px] py-[1px] font-mono text-[10.5px] font-bold uppercase tracking-[0.06em] text-ink-2">
+                          Suspended
+                        </span>
+                      )}
+                    </p>
                     <p className="m-0 font-mono text-[11.5px] text-ink-3">{m.email}</p>
                   </div>
-                  <ResetPassword
-                    userId={m.id}
-                    name={m.name.split(" ")[0] ?? m.name}
-                    expiresInMinutes={RESET_TTL_MINUTES}
-                  />
+                  <div className="flex flex-wrap items-center gap-[8.8px]">
+                    <ResetPassword
+                      userId={m.id}
+                      name={m.name.split(" ")[0] ?? m.name}
+                      expiresInMinutes={RESET_TTL_MINUTES}
+                    />
+                    <MemberAccess
+                      userId={m.id}
+                      name={m.name.split(" ")[0] ?? m.name}
+                      suspended={m.banned === true}
+                    />
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,4 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <!-- The brand mark: the same teal disc as the wordmark in the header. -->
-  <circle cx="16" cy="16" r="16" fill="#12645f"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Pretty Please Print">
+  <!--
+    The brand mark, matching <Brand> in src/components/ui.tsx: a cherry disc
+    with the heavy ink keyline this design language uses everywhere, and the
+    cream bead of filament coming off the nozzle.
+
+    It was a plain teal circle, the wordmark colour from the original design
+    handoff, which the app has not used since it was renamed.
+  -->
+  <circle cx="16" cy="16" r="14" fill="#e4322f" stroke="#221a14" stroke-width="3"/>
+  <circle cx="16" cy="16" r="4.2" fill="#fff6e9"/>
 </svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next";
 import { Alfa_Slab_One, Archivo, Courier_Prime, Pacifico } from "next/font/google";
 import "./globals.css";
 
+import { SourceLink } from "@/components/source-link";
+import { sourceUrl } from "@/lib/runtime";
+
 /*
  * Four faces, each with a job, which is how a real diner sign works: a script
  * logotype, fat slab for the shouting, a workhorse for the reading, and a
@@ -54,8 +57,13 @@ export default function RootLayout({
       lang="en"
       className={`${script.variable} ${slab.variable} ${archivo.variable} ${courier.variable}`}
     >
-      <body className="plate min-h-screen bg-cream text-ink antialiased">
-        {children}
+      <body className="plate flex min-h-screen flex-col bg-cream text-ink antialiased">
+        <div className="flex-1">{children}</div>
+        {/* AGPL-3.0 section 13 wants the source offer in front of people using
+            the app over a network. In the root layout it reaches every page,
+            signed in or not, and is resolved server-side so a fork can point
+            it at its own source with SOURCE_URL. */}
+        <SourceLink href={sourceUrl()} />
       </body>
     </html>
   );

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -18,7 +18,8 @@ const ERRORS: Record<string, string> = {
     "That address has not been invited. Pretty Please Print is invite-only — ask whoever owns the printer for a link.",
   INVALID_TOKEN: "That link is no longer valid. Ask the printer owner for a fresh one.",
   TOKEN_EXPIRED: "That link expired. Ask the printer owner for another.",
-  banned: "That account has been suspended.",
+  banned: "That account has been suspended. Ask whoever owns the printer.",
+  BANNED_USER: "That account has been suspended. Ask whoever owns the printer.",
 };
 
 /** Set by /set-password once a new one has been chosen. */

--- a/src/components/member-access.tsx
+++ b/src/components/member-access.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+
+import { setMemberAccessAction, type InviteFormState } from "@/app/admin/invites/actions";
+import { Notice } from "@/components/ui";
+
+function Submit({ revoke, name }: { revoke: boolean; name: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className={
+        revoke
+          ? "stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-wash px-[15px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-cherry-dk hover:bg-cherry hover:text-cream disabled:opacity-50"
+          : "stamp cursor-pointer rounded-chip border-[3px] border-ink bg-mint px-[15px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink hover:bg-aqua disabled:opacity-50"
+      }
+    >
+      {pending ? "Working…" : revoke ? `Revoke ${name}'s access` : `Restore ${name}'s access`}
+    </button>
+  );
+}
+
+/**
+ * "They have left, and should not be able to get back in."
+ *
+ * Suspension, not deletion: their tickets, comments and audit trail stay
+ * exactly where they are. Behind a disclosure because it is not an everyday
+ * action, and it takes effect the moment it is pressed — including on the
+ * session they are using right now.
+ */
+export function MemberAccess({
+  userId,
+  name,
+  suspended,
+}: {
+  userId: string;
+  name: string;
+  suspended: boolean;
+}) {
+  const [state, formAction] = useActionState<InviteFormState, FormData>(
+    setMemberAccessAction,
+    {},
+  );
+
+  return (
+    <details>
+      <summary className="inline-block cursor-pointer list-none rounded-chip border-[3px] border-transparent px-[13.2px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink-2 hover:border-ink hover:bg-cream-2">
+        {suspended ? "Suspended" : "Revoke access?"}
+      </summary>
+      <form action={formAction} className="mt-[8px] max-w-[560px]">
+        <input type="hidden" name="userId" value={userId} />
+        <input type="hidden" name="revoke" value={suspended ? "false" : "true"} />
+        <div className="rounded-card border-[3px] border-ink bg-cream-2 p-[11px]">
+          <p className="m-0 mb-[8px] text-[13.5px] leading-[1.45] text-ink-2">
+            {suspended ? (
+              <>
+                {name} cannot sign in. Restoring lets them back in with the
+                password or passkey they already had — nothing was deleted.
+              </>
+            ) : (
+              <>
+                Signs {name} out everywhere and refuses any new sign-in. Their
+                tickets, comments and history stay exactly as they are, and you
+                can restore access at any time. Recorded in the audit log.
+              </>
+            )}
+          </p>
+          <Submit revoke={!suspended} name={name} />
+        </div>
+        {state.error && (
+          <div className="mt-[8px]">
+            <Notice tone="warn">{state.error}</Notice>
+          </div>
+        )}
+      </form>
+    </details>
+  );
+}

--- a/src/components/source-link.tsx
+++ b/src/components/source-link.tsx
@@ -1,0 +1,27 @@
+/**
+ * Where the source of *this* instance lives.
+ *
+ * The app is AGPL-3.0, whose section 13 says anyone who modifies it and lets
+ * people use their version over a network must offer those users the
+ * corresponding source. Nobody honours that from a link in a README they will
+ * never open, so it belongs in the running app, on every page.
+ *
+ * Deliberately takes the URL rather than reading it: this renders inside the
+ * root layout, and a component that reached for `process.env` would also be
+ * dragged into the client bundle by anything that imports it, where the value
+ * is simply absent.
+ */
+export function SourceLink({ href }: { href: string }) {
+  return (
+    <footer className="mx-auto w-full max-w-[1180px] px-[26.4px] pb-[26.4px] pt-[8.8px]">
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-3 underline underline-offset-2 hover:text-cherry-dk"
+      >
+        Source · AGPL-3.0
+      </a>
+    </footer>
+  );
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -28,6 +28,8 @@ export type AuditAction =
   | "user.role_changed"
   | "password.reset_requested"
   | "password.reset_completed"
+  | "access.revoked"
+  | "access.restored"
   // work
   | "story.created"
   | "upload.rejected"

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -19,7 +19,16 @@ export {
   type Actor,
 } from "@/lib/scope";
 
-/** The signed-in user, or null. Never throws. */
+/**
+ * The signed-in user, or null. Never throws.
+ *
+ * Suspension is checked here as well as at sign-in, and the redundancy is the
+ * point. The admin plugin refuses to *create* a session for a suspended
+ * account, which stops them getting back in but does nothing about the
+ * session they already hold — that one keeps working until it expires.
+ * Revoking access deletes those sessions, and this is the belt to that
+ * braces: a session that somehow survives still resolves to nobody.
+ */
 export async function currentUser(): Promise<Actor | null> {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session?.user) return null;
@@ -27,7 +36,10 @@ export async function currentUser(): Promise<Actor | null> {
   const u = session.user as typeof session.user & {
     initials?: string | null;
     role?: string | null;
+    banned?: boolean | null;
   };
+
+  if (u.banned) return null;
 
   return {
     id: u.id,

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -13,3 +13,16 @@
  * the moment that matters.
  */
 export const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+
+/**
+ * The public location of this instance's source.
+ *
+ * AGPL-3.0 section 13 obliges anyone who modifies this app and serves it over
+ * a network to offer their users the corresponding source. The default points
+ * at the upstream repository, which is correct only for an unmodified
+ * instance: **if you change the code, change this**, or the offer in the
+ * footer points at source that is not what is running.
+ */
+export function sourceUrl(): string {
+  return process.env.SOURCE_URL ?? "https://github.com/danileau/ppp";
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -68,6 +68,12 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  // Everything except Next's own static assets, which need no nonce.
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.png$).*)"],
+  // Everything except static assets, which need no nonce and no session.
+  //
+  // `icon.svg` is on this list because leaving it off put the favicon behind
+  // the sign-in redirect: a signed-out browser asked for it, got a 307 to
+  // /signin, and rendered no icon at all — on precisely the pages where the
+  // brand is doing the most work. It is a public brand asset; there is
+  // nothing there to protect.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|icon.svg|.*\\.png$).*)"],
 };


### PR DESCRIPTION
Three things asked for, and one bug found while proving the third.

## Revoking a member's access

Invitations could be withdrawn right up until they were accepted; after that an account was permanent. You could reset somebody's password but never take their access away — which is the thing you actually need when a person leaves.

**Suspension rather than deletion**, deliberately: `Story.uploaderId` cascades, so removing the row would take their print history with it — finished tickets, conversations, and the audit trail's actor links. Somebody leaving is not a reason to lose the record of what was printed for them. Reversible, and audited both ways.

**Two things have to happen together or the control is theatre.** The admin plugin refuses to *create* a session for a suspended account, which shuts the door they would come back to — but does nothing about the session they are already holding, which would keep working until it expired. So the sessions are deleted too, and `currentUser()` refuses a suspended account besides.

**The printer owner cannot be suspended.** They are the only way into the admin surface, so it would lock the app with no way back. The guard is in the action, not only in the UI that renders no control for them.

## The AGPL source offer

§13 obliges anyone who modifies the app and serves it over a network to offer their users the source. Nobody honours that from a README they never open, so it is in the running app — root layout, every page, signed in or not.

It reads `SOURCE_URL` rather than hard-coding the upstream repository, because **a fork pointing at somebody else's source is worse than saying nothing: it looks like compliance.** Documented in the README and `.env.docker.example`.

It resolves server-side and takes the URL as a prop. A component that reached for `process.env` would be dragged into the client bundle by anything importing it, where the value simply is not there.

## The favicon

Still the old teal disc `#12645f` from the design handoff — a colour the app has not used since it was renamed. Now the cherry mark with the ink keyline and cream bead, matching `<Brand>`.

**And the bug it surfaced:** `/icon.svg` was not in the middleware matcher's exclusion list, so a signed-out browser asking for the favicon got a **307 to /signin** and rendered no icon at all — on precisely the pages where the brand does the most work (sign-in, invite, set-password). It is a public brand asset with nothing to protect.

## Verification

`verify:queue` grows **50 → 70 checks**, covering the full revoke/restore cycle, the session-already-held case, both guards, the source offer on authenticated and unauthenticated pages, and that the favicon is served rather than redirected.

All suites green against the built image: `verify:auth`, `verify:queue` 70, `verify:upload` 53, `probe:security` 62, `verify:passkey` 13, `verify:models` 29.

Two things worth noting about how this was tested, because both nearly produced false confidence:

- My first harness posted the `useActionState` action payloads **without HTML-unescaping them**, so the server could not resolve the action reference and returned 500. `verify-auth`'s `submit()` already did this correctly; the throwaway did not.
- Two guard checks were passing **vacuously**: I had re-run `ensureCredentials` for the admin mid-test, which resets their password, and `revokeSessionsOnPasswordReset` had quietly signed them out. A signed-out POST does nothing either. The suite now asserts the admin session is still live *before* relying on the guards.