### PR TITLE
Follow the repository rename, including where redirects do not reach

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Please do **not** report security vulnerabilities here — see
-        [SECURITY.md](https://github.com/danileau/ppp/blob/main/SECURITY.md)
+        [SECURITY.md](https://github.com/danileau/prettypleaseprint/blob/main/SECURITY.md)
         for the private route.
   - type: textarea
     id: expected

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/danileau/ppp/security/advisories/new
+    url: https://github.com/danileau/prettypleaseprint/security/advisories/new
     about: Report privately, never as a public issue. See SECURITY.md.
   - name: Deployment trouble
-    url: https://github.com/danileau/ppp#troubleshooting
+    url: https://github.com/danileau/prettypleaseprint#troubleshooting
     about: 502s, registry auth, certificates and the bootstrap link are covered in the README.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
         This app is built for a handful of people and one printer, and is
         deliberately narrow. Ideas that only make sense at a hundred users are
         likely to be declined — see
-        [CONTRIBUTING.md](https://github.com/danileau/ppp/blob/main/CONTRIBUTING.md).
+        [CONTRIBUTING.md](https://github.com/danileau/prettypleaseprint/blob/main/CONTRIBUTING.md).
   - type: textarea
     id: problem
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Changed
+
+- **The repository is now `danileau/prettypleaseprint`.** GitHub redirects the
+  old path — web, git remotes and the API — so clones and links keep working.
+  Two things redirects do not cover, both handled here:
+
+  - **Keyless signatures embed the repository path.** Images built before the
+    rename carry `…/danileau/ppp/…` in their certificate identity and images
+    built after carry the new one, so verifying against a single name would
+    make either today's image or every rollback target fail. The deploy wizard
+    now accepts both, and rejects everything else — a fork, another workflow,
+    another branch. Drop the old alternative once nothing you would roll back
+    to predates the rename.
+  - **The wizard did not follow redirects.** `curl` without `-L` against a
+    renamed repository returns an empty body that looks exactly like "nothing
+    published". It follows them now, which also makes it survive the next
+    rename.
+
+  **The container images keep their names** — `ppp-app` and `ppp-migrate`.
+  They are named by the release workflow, not by the repository, so nothing
+  deployed has to change. Renaming them would break every pinned `PPP_TAG`
+  and orphan `v0.1.0` in exchange for tidiness.
+
 ### Added
 
 - **`Done` is now the end of the flow**, and a ticket marked Done leaves the

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pretty Please Print
 
-[![CI](https://github.com/danileau/ppp/actions/workflows/ci.yml/badge.svg)](https://github.com/danileau/ppp/actions/workflows/ci.yml)
+[![CI](https://github.com/danileau/prettypleaseprint/actions/workflows/ci.yml/badge.svg)](https://github.com/danileau/prettypleaseprint/actions/workflows/ci.yml)
 [![Licence: AGPL-3.0](https://img.shields.io/badge/licence-AGPL--3.0-blue.svg)](LICENSE)
 [![Self-hosted](https://img.shields.io/badge/self--hosted-docker%20compose-2496ed)](docs/deployment.md)
-[![Stars](https://img.shields.io/github/stars/danileau/ppp?style=flat)](https://github.com/danileau/ppp/stargazers)
-[![Forks](https://img.shields.io/github/forks/danileau/ppp?style=flat)](https://github.com/danileau/ppp/network/members)
+[![Stars](https://img.shields.io/github/stars/danileau/prettypleaseprint?style=flat)](https://github.com/danileau/prettypleaseprint/stargazers)
+[![Forks](https://img.shields.io/github/forks/danileau/prettypleaseprint?style=flat)](https://github.com/danileau/prettypleaseprint/network/members)
 
 **Invite-only 3D print requests for a small office.** One person owns the
 printer. Everyone else uploads a model, says what they are hoping for, and
@@ -62,7 +62,7 @@ that: there is no multi-tenancy, no billing, and no queue theory.
 ## Quick start
 
 ```bash
-git clone https://github.com/danileau/ppp.git && cd ppp
+git clone https://github.com/danileau/prettypleaseprint.git && cd prettypleaseprint
 cp .env.docker.example .env.docker
 ```
 
@@ -147,6 +147,10 @@ Every merge to `main` publishes images tagged with the commit SHA and `latest`;
 every `v*` tag publishes that same commit under its version. Pin `PPP_TAG` to a
 release if you want to move deliberately, or to a SHA if you want to follow
 `main` closely.
+
+The images are named `ppp-app` and `ppp-migrate` — after the project's old
+short name, kept deliberately because they are a deployment interface. Renaming
+them would break every pinned `PPP_TAG` in exchange for nothing.
 
 The images are **public**, so a deployment needs no registry credential at all.
 `scripts/deploy-wizard.sh` reflects that: run it without a token and it lists

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please report security issues **privately**, not as a public issue.
 
-- **Preferred:** [open a private advisory](https://github.com/danileau/ppp/security/advisories/new)
+- **Preferred:** [open a private advisory](https://github.com/danileau/prettypleaseprint/security/advisories/new)
   on this repository. It is visible only to the maintainers until a fix ships.
 - **Otherwise:** email <danilo.licitra@gmail.com> with `[ppp security]` in the
   subject.

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "author": "Danilo Licitra",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/danileau/ppp.git"
+    "url": "git+https://github.com/danileau/prettypleaseprint.git"
   },
-  "homepage": "https://github.com/danileau/ppp#readme",
+  "homepage": "https://github.com/danileau/prettypleaseprint#readme",
   "bugs": {
-    "url": "https://github.com/danileau/ppp/issues"
+    "url": "https://github.com/danileau/prettypleaseprint/issues"
   },
   "type": "module",
   "scripts": {

--- a/scripts/deploy-wizard.sh
+++ b/scripts/deploy-wizard.sh
@@ -46,7 +46,7 @@ PROJECT_DIR="${PPP_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 HEALTH_URL="${PPP_HEALTH_URL:-https://ppp.danileau.com/api/health}"
 REGISTRY_OWNER="${PPP_REGISTRY_OWNER:-danileau}"
-REPO="${PPP_REPO:-danileau/ppp}"
+REPO="${PPP_REPO:-danileau/prettypleaseprint}"
 IMAGES="${PPP_IMAGES:-ppp-app ppp-migrate}"
 WINDOW="${PPP_WINDOW:-15}"
 HEALTH_TIMEOUT="${PPP_HEALTH_TIMEOUT:-300}"
@@ -181,14 +181,16 @@ read_token
 if [ -n "$TOKEN" ]; then
   echo "${DIM}→ asking ghcr.io what is published…${R}"
   SOURCE_LABEL="every published image"
-  VERSIONS="$(curl -sS --max-time 20 \
+  # -L because a renamed repository answers 301 here, and an unfollowed
+  # redirect returns an empty body that looks exactly like "nothing published".
+  VERSIONS="$(curl -sSL --max-time 20 \
     -H "Authorization: Bearer $TOKEN" \
     -H "Accept: application/vnd.github+json" \
     "https://api.github.com/user/packages/container/ppp-app/versions?per_page=100" 2>/dev/null || true)"
 else
   echo "${DIM}→ asking GitHub what has been released…${R}"
   SOURCE_LABEL="releases only (no token given)"
-  VERSIONS="$(curl -sS --max-time 20 \
+  VERSIONS="$(curl -sSL --max-time 20 \
     -H "Accept: application/vnd.github+json" \
     "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null || true)"
 fi
@@ -327,9 +329,20 @@ read -r ans; case "$ans" in y|Y|yes|YES) ;; *) echo "aborted."; exit 0 ;; esac
 # silently skipped.
 if command -v cosign >/dev/null; then
   echo "${DIM}→ verifying signatures…${R}"
+  # Keyless signing embeds the workflow's identity, and that identity contains
+  # the repository PATH — so renaming the repository splits the published
+  # images in two: everything built before it carries the old path, everything
+  # after carries the new one. Verifying against only one of them means either
+  # today's image or every rollback target fails, and the wizard refuses to
+  # deploy a perfectly good image.
+  #
+  # The signature itself is unaffected: it is over the digest, and the old ones
+  # remain valid. Only the pattern has to admit both names. Drop the old
+  # alternative once nothing you would roll back to predates the rename.
+  IDENTITY="^https://github\.com/danileau/(prettypleaseprint|ppp)/\.github/workflows/release-images\.yml@refs/heads/main$"
   for img in $IMAGES; do
     if cosign verify \
-        --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/release-images\.yml@refs/heads/main$" \
+        --certificate-identity-regexp "$IDENTITY" \
         --certificate-oidc-issuer https://token.actions.githubusercontent.com \
         "ghcr.io/${REGISTRY_OWNER}/${img}:${TARGET}" >/dev/null 2>&1; then
       echo "  ${GRN}✓${R} ${img}:${TARGET} signed by release-images on ${REPO}"

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -24,5 +24,5 @@ export const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
  * footer points at source that is not what is running.
  */
 export function sourceUrl(): string {
-  return process.env.SOURCE_URL ?? "https://github.com/danileau/ppp";
+  return process.env.SOURCE_URL ?? "https://github.com/danileau/prettypleaseprint";
 }


### PR DESCRIPTION
The repository is `danileau/prettypleaseprint` now. GitHub redirects the old path — web, git remotes, and the API (`301`) — so clones, links and existing checkouts keep working.

**Two things redirects do not cover.**

## Keyless signatures embed the repository path

Every image built *before* the rename carries `…/danileau/ppp/…` in its certificate identity; everything built *after* carries the new one.

The deploy wizard pinned that identity to a single name. Update it naively and **every rollback target fails verification** — including `v0.1.0`. Leave it alone and the next image built fails instead. Either way the wizard refuses to deploy a perfectly good image, and the error says "failed signature verification", which reads like a supply-chain attack rather than a rename.

It accepts both now, and still rejects everything else. Checked rather than eyeballed:

```
ok   pre-rename  (v0.1.0 and every SHA)   accepted=True
ok   post-rename (everything from now)    accepted=True
ok   a fork                               accepted=False
ok   a different workflow                 accepted=False
ok   a branch that is not main            accepted=False
ok   a lookalike repo name                accepted=False
```

The signatures themselves are unaffected — they are over the digest and remain valid. Only the pattern had to admit both names. Drop the old alternative once nothing you would roll back to predates the rename.

## The wizard did not follow redirects

`curl` without `-L` against a renamed repository returns an empty body, which the wizard reports as *"could not read the list"* — indistinguishable from a bad token, and it would have sent someone hunting for a scope problem that isn't there. It follows them now, which also makes it survive the *next* rename rather than only this one.

## The images keep their names

`ppp-app` and `ppp-migrate` are named by the release workflow, not the repository, so nothing deployed has to change and `v0.1.0` stays pullable. Renaming them would break every pinned `PPP_TAG` and orphan the existing release in exchange for tidiness — a bad trade for something that is a deployment interface. The README now says so, where somebody would otherwise wonder.

## Everything else

Badges, issue templates, the security policy's advisory link, `package.json`, and the `SOURCE_URL` default that the AGPL footer points at.

> Merging this publishes the first image signed under the **new** identity — which is exactly why the dual-identity fix is in this PR rather than a follow-up.