### PR TITLE
Releases that are more than a name

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -4,8 +4,13 @@
 # the source tree or a toolchain, and what runs there is byte-for-byte what CI
 # tested. Deploying stays a human action — nothing here reaches into TrueNAS.
 #
-# Tags per image: the 7-char commit SHA, and a moving `latest`. Pin PPP_TAG to
-# a SHA on the NAS, because that is also how you roll back.
+# Tags per image: the 7-char commit SHA always, plus a moving `latest` on a
+# push to main, or the version on a `v*` tag. Pin PPP_TAG to a SHA or a
+# version on the NAS — either is also how you roll back.
+#
+# A release deliberately does not move `latest`: the tag is cut from a commit
+# already on main, so `latest` already points at it or at something newer, and
+# a patch release for an older line must not drag it backwards.
 #
 # Images are signed with cosign keyless (GitHub OIDC, logged to Rekor). The
 # signature pins the identity of THIS workflow on THIS repo, which protects
@@ -23,6 +28,9 @@ name: Release images
 on:
   push:
     branches: [main]
+    # A version tag republishes the same commit under a name a human can say
+    # out loud, so PPP_TAG can read v0.1.0 instead of a 7-char SHA.
+    tags: ["v*"]
     # The daily traffic snapshot writes only here, and republishing images for
     # a row of numbers helps nobody.
     paths-ignore:
@@ -58,9 +66,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Short SHA
-        id: sha
-        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - name: Which tags
+        id: tags
+        run: |
+          set -euo pipefail
+          short="${GITHUB_SHA::7}"
+          image="ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}"
+          # The SHA tag always goes on: it is what a deployment pins to and
+          # what a rollback selects by.
+          list="$image:$short"
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            # A release: add the version, and do NOT move `latest`. The tag is
+            # cut from a commit already on main, so latest already points at
+            # it or at something newer — moving it backwards on a patch
+            # release for an older line would be wrong.
+            list="$list"$'\n'"$image:${GITHUB_REF_NAME}"
+          else
+            list="$list"$'\n'"$image:latest"
+          fi
+          echo "short=$short" >> "$GITHUB_OUTPUT"
+          {
+            echo "list<<TAGS"
+            echo "$list"
+            echo "TAGS"
+          } >> "$GITHUB_OUTPUT"
+          echo "tagging:"; echo "$list" | sed 's/^/  /' 
 
       - name: Build and push
         id: push
@@ -69,9 +99,7 @@ jobs:
           context: .
           target: ${{ matrix.target }}
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.sha.outputs.short }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
+          tags: ${{ steps.tags.outputs.list }}
           # No registry cache on the base layers: an `apk upgrade` has to
           # really re-run, or a CVE fixed upstream shows up as a stale replay.
           provenance: true
@@ -89,7 +117,7 @@ jobs:
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
-          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.sha.outputs.short }}
+          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tags.outputs.short }}
           severity: HIGH,CRITICAL
           exit-code: '1'
           ignore-unfixed: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+Notable changes. Every entry names a released version; deployments pin
+`PPP_TAG` to one of these, or to a commit SHA if they follow `main` closely.
+
+## v0.1.0
+
+The first release worth naming. Everything the design handoff asked for is
+built, and the deployment path has been walked end to end on real hardware.
+
+### What it does
+
+- **Invite-only registration.** No public sign-up; a `User` row cannot exist
+  without a pending invitation, enforced in a single hook that every
+  authentication method goes through.
+- **Username and password sign-in**, with passkeys as an optional and stronger
+  second method. Passwords are at least ten characters and refused if they
+  appear in a known breach corpus.
+- **Upload → board → story.** `.stl` and `.3mf` validated against their bytes
+  rather than their filename, measured for a bounding box, stored in object
+  storage and never in the web root.
+- **The admin queue and the status flow** — Requested → Accepted → Printing →
+  Done → Delivery, forwards only, one step at a time. Or Declined, with a
+  reason.
+- **A conversation per ticket**, and **the real geometry** rendered in the
+  browser.
+- **Access control you can undo.** Invitations withdrawn before they are
+  accepted; access revoked afterwards, which signs the person out everywhere
+  and refuses new sign-ins while keeping their history.
+- **An append-only audit trail** of everything that changes who can get in or
+  what happens to someone's model.
+
+### Deploying it
+
+- Published, signed and scanned container images; the host needs no source
+  tree and no toolchain.
+- `scripts/deploy-wizard.sh` — lists what is published, cosign-verifies before
+  swapping, health-checks after, and rolls back on its own if the new image
+  does not come good.
+- **Mail is genuinely optional.** Nothing in the running system needs it.
+- The admin bootstraps from a one-use link the migrator prints; there is
+  deliberately no `ADMIN_PASSWORD`.
+
+### Verified
+
+Six suites, all running in CI against the built container image rather than a
+dev server: registration and sign-in, upload and board, the admin queue,
+the upload validator against hostile fixtures, WebAuthn ceremonies in a real
+browser, and OWASP-mapped security probes.
+
+Assessed against the OWASP Top 10 (2021) with SAST, SCA and DAST — see
+[docs/security-audit.md](docs/security-audit.md), including the residual risk
+that was knowingly accepted.
+
+### Licence
+
+AGPL-3.0-or-later.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ with commentary is [`.env.docker.example`](.env.docker.example).
 | `TRUST_PROXY_HEADERS` | | Which header carries the client address: `false` (trust nothing, the default), `true` (left-most `X-Forwarded-For`), or `cloudflare` (`CF-Connecting-IP`). See [the reasoning](docs/deployment.md#why-trust_proxy_headers-is-a-separate-switch). |
 | `HIBP_DISABLED` | | `true` disables the breach check. Only for a host with no outbound internet — it fails closed, so without it nobody could register. |
 | `SOURCE_URL` | | Where this instance's source lives, shown in the footer. **Change it if you modify the code** — see [Licence](#licence). Defaults to the upstream repository. |
-| `PPP_REGISTRY` / `PPP_TAG` | | Which published image to run. Pin `PPP_TAG` to a commit SHA; that is also how you roll back. |
+| `PPP_REGISTRY` / `PPP_TAG` | | Which published image to run. Pin `PPP_TAG` to a release (`v0.1.0`) or a commit SHA; either is also how you roll back. |
 
 ## Deploying
 
@@ -138,6 +138,11 @@ docker compose --env-file .env.docker \
 deployment needs no source tree and no toolchain, and what runs there is
 byte-for-byte what CI tested and signed. It publishes **no host ports at all** —
 each overlay adds only what its context needs.
+
+Every merge to `main` publishes images tagged with the commit SHA and `latest`;
+every `v*` tag publishes that same commit under its version. Pin `PPP_TAG` to a
+release if you want to move deliberately, or to a SHA if you want to follow
+`main` closely — the wizard lists both.
 
 `scripts/deploy-wizard.sh` is the way to move between versions: it lists what is
 published, cosign-verifies before swapping, health-checks after, and rolls back
@@ -272,6 +277,7 @@ has no outbound internet, set `HIBP_DISABLED=true` — and only then.
 | **[Security audit](docs/security-audit.md)** | the OWASP Top 10 assessment, findings, and residual risk accepted |
 | **[Security policy](SECURITY.md)** | how to report a vulnerability |
 | **[Contributing](CONTRIBUTING.md)** | the six suites are the contract; what a good change looks like |
+| **[Changelog](CHANGELOG.md)** | what changed in each release |
 
 ## Security
 

--- a/scripts/deploy-wizard.sh
+++ b/scripts/deploy-wizard.sh
@@ -10,8 +10,9 @@
 # It answers the questions a bare `sed PPP_TAG && docker compose up -d` does
 # not:
 #   1. WHICH image?   → lists what is actually published to ghcr.io, newest
-#      first, with publish dates and the live one marked. You pick from a menu
-#      instead of copying a 7-char SHA out of a CI log.
+#      first, with publish dates and the live one marked, showing a release
+#      version where one exists and the commit SHA otherwise. You pick from a
+#      menu instead of copying a tag out of a CI log.
 #   2. IS IT INTACT?  → cosign-verifies the image against the identity of the
 #      release-images workflow on this repo before anything is swapped. If
 #      cosign is absent it says so loudly rather than quietly skipping.
@@ -176,7 +177,10 @@ VERSIONS="$(curl -sS --max-time 20 \
 #     superseded.
 CANDIDATES="$(printf '%s' "$VERSIONS" | python3 -c '
 import json, re, sys
-SHA = re.compile(r"^[0-9a-f]{7}$")
+# A 7-char commit SHA, or a release like v0.1.0 / v1.2.3-rc1. Everything else
+# in this package is machinery: cosign publishes `sha256-<digest>.sig` and the
+# SBOM publishes `.att`, and neither is a runnable image.
+DEPLOYABLE = re.compile(r"^([0-9a-f]{7}|v\d+\.\d+\.\d+[0-9A-Za-z.\-]*)$")
 try:
     data = json.load(sys.stdin)
 except Exception:
@@ -186,7 +190,10 @@ if not isinstance(data, list):
 rows = []
 for v in data:
     tags = (v.get("metadata") or {}).get("container", {}).get("tags", []) or []
-    sha = next((t for t in tags if SHA.match(t)), None)
+    # Prefer a version tag when the same image carries both, because that is
+    # the name a person will recognise in the menu.
+    sha = next((t for t in tags if t.startswith("v") and DEPLOYABLE.match(t)), None) \
+          or next((t for t in tags if DEPLOYABLE.match(t)), None)
     if not sha:
         continue
     rows.append((v.get("created_at") or "", sha, "latest" in tags))


### PR DESCRIPTION
There are no tags at all, so `PPP_TAG` can only ever be a 7-char SHA. **A version nobody can deploy is decoration**, so this makes one deployable rather than just adding a label.

## `release-images` publishes versions

Now runs on `v*` tags as well as pushes to `main`, and picks its tags accordingly:

| trigger | tags published |
| --- | --- |
| push to `main` | `<sha>`, `latest` |
| push of `v0.1.0` | `<sha>`, `v0.1.0` |

**A release deliberately does not move `latest`.** The tag is cut from a commit already on main, so `latest` already points at it or at something newer — and a patch release for an older line must not drag it backwards.

The tag list is computed in a step rather than an inline YAML ternary, because a conditional buried in an expression is exactly the kind of thing that silently publishes the wrong name. Both branches simulated before committing:

```
ref_type=branch → ppp-app:abcdef1, ppp-app:latest
ref_type=tag    → ppp-app:abcdef1, ppp-app:v0.1.0
```

## The wizard would not have shown the tag

It filtered candidates on `/^[0-9a-f]{7}$/` — which would have hidden `v0.1.0` from its own menu, the very tag this change exists to create. It now accepts a SHA **or** a semver-shaped version, still rejects the cosign `.sig` and SBOM `.att` tags that share the package, and prefers the version when one image carries both, because that is the name a person will recognise.

Verified against a fixture carrying all four kinds:

```
  v0.1.0       2026-08-24 09:00   latest
  e8a9b89      2026-08-23 14:18
  (.sig / .att / untagged correctly excluded)
```

## Also

`CHANGELOG.md` describing what v0.1.0 actually is, and a README note that a deployment may pin either a release or a SHA.

## After this merges

I'll push the `v0.1.0` tag, which is what actually exercises the new workflow path — and confirm the images come out carrying the version.