### PR TITLE
Release images could never pass signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Fixed
+
+- **Release images could never pass signature verification.** A tag-triggered
+  build signs with `refs/tags/<tag>`, not `refs/heads/main`, so the deploy
+  wizard's identity pattern — written for branch builds — rejected exactly the
+  images a deployment is supposed to pin. The bug was invisible because
+  without cosign installed the wizard skips the check and says so; it would
+  have surfaced the first time anyone installed it. Found by verifying a real
+  signature rather than by reading the workflow.
+
+  The wizard also looks for `cosign` beside the project now, not only on PATH.
+  On a host whose OS filesystem is replaced by updates, a binary in
+  `/usr/local/bin` disappears and the check stops happening silently — which
+  is worse than never having had it.
+
 ### Changed
 
 - **The repository is now `danileau/prettypleaseprint`.** GitHub redirects the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,6 +99,50 @@ docker compose --env-file .env.docker \
 
 Deploying is a human action by design. Nothing in CI reaches into the NAS.
 
+
+### Verifying signatures (and where cosign has to live)
+
+CI signs every image with cosign keyless, which is what protects the
+registry-to-host link against a substituted image. The wizard checks that
+before it swaps anything — but only if it can find `cosign`, and it says so
+loudly when it cannot rather than skipping quietly.
+
+**Do not install it into the OS.** TrueNAS and similar appliances replace the
+system filesystem on update, taking `/usr/local/bin` with it — the check would
+silently stop happening at the next upgrade, which is worse than never having
+had it. Put the binary on the same dataset as the deployment, where the wizard
+also looks:
+
+```bash
+cd /mnt/<pool>/applications/ppp/app
+mkdir -p bin
+curl -fsSL -o bin/cosign \
+  https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+chmod +x bin/cosign
+./bin/cosign version
+```
+
+It is a single statically linked binary with no runtime dependencies, so there
+is nothing else to install.
+
+Verify by hand if you want to see it work:
+
+```bash
+./bin/cosign verify \
+  --certificate-identity-regexp '^https://github\.com/danileau/(prettypleaseprint|ppp)/\.github/workflows/release-images\.yml@refs/(heads/main|tags/v[0-9][0-9A-Za-z.\-]*)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/danileau/ppp-app:v0.1.0
+```
+
+Two things that alternation is carrying, both found by verifying a real
+signature rather than by reading the workflow:
+
+- **A tag build signs with `refs/tags/<tag>`, not `refs/heads/main`.** Release
+  images — the thing a deployment is meant to pin — therefore fail a pattern
+  written only for branch builds.
+- **Keyless signing embeds the repository path**, so images built before the
+  repository was renamed carry the old one and stay verifiable.
+
 ### The deploy wizard
 
 `scripts/deploy-wizard.sh` is the single entry point for a deploy. Copy it next

--- a/scripts/deploy-wizard.sh
+++ b/scripts/deploy-wizard.sh
@@ -327,8 +327,14 @@ read -r ans; case "$ans" in y|Y|yes|YES) ;; *) echo "aborted."; exit 0 ;; esac
 # registry-to-NAS link against a substituted or tampered image, so it is
 # checked BEFORE anything is swapped — and its absence is reported, never
 # silently skipped.
-if command -v cosign >/dev/null; then
-  echo "${DIM}→ verifying signatures…${R}"
+# TrueNAS and friends replace the OS filesystem on update, taking anything
+# installed into it. So look beside the project as well as on PATH: a binary on
+# the data dataset survives, and one in /usr/local/bin does not.
+COSIGN="$(command -v cosign 2>/dev/null || true)"
+[ -z "$COSIGN" ] && [ -x "$PROJECT_DIR/bin/cosign" ] && COSIGN="$PROJECT_DIR/bin/cosign"
+
+if [ -n "$COSIGN" ]; then
+  echo "${DIM}→ verifying signatures with ${COSIGN}…${R}"
   # Keyless signing embeds the workflow's identity, and that identity contains
   # the repository PATH — so renaming the repository splits the published
   # images in two: everything built before it carries the old path, everything
@@ -339,9 +345,21 @@ if command -v cosign >/dev/null; then
   # The signature itself is unaffected: it is over the digest, and the old ones
   # remain valid. Only the pattern has to admit both names. Drop the old
   # alternative once nothing you would roll back to predates the rename.
-  IDENTITY="^https://github\.com/danileau/(prettypleaseprint|ppp)/\.github/workflows/release-images\.yml@refs/heads/main$"
+  # Two alternations, both learned by verifying a real signature rather than
+  # by reading the workflow.
+  #
+  # The REF: a tag build signs with refs/tags/<tag>, not refs/heads/main. So
+  # every release image — the thing a deployment is meant to pin — failed
+  # verification, while branch builds passed. The bug was invisible until
+  # cosign was actually installed somewhere, because without it the wizard
+  # skips the check and says so.
+  #
+  # The REPO NAME: keyless signing embeds the repository path, so images built
+  # before the rename carry the old one. Both are admitted; a fork, another
+  # workflow, another branch and a non-version tag are not.
+  IDENTITY="^https://github\.com/danileau/(prettypleaseprint|ppp)/\.github/workflows/release-images\.yml@refs/(heads/main|tags/v[0-9][0-9A-Za-z.\-]*)$"
   for img in $IMAGES; do
-    if cosign verify \
+    if "$COSIGN" verify \
         --certificate-identity-regexp "$IDENTITY" \
         --certificate-oidc-issuer https://token.actions.githubusercontent.com \
         "ghcr.io/${REGISTRY_OWNER}/${img}:${TARGET}" >/dev/null 2>&1; then
@@ -351,10 +369,18 @@ if command -v cosign >/dev/null; then
     fi
   done
 else
-  echo "${YLW}⚠ cosign is not installed — signatures were NOT checked.${R}"
+  echo "${YLW}⚠ cosign was not found — signatures were NOT checked.${R}"
   echo "  ${DIM}The images are still pulled by tag over TLS, but nothing proves they"
-  echo "  came from this repo's workflow. Install cosign to close that gap:"
-  echo "  https://docs.sigstore.dev/cosign/installation/${R}"
+  echo "  came from this repo's workflow. One static binary closes that gap, and"
+  echo "  on a host whose OS is replaced by updates it belongs beside the"
+  echo "  project rather than in /usr/local/bin:"
+  echo
+  echo "      mkdir -p ${PROJECT_DIR}/bin"
+  echo "      curl -fsSL -o ${PROJECT_DIR}/bin/cosign \\"
+  echo "        https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64"
+  echo "      chmod +x ${PROJECT_DIR}/bin/cosign"
+  echo
+  echo "  This wizard looks there as well as on PATH.${R}"
   printf "Continue without verification? [y/N] "
   read -r ans; case "$ans" in y|Y|yes|YES) ;; *) echo "aborted."; exit 0 ;; esac
 fi


### PR DESCRIPTION
Installing cosign for the first time is what exposed this.

**A tag-triggered build signs with `refs/tags/<tag>`, not `refs/heads/main`.** The wizard's identity pattern was written for branch builds and never tested against a real signature, so it rejected exactly the images a deployment is meant to pin.

The real subject on `v0.1.0`:

```
https://github.com/danileau/ppp/.github/workflows/release-images.yml@refs/tags/v0.1.0
```

against a pattern demanding `@refs/heads/main`. Every release would have been refused with *"failed signature verification"* — which reads like a supply-chain attack rather than a bad regexp.

## The shape of the bug is the worst kind

It was **invisible** because without cosign the wizard skips the check and says so. The gap only opens when somebody closes the other one: dormant until the moment you improve your security posture, then failing in a way that looks exactly like the threat you were protecting against.

## Fixed and verified against reality

The pattern admits `refs/heads/main` and `refs/tags/v*`, alongside both repository names from the rename.

Verified against **all four published images** — `ppp-app` and `ppp-migrate`, at `v0.1.0` and `latest` — all four now verify. And against eight identity cases:

```
ok  release tag, old repo name        accepted=True
ok  release tag, new repo name        accepted=True
ok  main branch build                 accepted=True
ok  a fork                            accepted=False
ok  another workflow                  accepted=False
ok  a feature branch                  accepted=False
ok  an arbitrary tag, not a version   accepted=False
ok  lookalike repo                    accepted=False
```

## Where cosign has to live

The wizard now looks beside the project as well as on PATH. **TrueNAS and similar appliances replace the OS filesystem on update**, so a binary in `/usr/local/bin` disappears at the next upgrade and the check stops happening silently — worse than never having had it.

The "not found" message now prints the command to put it on the data dataset, instead of linking to install docs that recommend the place it will be deleted from. `docs/deployment.md` explains the same, with a by-hand verification command.