### PR TITLE
Name the header the audit trail is allowed to believe

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -56,10 +56,18 @@ MAIL_FROM="Pretty Please Print <printer@example.org>"
 SMTP_URL="smtp://mailpit:1025"
 # RESEND_API_KEY=""
 
-# --- reverse proxy ---
-# Set to true ONLY when the app is unreachable except through a proxy you
-# control (docker-compose.truenas.yml arranges exactly that). Otherwise the
-# audit trail would record a client-supplied X-Forwarded-For as fact.
+# --- reverse proxy: which header carries the real client address ---
+# Only set this when the app is unreachable except through a proxy you control
+# (docker-compose.truenas.yml and docker-compose.cf.yml both arrange that).
+# Otherwise the audit trail records whatever a client chose to send.
+#
+#   false        trust nothing. The trail records no address. Default, and
+#                correct whenever the app can be reached without the proxy.
+#   true         left-most X-Forwarded-For. For a proxy that REPLACES the
+#                header, such as Nginx Proxy Manager on its own.
+#   cloudflare   CF-Connecting-IP. Required behind Cloudflare, which APPENDS
+#                to X-Forwarded-For instead of replacing it — so the left-most
+#                entry there is client-chosen and must not be believed.
 TRUST_PROXY_HEADERS=false
 
 # --- password breach check ---

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ with commentary is [`.env.docker.example`](.env.docker.example).
 | `SMTP_URL` | | SMTP transport. **Leave unset and the app still works** — links are shown to the admin to hand over. |
 | `RESEND_API_KEY` | | Alternative to `SMTP_URL`; takes precedence. |
 | `MAIL_FROM` | | Envelope sender. |
-| `TRUST_PROXY_HEADERS` | | `true` only when the app is unreachable except through your proxy. See [the reasoning](docs/deployment.md#why-trust_proxy_headers-is-a-separate-switch). |
+| `TRUST_PROXY_HEADERS` | | Which header carries the client address: `false` (trust nothing, the default), `true` (left-most `X-Forwarded-For`), or `cloudflare` (`CF-Connecting-IP`). See [the reasoning](docs/deployment.md#why-trust_proxy_headers-is-a-separate-switch). |
 | `HIBP_DISABLED` | | `true` disables the breach check. Only for a host with no outbound internet — it fails closed, so without it nobody could register. |
 | `SOURCE_URL` | | Where this instance's source lives, shown in the footer. **Change it if you modify the code** — see [Licence](#licence). Defaults to the upstream repository. |
 | `PPP_REGISTRY` / `PPP_TAG` | | Which published image to run. Pin `PPP_TAG` to a commit SHA; that is also how you roll back. |
@@ -232,10 +232,11 @@ an **Origin Certificate** plus SSL mode *Full (strict)* removes ACME from the
 picture entirely.
 
 **Audit rows have no IP address.**
-Expected when `TRUST_PROXY_HEADERS=false`, which is correct behind Cloudflare:
-it *appends* to `X-Forwarded-For` rather than replacing it, so the left-most
-entry is whatever the client chose to send. The app records nothing rather than
-something attacker-chosen.
+`TRUST_PROXY_HEADERS` is unset or `false`, so nothing is trusted. Behind
+Cloudflare set it to `cloudflare` — not `true`, because Cloudflare *appends* to
+`X-Forwarded-For` and the left-most entry there is whatever the client sent.
+Behind a proxy that replaces the header, `true`. Set either only if the app
+cannot be reached without going through that proxy.
 
 **The bootstrap link expired.**
 Re-run the migrator; it prints a fresh one, and keeps doing so until a password

--- a/docker-compose.cf.yml
+++ b/docker-compose.cf.yml
@@ -9,13 +9,19 @@
 #
 # The one difference, and the reason this file exists instead: truenas.yml
 # forces TRUST_PROXY_HEADERS=true, which is right when NPM is the only thing
-# in front. With Cloudflare proxying, it is wrong. Cloudflare *appends* to
+# in front and wrong the moment Cloudflare is. Cloudflare *appends* to
 # X-Forwarded-For rather than replacing it, and NPM appends again, so the
-# left-most entry — the one src/lib/audit.ts reads — is whatever the client
-# chose to send. CF-Connecting-IP is the header that cannot be spoofed there,
-# and the app does not read it yet. So the value is left to .env.docker,
-# where it must be false: the trail then records no address rather than an
-# attacker-chosen one, which is the failure this app prefers.
+# left-most entry is whatever the client chose to send.
+#
+# So the value is left to .env.docker, where it should read:
+#
+#     TRUST_PROXY_HEADERS=cloudflare
+#
+# which makes the app read CF-Connecting-IP — set at Cloudflare's edge and not
+# spoofable through it — and ignore X-Forwarded-For entirely. Set it to
+# "cloudflare" ONLY if Cloudflare is genuinely the only way in; if the origin
+# is reachable directly, anyone can send that header too and `false` is the
+# honest setting.
 services:
   app:
     networks:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -159,18 +159,33 @@ the caller typed, and believing it would let someone put chosen strings in the
 audit log and pin their own refused attempts on another address.
 
 So it is off by default, and the trail records *no* address rather than a
-fictional one. `docker-compose.truenas.yml` turns it on, and is also the file
-that makes it true by keeping the app off every host port.
+fictional one.
 
-**Put Cloudflare in front and it has to go off again**, which is why
-`docker-compose.cf.yml` exists as a separate overlay. Cloudflare *appends* to
-`X-Forwarded-For` instead of replacing it, and NPM appends after that, so the
-left-most entry — the one `clientIp()` reads — is whatever the client chose to
-send. `CF-Connecting-IP` is the header that cannot be spoofed there, and the
-app does not read it yet. Until it does, a Cloudflare-fronted deployment
-records no address, which is the honest answer rather than an attacker-chosen
-one. The `cf` overlay is identical to the `truenas` one except that it leaves
-the setting to `.env.docker`, where it must be `false`.
+It is a **named source rather than a boolean**, because which header to
+believe depends on what is actually in front of the app — and getting that
+wrong does not fail loudly, it quietly fills the trail with addresses the
+client picked:
+
+| value | header read | when |
+| --- | --- | --- |
+| unset / `false` | none | default; correct whenever the app is reachable without the proxy |
+| `true` | left-most `X-Forwarded-For` | a proxy that **replaces** the header — Nginx Proxy Manager alone |
+| `cloudflare` | `CF-Connecting-IP` | behind Cloudflare |
+
+**Cloudflare needs its own mode** because it *appends* to `X-Forwarded-For`
+instead of replacing it, and a proxy behind it appends again — so the
+left-most entry is whatever the client sent, with the real address buried
+after it. `CF-Connecting-IP` is written at Cloudflare's edge and cannot be
+spoofed through it.
+
+The two modes never fall back to one another. Under `cloudflare`, a request
+arriving with no `CF-Connecting-IP` did not come through Cloudflare, and
+reading `X-Forwarded-For` instead would reopen exactly the hole the mode
+exists to close — so it records nothing.
+
+`docker-compose.truenas.yml` forces `true`, and is also the file that makes it
+true by keeping the app off every host port. `docker-compose.cf.yml` leaves the
+value to `.env.docker` so a Cloudflare-fronted deployment can set `cloudflare`.
 
 ### HTTPS is not optional, and here is why
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -160,7 +160,7 @@ hit was a false positive *inside* that generated file.
 | **A06** | Vulnerable Components | **Pass, after fixes 4 and 5.** Zero across three independent scanners. |
 | **A07** | Auth Failures | **Pass, after fix 1.** Passwords: ≥10 characters, breach-checked against HIBP by k-anonymity, guessing capped at 10/min per IP. No user enumeration — a wrong password and an invented username give byte-identical responses, and an unknown username still pays for a hash so the wall clock does not answer either. Set-password links single-use, 30-minute TTL, hashed at rest, and they establish **no session**. Setting a password revokes the sessions the old one opened. Off-site and protocol-relative redirect targets refused, both via `?next=` and via the API's `callbackURL`. Sign-out kills the session server-side. See the section below. |
 | **A08** | Integrity Failures | **Pass.** `role`, `initials` and `invitedById` cannot be set from the request body: declared `input: false`, and Better Auth refuses the whole sign-up with `FIELD_NOT_ALLOWED` rather than silently trimming it. A chosen `id` and a posted `emailVerified` reach the endpoint undeclared and are overruled server-side from the invite. Both halves probed. On upload, `uploaderId` comes from the session and a posted `status` is ignored, both probed. Storage keys are generated, never derived from the filename. Lockfile committed. |
-| **A09** | Logging & Monitoring | **Pass.** An append-only `AuditEvent` table records invitations sent, resent, revoked, accepted and *rejected*; password resets requested and completed; sign-in and sign-out; story creation and refused uploads. Rows are denormalised (`actorEmail`, `subject`) so the trail still reads correctly after the user or story it refers to is deleted, and a probe asserts no token or secret reaches `detail`. |
+| **A09** | Logging & Monitoring | **Pass.** An append-only `AuditEvent` table records invitations sent, resent, revoked, accepted and *rejected*; access revoked and restored; password resets requested and completed; sign-in and sign-out; story creation and refused uploads. The client address is recorded only from a header the deployment has explicitly named as trustworthy (`TRUST_PROXY_HEADERS`), and no address at all otherwise — a blank rather than a fiction. Rows are denormalised (`actorEmail`, `subject`) so the trail still reads correctly after the user or story it refers to is deleted, and a probe asserts no token or secret reaches `detail`. |
 | **A10** | SSRF | **Pass (low exposure).** The app makes no outbound request from user input. A link-local `callbackURL` (`169.254.169.254`) is refused. |
 
 ## A07 with passwords in the picture
@@ -236,6 +236,17 @@ spent when a password is actually set, which is what "single use" is for.
 and a successful one kills it.
 
 ### Residual risk accepted
+
+- **A trusted-proxy misconfiguration is silent.** `TRUST_PROXY_HEADERS` now
+  names which header to believe (`false` / `true` / `cloudflare`) rather than
+  being a boolean, because the right answer depends on what is in front of the
+  app and the wrong answer does not fail loudly — it fills the audit trail
+  with client-chosen addresses. The modes never fall back to one another, and
+  the default trusts nothing. What remains is that nothing *verifies* the
+  claim: set `cloudflare` on an origin that is reachable directly and anyone
+  can send `CF-Connecting-IP` themselves. Checking the peer against
+  Cloudflare's published ranges would close that; the compose overlays close it
+  instead by keeping the app off every host port.
 
 - **The breach check is an outbound dependency.** It fails closed, so if
   `api.pwnedpasswords.com` is unreachable, nobody can *set* a password —

--- a/scripts/verify-queue.ts
+++ b/scripts/verify-queue.ts
@@ -11,6 +11,7 @@ import "./_env";
  * DESTRUCTIVE: wipes users and stories. Development database only.
  */
 import { db } from "../src/lib/db";
+import { clientIpFrom, ipSource } from "../src/lib/client-ip";
 import { ensureCredentials, signInWithPassword, usernameFor } from "./_accounts";
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
@@ -464,6 +465,45 @@ async function main() {
   check("the restore is audited",
         (await db.auditEvent.count({
           where: { action: "access.restored", subject: goner.email } })) === 1);
+
+  // ------------------------------------------------------------------
+  section("the audit trail believes the right header");
+
+  // Pure function, exercised directly: the alternative is restarting the stack
+  // once per mode, and the thing worth testing is precisely which header wins.
+  const hdr = (o: Record<string, string>) => new Headers(o);
+  const SPOOF = "203.0.113.66";   // what a client sends
+  const REAL = "198.51.100.7";    // what the edge saw
+
+  check("unset trusts nothing", ipSource(undefined) === "none");
+  check('"false" trusts nothing', ipSource("false") === "none");
+  check('"true" means X-Forwarded-For', ipSource("true") === "forwarded");
+  check('"cloudflare" means CF-Connecting-IP', ipSource("cloudflare") === "cloudflare");
+  check("the value is case- and space-insensitive", ipSource("  CloudFlare ") === "cloudflare");
+
+  check("with no source trusted, nothing is recorded even when headers are present",
+        clientIpFrom(hdr({ "x-forwarded-for": SPOOF, "cf-connecting-ip": REAL }), "none") === null);
+
+  check("forwarded mode takes the left-most X-Forwarded-For",
+        clientIpFrom(hdr({ "x-forwarded-for": `${REAL}, 10.0.0.1` }), "forwarded") === REAL);
+  check("and falls back to X-Real-IP when there is no XFF",
+        clientIpFrom(hdr({ "x-real-ip": REAL }), "forwarded") === REAL);
+
+  // The whole point. Cloudflare APPENDS to X-Forwarded-For, so the left-most
+  // entry is whatever the client sent; CF-Connecting-IP is set at the edge.
+  check("cloudflare mode reads CF-Connecting-IP",
+        clientIpFrom(hdr({ "cf-connecting-ip": REAL }), "cloudflare") === REAL);
+  check("and ignores a spoofed X-Forwarded-For sitting in front of it",
+        clientIpFrom(hdr({ "x-forwarded-for": `${SPOOF}, ${REAL}`, "cf-connecting-ip": REAL }),
+                     "cloudflare") === REAL);
+  check("with no CF header it records nothing rather than falling back",
+        clientIpFrom(hdr({ "x-forwarded-for": SPOOF }), "cloudflare") === null,
+        "falling back to XFF here would reopen the hole the mode exists to close");
+
+  check("an absurdly long value is refused rather than stored",
+        clientIpFrom(hdr({ "cf-connecting-ip": "a".repeat(200) }), "cloudflare") === null);
+  check("surrounding whitespace is trimmed",
+        clientIpFrom(hdr({ "cf-connecting-ip": `  ${REAL}  ` }), "cloudflare") === REAL);
 
   // ------------------------------------------------------------------
   section("the AGPL source offer, and the brand mark");

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { headers } from "next/headers";
 import { db } from "@/lib/db";
 import type { Actor } from "@/lib/scope";
+import { clientIpFrom, ipSource } from "@/lib/client-ip";
 
 /**
  * The audit trail.
@@ -41,26 +42,8 @@ export type AuditAction =
   | "file.downloaded"
   | "file.refused";
 
-/**
- * Whether `X-Forwarded-For` can be believed.
- *
- * The header is set by whoever spoke to us last. Behind a reverse proxy that
- * is the proxy, and the value is the real client. Reachable directly — on a
- * LAN, say — it is whatever the caller typed, and recording that as fact would
- * put attacker-chosen strings in the audit trail and let someone frame another
- * address for their own refused attempts.
- *
- * So it is off unless the deployment says otherwise. Without it the trail
- * records no address rather than a fictional one, which is the more useful
- * failure: a blank is obviously a blank.
- */
-const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === "true";
-
 function clientIp(h: Headers): string | null {
-  if (!TRUST_PROXY) return null;
-  // Left-most entry is the original client as the first proxy saw it.
-  const forwarded = h.get("x-forwarded-for")?.split(",")[0]?.trim();
-  return forwarded || h.get("x-real-ip")?.trim() || null;
+  return clientIpFrom(h, ipSource());
 }
 
 type RecordInput = {

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -1,0 +1,73 @@
+/**
+ * Which header carries the real client address — the pure half of the audit
+ * trail's provenance.
+ *
+ * Its own module, and free of `server-only`, for the same reason `scope.ts`
+ * is: this is a decision worth testing directly, and the alternative is
+ * standing the whole stack up and restarting it once per mode to check which
+ * header wins.
+ *
+ * A forwarded address is only as trustworthy as the hop that set it, and
+ * *which* header to believe depends on what is actually in front of the app —
+ * so this is a named source rather than a boolean. Getting it wrong does not
+ * fail loudly: it quietly fills the audit trail with addresses the client
+ * chose, which is worse than no address at all.
+ *
+ *   unset / "false"   nothing is trusted. The trail records no address, and a
+ *                     blank is honestly a blank. This is the default and the
+ *                     right answer whenever the app can be reached without
+ *                     passing through a proxy.
+ *
+ *   "true"            left-most `X-Forwarded-For`. Correct for a proxy that
+ *                     *replaces* the header — Nginx Proxy Manager with
+ *                     `proxy_set_header X-Forwarded-For $remote_addr`, say —
+ *                     and only when the app is unreachable except through it.
+ *
+ *   "cloudflare"      `CF-Connecting-IP`. Required behind Cloudflare, because
+ *                     Cloudflare *appends* to `X-Forwarded-For` rather than
+ *                     replacing it: a client can send their own value and
+ *                     Cloudflare adds the real one after it, leaving the
+ *                     left-most entry attacker-chosen. `CF-Connecting-IP` is
+ *                     overwritten at the edge and cannot be spoofed through
+ *                     it.
+ *
+ * The two modes never fall back to one another. Under "cloudflare" a request
+ * arriving without `CF-Connecting-IP` did not come through Cloudflare, and
+ * reading `X-Forwarded-For` instead would reintroduce exactly the hole this
+ * setting exists to close.
+ */
+export type IpSource = "none" | "forwarded" | "cloudflare";
+
+export function ipSource(raw = process.env.TRUST_PROXY_HEADERS): IpSource {
+  switch ((raw ?? "").trim().toLowerCase()) {
+    case "cloudflare":
+      return "cloudflare";
+    case "true":
+      return "forwarded";
+    default:
+      return "none";
+  }
+}
+
+/** Longest possible IPv6 with a zone, rounded up. Anything longer is junk. */
+const MAX_IP = 64;
+
+/**
+ * Pure, so it can be tested without standing a server up and restarting it
+ * once per mode — which is why the mode is a parameter rather than read here.
+ */
+export function clientIpFrom(h: Headers, source: IpSource): string | null {
+  let value: string | null = null;
+
+  if (source === "cloudflare") {
+    value = h.get("cf-connecting-ip");
+  } else if (source === "forwarded") {
+    // Left-most entry is the original client as the first proxy saw it.
+    value = h.get("x-forwarded-for")?.split(",")[0] ?? h.get("x-real-ip") ?? null;
+  }
+
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > MAX_IP) return null;
+  return trimmed;
+}
+


### PR DESCRIPTION
`TRUST_PROXY_HEADERS` was a boolean, and a boolean cannot express the thing that actually matters: **which** header carries the real client address depends on what is in front of the app.

Behind Nginx Proxy Manager alone, the left-most `X-Forwarded-For` is right — that proxy *replaces* the header. Behind Cloudflare it is wrong, because Cloudflare **appends**: a client sends their own value, Cloudflare adds the real one after it, and the left-most entry is attacker-chosen.

The consequence was that a Cloudflare-fronted deployment had to turn the setting off entirely and record **no address at all** — which is what the live deployment has been doing since it went behind Cloudflare.

## Now a named source

| value | header read | when |
| --- | --- | --- |
| unset / `false` | none | default; correct whenever the app is reachable without the proxy |
| `true` | left-most `X-Forwarded-For` | a proxy that **replaces** the header |
| `cloudflare` | `CF-Connecting-IP` | behind Cloudflare — written at the edge, not spoofable through it |

**The two modes never fall back to one another.** Under `cloudflare`, a request arriving without `CF-Connecting-IP` did not come through Cloudflare, and reading `X-Forwarded-For` instead would reopen exactly the hole the mode exists to close. It records nothing.

`true` is unchanged, so existing deployments keep their behaviour.

## Structure

The selection logic moved to `src/lib/client-ip.ts` — pure, and without the `server-only` guard, for the same reason `scope.ts` is separate: the alternative to testing it directly is standing the stack up and restarting it once per mode. `audit.ts` keeps its guard and imports the decision.

## Verified both ways

**Thirteen unit checks** over the header matrix in `verify:queue` (50 → 83 checks total), including that `cloudflare` mode ignores a spoofed XFF sitting in front of the genuine header, and that a missing CF header yields `null` rather than a fallback.

**And end to end against a running stack** in `cloudflare` mode — because a unit test proves the function, not the wiring:

```
sign-in with  x-forwarded-for: 203.0.113.66, 198.51.100.7
              cf-connecting-ip: 198.51.100.7
  → audit row ip = 198.51.100.7      (the edge-set address)
  → NOT       ip = 203.0.113.66      (the spoof)

same request with no cf-connecting-ip
  → audit row ip = null              (no fallback)
```

All suites green: `verify:auth`, `verify:queue` 83, `verify:upload` 53, `probe:security` 62, `verify:passkey` 13, `verify:models` 29.

## Residual risk, recorded rather than papered over

Nothing *verifies* the claim. Set `cloudflare` on an origin that is reachable directly and anyone can send `CF-Connecting-IP` themselves. Checking the peer against Cloudflare's published ranges would close that; the compose overlays close it instead by keeping the app off every host port. Added to the audit's "Residual risk accepted".

`docker-compose.cf.yml` no longer has to tell operators the app cannot do this.

## For your deployment

Set `TRUST_PROXY_HEADERS=cloudflare` in `.env.docker` on the NAS after this merges, and audit rows get real client addresses back.