### PR TITLE
Public images, so stop asking for a credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,14 @@ each overlay adds only what its context needs.
 Every merge to `main` publishes images tagged with the commit SHA and `latest`;
 every `v*` tag publishes that same commit under its version. Pin `PPP_TAG` to a
 release if you want to move deliberately, or to a SHA if you want to follow
-`main` closely — the wizard lists both.
+`main` closely.
+
+The images are **public**, so a deployment needs no registry credential at all.
+`scripts/deploy-wizard.sh` reflects that: run it without a token and it lists
+releases, which is the right menu for most deployments; give it a
+`read:packages` token and it lists every published image including SHA builds.
+That token is optional, is never stored, and is only needed because GitHub
+gates the package *listing* API even for public packages.
 
 `scripts/deploy-wizard.sh` is the way to move between versions: it lists what is
 published, cosign-verifies before swapping, health-checks after, and rolls back
@@ -223,9 +230,18 @@ docker run --rm --network npm-proxy curlimages/curl -sS -m 5 http://ppp-app:3000
 ```
 
 **`unauthorized` when pulling the images.**
-The registry token needs **`read:packages`** and nothing else — it is a
-*classic* token scope, nested under `write:packages` in the checkbox list.
-Fine-grained tokens do not work with ghcr.io at all. Check what yours carries:
+The published images are public, so this should not happen — check the tag
+exists before assuming it is an auth problem:
+
+```bash
+docker manifest inspect ghcr.io/danileau/ppp-app:v0.1.0
+```
+
+On a **fork** with private packages you do need a credential, and it must be a
+*classic* token with **`read:packages`** and nothing else — that scope is
+nested under `write:packages` in the checkbox list, which is easy to scroll
+past. Fine-grained tokens do not work with ghcr.io at all. Check what yours
+carries:
 
 ```bash
 curl -sSI -H "Authorization: Bearer $TOKEN" https://api.github.com/user | grep -i x-oauth-scopes

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,10 +63,12 @@ docker network create npm-proxy
 docker network connect npm-proxy <your-nginx-proxy-manager-container>
 ```
 
-**Authenticate to the registry once**, so the NAS can pull what CI publishes:
+**No registry credential is needed.** The images are public, so the host pulls
+them anonymously — nothing to create, store or rotate. Forks that keep their
+packages private need a one-off login instead:
 
 ```bash
-docker login ghcr.io -u <your-github-user> -p <PAT with read:packages>
+docker login ghcr.io -u <your-github-user> -p <classic PAT with read:packages>
 ```
 
 **In `.env.docker`:**

--- a/scripts/deploy-wizard.sh
+++ b/scripts/deploy-wizard.sh
@@ -19,10 +19,15 @@
 #   3. DID IT WORK?   → polls the public health URL after the swap, and rolls
 #      back to the previous tag automatically if it does not come good.
 #
-# The registry token is borrowed and returned: read from a hidden prompt,
-# used for the pull, then `docker logout`. Nothing long-lived is left behind,
-# which matters because the images are local afterwards and reboots need no
-# registry access at all.
+# The images are public, so no registry credential is needed to pull one. A
+# token is optional and buys only a longer menu: GitHub gates the package
+# *listing* API even for public packages, so without one the wizard lists
+# releases instead — which is the right list for most deployments anyway.
+#
+# When a token IS given (a fork with private packages, or someone following
+# main by SHA) it is borrowed and returned: read from a hidden prompt, used for
+# the pull, then `docker logout` on exit including on failure. Nothing
+# long-lived is left behind.
 #
 # Usage:
 #   ./deploy-wizard.sh              # interactive
@@ -150,22 +155,40 @@ hr
 # ----- candidates -----------------------------------------------------------
 # Asked of the registry, not of a checkout: the NAS has no git, and "what is
 # published" is the honest definition of what is deployable anyway.
+# A token is OPTIONAL, and what it buys is a longer list rather than access.
+#
+# The images are public, so pulling one needs no credential at all. What is
+# still gated is GitHub's package *listing* API, which returns 401 even for a
+# public package — so without a token the wizard lists releases instead, from
+# the public Releases API. That is the better list for most deployments
+# anyway: named versions with dates, rather than every commit.
+#
+# With a token it lists every published image, SHA builds included, which is
+# what you want when following main closely.
 read_token() {
   if [ -n "${PPP_TOKEN:-}" ]; then TOKEN="$PPP_TOKEN"; return; fi
-  printf 'ghcr.io token (read:packages, hidden): '
+  printf 'ghcr.io token for the full image list, or press enter for releases only: '
   stty -echo 2>/dev/null || true
   read -r TOKEN
   stty echo 2>/dev/null || true
   printf '\n'
-  [ -n "$TOKEN" ] || die "no token given"
 }
 read_token
 
-echo "${DIM}→ asking ghcr.io what is published…${R}"
-VERSIONS="$(curl -sS --max-time 20 \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/user/packages/container/ppp-app/versions?per_page=100" 2>/dev/null || true)"
+if [ -n "$TOKEN" ]; then
+  echo "${DIM}→ asking ghcr.io what is published…${R}"
+  SOURCE_LABEL="every published image"
+  VERSIONS="$(curl -sS --max-time 20 \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/user/packages/container/ppp-app/versions?per_page=100" 2>/dev/null || true)"
+else
+  echo "${DIM}→ asking GitHub what has been released…${R}"
+  SOURCE_LABEL="releases only (no token given)"
+  VERSIONS="$(curl -sS --max-time 20 \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null || true)"
+fi
 
 # Two things this filtering has to get right, both learned the hard way:
 #   - release-images publishes cosign signatures and SBOM attestations to the
@@ -189,6 +212,15 @@ if not isinstance(data, list):
     sys.exit(1)
 rows = []
 for v in data:
+    # Two shapes: a package version carries its tags under metadata.container,
+    # a release is simply its tag_name. Both give a date.
+    if "tag_name" in v:
+        if v.get("draft"):
+            continue
+        tag = v["tag_name"]
+        if DEPLOYABLE.match(tag):
+            rows.append((v.get("published_at") or v.get("created_at") or "", tag, False))
+        continue
     tags = (v.get("metadata") or {}).get("container", {}).get("tags", []) or []
     # Prefer a version tag when the same image carries both, because that is
     # the name a person will recognise in the menu.
@@ -203,14 +235,14 @@ for when, sha, is_latest in rows:
 ' 2>/dev/null || true)"
 
 if [ -z "$CANDIDATES" ]; then
-  echo "${YLW}⚠ could not read the package list.${R}"
-  echo "  ${DIM}Most likely the token lacks read:packages, or it expired."
+  echo "${YLW}⚠ could not read the list.${R}"
+  echo "  ${DIM}With a token, the most likely cause is that it lacks read:packages or expired."
   echo "  Verify with:  curl -sSI -H \"Authorization: Bearer \$TOKEN\" https://api.github.com/user | grep -i x-oauth-scopes${R}"
   exit 1
 fi
 
 echo
-echo "${B}Published images${R} ${DIM}(newest first):${R}"
+echo "${B}Deployable${R} ${DIM}— ${SOURCE_LABEL}, newest first:${R}"
 echo
 printf "  ${DIM} %-3s %-10s %-18s %-8s %s${R}\n" "#" "tag" "published" "moving" "state"
 
@@ -315,9 +347,13 @@ fi
 cleanup() { docker logout ghcr.io >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
-echo "${DIM}→ authenticating to ghcr.io…${R}"
-printf '%s' "$TOKEN" | docker login ghcr.io -u "$REGISTRY_OWNER" --password-stdin >/dev/null \
-  || die "docker login failed — check the token's read:packages scope"
+if [ -n "$TOKEN" ]; then
+  # Only needed if the packages are private. Public images pull anonymously,
+  # and logging in would leave a credential on disk for nothing.
+  echo "${DIM}→ authenticating to ghcr.io…${R}"
+  printf '%s' "$TOKEN" | docker login ghcr.io -u "$REGISTRY_OWNER" --password-stdin >/dev/null \
+    || die "docker login failed — check the token's read:packages scope"
+fi
 
 echo "${DIM}→ pulling ${TARGET}…${R}"
 ( cd "$PROJECT_DIR" && sed -i "s|^PPP_TAG=.*|PPP_TAG=\"$TARGET\"|" .env.docker )


### PR DESCRIPTION
The packages are public now, which makes three previously-true things wrong.

## Pulling needs no credential

`docs/deployment.md` told operators to `docker login` before their first pull. That is no longer merely unnecessary — it is **wrong**, and it was the step that made a prospective self-hoster create a token before they could try the thing at all.

Forks that keep their packages private still need it, so the instruction stays, correctly scoped to them.

## The wizard demanded a token and died without one

It now asks and accepts silence. **What a token buys is a longer menu, not access.**

GitHub gates the package *listing* API even for a public package — verified, `401` anonymously:

```
GET /users/danileau/packages/container/ppp-app/versions  → 401 Requires authentication
GET /repos/danileau/ppp/releases                         → 200, names and dates
```

So without a token the wizard lists **releases**, which answers anonymously and is the better list for most deployments anyway: named versions rather than every commit. With a token it lists every published image, SHA builds included.

`docker login` is now conditional on a token actually being given, so the common path leaves **no credential on disk at all** rather than writing one and removing it again.

## The `unauthorized` troubleshooting blamed the token

With public images that is the wrong first suspicion. It now says check the tag exists, and keeps the token guidance for forks.

## Verification

The listing parser handles both payload shapes — a package version carries tags under `metadata.container`, a release is its `tag_name` — and **skips drafts**, which would otherwise offer something nobody can pull. Checked against the real anonymous Releases response and a fixture carrying versions, SHAs, cosign `.sig`, SBOM `.att` and a draft.

Both wizard paths exercised end to end against stubs:

```
no token  → "Deployable — releases only (no token given)"   v0.1.0
token     → "Deployable — every published image"            v0.1.0 (latest), e8a9b89 (LIVE)
```

Anonymous pulls confirmed for `ppp-app` and `ppp-migrate` at both `v0.1.0` and `latest`.