### PR TITLE
Restore, actually performed

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,21 @@ zfs snapshot -r storage/applications/ppp@$(date +%F)
 ```
 
 That snapshot is *crash-consistent*, not clean — Postgres replays its WAL on
-start and recovers, which is fine and is what it is designed for. If you want a
-backup that can be restored into any Postgres rather than only onto this data
-directory, take a logical dump alongside it:
+start and recovers, which is fine and is what it is designed for.
+
+**Without ZFS, do the file copy from inside a container.** The Postgres data
+directory is mode `700` owned by uid `70`, so a `tar` or `cp -a` as your own
+user cannot even read it, and one run with `sudo` that loses ownership produces
+an archive Postgres will refuse to start from:
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml down
+docker run --rm -v "$DATA_ROOT:/data:ro" -v "$PWD:/backup" alpine \
+  tar czf /backup/ppp-$(date +%F).tgz -C /data .
+```
+
+Either way, take a logical dump alongside it — it restores into *any* Postgres,
+not only back onto this data directory, and it needs no root:
 
 ```bash
 docker exec ppp-db pg_dump -U ppp -Fc ppp > ppp-$(date +%F).dump
@@ -189,32 +201,54 @@ docker exec ppp-db pg_dump -U ppp -Fc ppp > ppp-$(date +%F).dump
 # 1. stop the stack — never restore under a running Postgres
 docker compose --env-file .env.docker -f docker-compose.prod.yml down
 
-# 2. put the data back (ZFS rollback, or copy the files)
+# 2. put the data back (ZFS rollback, or extract the archive)
 zfs rollback storage/applications/ppp/data/db@2026-08-23
 zfs rollback storage/applications/ppp/data/models@2026-08-23
+#   without ZFS, from the container-made archive:
+#   docker run --rm -v "$DATA_ROOT:/data" -v "$PWD:/backup:ro" alpine \
+#     sh -c 'rm -rf /data/db /data/models && tar xzf /backup/ppp-2026-08-23.tgz -C /data'
 
 # 3. bring it up; the migrator applies any pending migrations
 docker compose --env-file .env.docker -f docker-compose.prod.yml up -d
 docker compose --env-file .env.docker -f docker-compose.prod.yml ps
 ```
 
-Two things that will bite if you do not know them:
-
-- **`DB_PASSWORD` must be the one the restored data was created with.** Postgres
-  stores the password inside the data directory. Restore `db/` from an old
-  backup while `.env.docker` holds a newly generated password and the app
-  cannot connect, with an authentication error that looks like a config typo.
-  This is the main reason `.env.docker` belongs in the backup.
-- **`BETTER_AUTH_SECRET` is not recoverable.** Lose it and every session is
-  invalidated — nobody is locked out permanently, everyone simply signs in
-  again. Passwords and passkeys are unaffected.
-
-Restore into a *different* host, or from a `pg_dump`, needs the database
-recreated first:
+Restoring from a logical dump instead, onto a running stack:
 
 ```bash
 docker exec -i ppp-db pg_restore -U ppp -d ppp --clean --if-exists < ppp-2026-08-23.dump
 ```
+
+### When it goes wrong
+
+Both of these were confirmed by actually doing it, not by reasoning about it.
+
+**`DB_PASSWORD` must be the one the restored data was created with.** Postgres
+stores the password inside the data directory and ignores `POSTGRES_PASSWORD`
+once that directory exists. Get it wrong and the symptoms point everywhere
+except the cause:
+
+| what you see | |
+| --- | --- |
+| `ppp-db` | **healthy** — this is the misleading part |
+| `ppp-app` | never starts, so it logs nothing at all |
+| `ppp-migrate` | `Error: P1000: Authentication failed against database server` |
+
+So look in the **migrator's** logs, which is the one place nobody thinks to
+check because it is the container that is supposed to exit:
+
+```bash
+docker compose --env-file .env.docker -f docker-compose.prod.yml logs migrate
+```
+
+Nothing is damaged by getting this wrong — the wrong password is refused, not
+destructive. Put the right one back and everything returns. This is the main
+reason `.env.docker` belongs in the backup.
+
+**`BETTER_AUTH_SECRET` is not recoverable, and costs one sign-in.** Restore
+without it and every existing session cookie stops validating — a held cookie
+goes from `200` to a `307` back to the sign-in page. Nobody is locked out:
+passwords and passkeys are untouched, and everyone simply signs in again.
 
 ## Troubleshooting
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -283,6 +283,33 @@ and a successful one kills it.
   `password.reset_requested` / `password.reset_completed` and a link that sets
   a password and nothing more.
 
+## Restore, exercised
+
+The backup and restore procedure used to be documented from reasoning. It has
+now been executed against a running stack: both paths taken, the data destroyed
+in between, and the result compared row for row.
+
+- **File-level restore** — stack down, data directory deleted outright,
+  archive extracted, stack up. Users, stories, comments, invitations and the
+  audit trail all returned identical, including a canary story and its comment
+  planted specifically to detect a partial restore.
+- **Logical restore** — a row deleted, then `pg_restore --clean --if-exists`
+  from a `pg_dump`, which brought it back with exit 0 and no errors.
+- **`DB_PASSWORD` mismatch** — confirmed to refuse rather than damage. The
+  documentation now names where the error actually surfaces, because the
+  obvious places are all silent: the database reports healthy, the app never
+  starts so logs nothing, and the only message is `P1000` in the migrator.
+- **`BETTER_AUTH_SECRET` loss** — confirmed to cost exactly one sign-in. A
+  held session cookie went from 200 to a 307 at the sign-in page, and signing
+  in again worked immediately.
+
+One finding worth the exercise on its own: the Postgres data directory is mode
+`700` owned by uid `70`, so a file-level backup taken as an ordinary user
+cannot read it, and one taken with `sudo` that flattens ownership produces an
+archive Postgres refuses to start from. On ZFS a snapshot sidesteps this
+entirely; elsewhere the copy has to be made from inside a container, which the
+README now says.
+
 ## Open items
 
 - **Nothing alerts automatically.** `/admin/audit` surfaces refusals but


### PR DESCRIPTION
The backup and restore procedure was written from reasoning. It has now been **executed**: both paths taken, the data destroyed in between, and the result compared row for row against a canary story and comment planted specifically to catch a partial restore. Everything came back identical.

Three things the exercise found that reasoning had not.

## A file-level backup needs root — and `sudo` is the wrong fix

The Postgres data directory is mode `700` owned by uid `70`. As an ordinary user you cannot even `du` it:

```
$ du -sh data/db
4.0K          ← not the real size; it could not read inside
$ docker exec ppp-db du -sh /var/lib/postgresql/data
63.5M
```

Reaching for `sudo` and flattening ownership produces an archive Postgres refuses to start from. On ZFS a snapshot sidesteps this entirely; elsewhere the copy has to be made from **inside a container**, which the README now gives as a command rather than assuming the reader's host is ZFS.

## The `DB_PASSWORD` failure points everywhere except at itself

The claim was right — Postgres stores the password in the data directory and ignores `POSTGRES_PASSWORD` once it exists. But *"the app cannot connect, with an authentication error"* describes something nobody actually sees:

| container | what it shows |
| --- | --- |
| `ppp-db` | **healthy** |
| `ppp-app` | never starts, logs nothing at all |
| `ppp-migrate` | `Error: P1000: Authentication failed against database server` |

The only message is in the migrator — the one container people ignore, because it is *supposed* to exit. The README now says where to look, and that the wrong password **refuses rather than damages**, which is the part worth knowing while panicking.

## Losing `BETTER_AUTH_SECRET` costs exactly one sign-in

Confirmed rather than assumed. A held session cookie:

```
before the secret changed  →  200
after                      →  307  (bounced to sign-in)
signing in again           →  works immediately
```

Passwords and passkeys untouched.

## The logical path too

A row deleted, then `pg_restore --clean --if-exists` from a `pg_dump` — brought it back with exit 0 and no errors.

## Verification

All suites green: `verify:auth`, `verify:queue` 83, `verify:upload` 53, `probe:security` 62, `verify:models` 29.

`docs/security-audit.md` records the exercise, since *"documented but never run"* was the honest description of this procedure until now, and is worth replacing with what was observed.