### PR TITLE
Open a model straight in PrusaSlicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Notable changes. Every entry names a released version; deployments pin
 
 ### Added
 
+- **Open a model straight in PrusaSlicer**, from a control on every ticket. A
+  click hands the model to a slicer running on the person's own machine.
+
+  The obvious route does not exist: PrusaSlicer's `prusaslicer://open?file=`
+  deep link only downloads from a hardcoded allowlist — Printables, Thingiverse,
+  Cults — with no setting to add a self-hosted host, and the requests to make it
+  configurable were closed as not planned. So instead of asking the slicer to
+  download, a small helper the printer owner installs once
+  (`scripts/prusa-open.sh`, registered for a `ppp://` scheme by
+  `scripts/install-slicer-handler.sh`) fetches the bytes through the API added
+  below and hands the slicer a *local file* — which has no domain to check. It
+  adds nothing to the server and needs no client bundle: a `ppp://` link invokes
+  the OS handler rather than making a request, so the CSP does not govern it.
+  Docs at [`docs/prusaslicer.md`](docs/prusaslicer.md); works with OrcaSlicer or
+  any slicer that opens a file from the command line.
+
 - **A JSON API, an OpenAPI document, and a console at `/docs`.** Everything the
   board and the queue can do is now reachable over HTTP: list and read tickets,
   move one along, decline, flag and unflag, comment, withdraw, read and clear

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ that: there is no multi-tenancy, no billing, and no queue theory.
   Swagger console at `/docs`. Same session, same scope, same audit trail as the
   UI; the rules live in one place, so the API cannot enforce less than the
   board does. See **[the API](docs/api.md)**.
+- **Open a model straight in PrusaSlicer** — one click on a ticket hands the
+  model to a slicer running on your own machine. A small helper the printer
+  owner installs once does the fetch, because PrusaSlicer's own deep link
+  refuses any host but Printables. See **[Open in PrusaSlicer](docs/prusaslicer.md)**.
 
 ## Requirements
 
@@ -337,6 +341,7 @@ has no outbound internet, set `HIBP_DISABLED=true` — and only then.
 | **[Architecture](docs/architecture.md)** | the viewer, upload validation, decisions taken against the design handoff, and the file layout |
 | **[Deployment](docs/deployment.md)** | containers, reverse proxies, the deploy wizard, TLS, first run |
 | **[The API](docs/api.md)** | the JSON surface, bearer tokens, the OpenAPI document and the console at `/docs` |
+| **[Open in PrusaSlicer](docs/prusaslicer.md)** | the one-click "send to the slicer" bridge, the helper, and why the deep link cannot be used |
 | **[Development](docs/development.md)** | stack, local setup, the verification suites, CI |
 | **[Security audit](docs/security-audit.md)** | the OWASP Top 10 assessment, findings, and residual risk accepted |
 | **[Security policy](SECURITY.md)** | how to report a vulnerability |

--- a/docs/prusaslicer.md
+++ b/docs/prusaslicer.md
@@ -1,0 +1,143 @@
+# Open in PrusaSlicer
+
+[← back to the README](../README.md)
+
+Every ticket has an **Open in PrusaSlicer** control. Clicking it fetches the
+model and opens it in PrusaSlicer on the machine you clicked from. This page is
+how to set that up once, and why it works the way it does.
+
+## Why it is not a one-line deep link
+
+PrusaSlicer has its own scheme — `prusaslicer://open?file=<url>` — and it would
+have been two lines to emit. It does not work here, and cannot be made to:
+
+> PrusaSlicer only downloads from a **hardcoded allowlist**: `printables.com`,
+> `thingiverse.com`, `cults3d.com`. There is no setting to add a domain. The
+> requests to make it configurable were closed as *not planned*
+> ([#13752](https://github.com/prusa3d/PrusaSlicer/issues/13752),
+> [#14313](https://github.com/prusa3d/PrusaSlicer/issues/14313)); Prusa adds
+> domains one at a time after a security review, on request.
+
+A self-hosted instance on your own hostname can never be on that list. And the
+allowlist is checked against the **URL string** PrusaSlicer is handed, before
+it makes any request — so there is no header on any request to us that could
+be set to look like Printables. (Trying to disguise the URL to slip past the
+check is a parser-confusion trick: brittle, it breaks the next time Prusa
+tightens the check, and it re-opens for you the exact hole the allowlist
+exists to close.)
+
+So the model is fetched by **a small helper on your own machine**, which hands
+PrusaSlicer a **local file**. A local file has no domain to check, so the
+allowlist never applies — that is the design, not a loophole. The helper is the
+only new moving part, and it talks to nothing but this app's own API.
+
+```
+ Browser                 Helper on your machine            This app
+ ───────                 ──────────────────────            ────────
+ click  ──ppp://slice/104──▶ prusa-open.sh
+                            GET /api/models/104  ───────────▶  (bearer token)
+                            ◀───────────────────── the .stl bytes
+                            writes /tmp/…/PPP-104-clip.stl
+                            prusa-slicer --single-instance <that file>
+```
+
+## Setup (Linux)
+
+On the machine with the printer, PrusaSlicer and your browser, from a checkout
+of this repo:
+
+```bash
+./scripts/install-slicer-handler.sh
+```
+
+That registers `ppp://` links to open with
+[`scripts/prusa-open.sh`](../scripts/prusa-open.sh), and creates
+`~/.config/ppp/slicer.conf` (mode `600`) for you to fill in:
+
+```sh
+PPP_BASE="https://print.example"      # your instance, no trailing slash
+PPP_TOKEN="…"                          # a bearer token — see below
+# PPP_SLICER="prusa-slicer"            # or the full path to an AppImage
+# PPP_DOWNLOAD_DIR="$HOME/.cache/ppp/models"
+```
+
+Get a token by signing in — and keep it out of your shell history:
+
+```bash
+curl -si https://print.example/api/auth/sign-in/username \
+  -H 'content-type: application/json' \
+  -d '{"username":"you","password":"…"}' | grep -i '^set-auth-token:'
+```
+
+The token **is** your session token: it carries your account's access and no
+more, and signing out of the app revokes it. That is also why the config file
+is `600` — it holds a credential. See [the API](api.md#authentication) for the
+full picture on bearer tokens.
+
+Now click **Open in PrusaSlicer** on any ticket. Nothing to paste — the link
+carries only the ticket number; the address and the token live in the config.
+
+## When it does not work
+
+A `ppp://` link with no handler installed does **nothing** — that is the
+browser, not a bug, and it is why the button says as much. Everything the
+helper does, and every refusal, is logged:
+
+```bash
+tail -f "${XDG_STATE_HOME:-$HOME/.local/state}/ppp/slicer.log"
+```
+
+Failures also raise a desktop notification where `notify-send` exists, because
+a protocol handler has no terminal and a click that silently fails is
+indistinguishable from one that was never wired up. Common lines:
+
+| It says | Means |
+| --- | --- |
+| `no config at …` | The installer has not run, or `$PPP_SLICER_CONF` points elsewhere. |
+| `not authorised (HTTP 401)` | The token is wrong, expired, or was revoked by signing out. Mint a new one. |
+| `story N … not one this account may see (HTTP 404)` | That ticket is not yours, or does not exist. |
+| `slicer '…' not found on PATH` | Set `PPP_SLICER` to the binary — an AppImage needs its full path. |
+| `WARNING: … is group/world-readable` | `chmod 600 ~/.config/ppp/slicer.conf`. |
+
+## macOS and Windows
+
+The installer is Linux/XDG only. The helper script itself is portable (`bash` +
+`curl`); only the scheme registration differs.
+
+**macOS** — register `ppp://` with a tiny app wrapper. In *Script Editor*, save
+an application that runs:
+
+```applescript
+on open location this_URL
+  do shell script "/path/to/prusa-open.sh " & quoted form of this_URL
+end open location
+```
+
+and add `CFBundleURLSchemes` = `ppp` to its `Info.plist`. Set `PPP_SLICER` to
+`/Applications/Original Prusa Drivers/PrusaSlicer.app/Contents/MacOS/PrusaSlicer`.
+
+**Windows** — the helper needs a `bash` (Git Bash / WSL). Register the scheme
+with a `.reg` file:
+
+```reg
+Windows Registry Editor Version 5.00
+[HKEY_CLASSES_ROOT\ppp]
+@="URL:Pretty Please Print"
+"URL Protocol"=""
+[HKEY_CLASSES_ROOT\ppp\shell\open\command]
+@="\"C:\\Program Files\\Git\\bin\\bash.exe\" \"C:/path/to/prusa-open.sh\" \"%1\""
+```
+
+Both are untested here and offered as starting points — the Linux path is the
+supported one, matching the app's own "one printer, one office" shape.
+
+## OrcaSlicer, and other slicers
+
+The helper opens whatever `PPP_SLICER` points at — it is not tied to Prusa.
+OrcaSlicer, for instance, opens `.stl`/`.3mf` from the command line the same
+way, so `PPP_SLICER="orca-slicer"` (or the AppImage path) works unchanged.
+
+OrcaSlicer also has its own `orcaslicer://open?file=` scheme, and unlike
+PrusaSlicer it is not obviously locked to an allowlist — if a future version
+accepts arbitrary hosts, a direct deep link becomes possible for Orca users and
+this helper stays the fallback. Nothing here depends on that.

--- a/scripts/install-slicer-handler.sh
+++ b/scripts/install-slicer-handler.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Register prusa-open.sh as the handler for `ppp://` links on this Linux
+# desktop, and lay down a config skeleton for it to read.
+#
+# Run it once, on the machine that has the printer and PrusaSlicer:
+#   ./scripts/install-slicer-handler.sh
+#
+# What it does, all under your own home directory — nothing system-wide, no
+# sudo:
+#   1. writes a .desktop entry into ~/.local/share/applications that points at
+#      this checkout's prusa-open.sh by absolute path;
+#   2. makes it the default handler for the x-scheme-handler/ppp MIME type;
+#   3. creates ~/.config/ppp/slicer.conf (mode 600) for you to fill in, if it
+#      is not already there.
+#
+# macOS and Windows register a scheme differently (a .app/Info.plist and a
+# registry key respectively) — docs/prusaslicer.md has both. This installer is
+# Linux/XDG only, and says so rather than pretending to work elsewhere.
+
+set -euo pipefail
+
+case "$(uname -s)" in
+  Linux) : ;;
+  *) echo "This installer is Linux/XDG only. See docs/prusaslicer.md for macOS and Windows." >&2
+     exit 1 ;;
+esac
+
+here="$(cd "$(dirname "$0")" && pwd)"
+handler="$here/prusa-open.sh"
+[ -f "$handler" ] || { echo "prusa-open.sh is not beside this installer ($handler)" >&2; exit 1; }
+chmod +x "$handler"
+
+apps_dir="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+desktop="$apps_dir/ppp-slicer.desktop"
+mkdir -p "$apps_dir"
+
+# %u is the clicked URL, passed through to the handler as its one argument.
+cat >"$desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=Pretty Please Print → PrusaSlicer
+Comment=Open a ppp:// model link in PrusaSlicer
+Exec=$handler %u
+Terminal=false
+NoDisplay=true
+MimeType=x-scheme-handler/ppp;
+DESKTOP
+
+echo "wrote $desktop"
+
+# Make it the default for the scheme. xdg-mime is the portable way; if it is
+# absent, fall back to editing mimeapps.list directly so this still works on a
+# minimal install.
+if command -v xdg-mime >/dev/null 2>&1; then
+  xdg-mime default ppp-slicer.desktop x-scheme-handler/ppp
+  echo "registered ppp:// via xdg-mime"
+else
+  mimeapps="${XDG_CONFIG_HOME:-$HOME/.config}/mimeapps.list"
+  touch "$mimeapps"
+  if ! grep -q '^x-scheme-handler/ppp=' "$mimeapps" 2>/dev/null; then
+    grep -q '^\[Default Applications\]' "$mimeapps" 2>/dev/null || printf '[Default Applications]\n' >>"$mimeapps"
+    # Insert the mapping under the Default Applications header.
+    tmp="$(mktemp)"
+    awk '/^\[Default Applications\]/ { print; print "x-scheme-handler/ppp=ppp-slicer.desktop"; next } { print }' \
+      "$mimeapps" >"$tmp" && mv "$tmp" "$mimeapps"
+  fi
+  echo "registered ppp:// in $mimeapps (xdg-mime not found)"
+fi
+
+command -v update-desktop-database >/dev/null 2>&1 &&
+  update-desktop-database "$apps_dir" 2>/dev/null || true
+
+# Config skeleton — never overwrite an existing one, and lock it down, because
+# it is about to hold a bearer token.
+conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ppp"
+conf="$conf_dir/slicer.conf"
+mkdir -p "$conf_dir"
+if [ -f "$conf" ]; then
+  echo "left your existing config alone: $conf"
+else
+  umask 077
+  cat >"$conf" <<'CONF'
+# Pretty Please Print → PrusaSlicer bridge config. Read by prusa-open.sh.
+# This file holds a credential: keep it mode 600 (this file was created so).
+
+# The instance, no trailing slash.
+PPP_BASE="https://print.example"
+
+# A bearer token. It is your session token, so signing out of the app revokes
+# it. Mint one — and keep it out of your shell history:
+#   curl -si "$PPP_BASE/api/auth/sign-in/username" \
+#     -H 'content-type: application/json' \
+#     -d '{"username":"you","password":"..."}' | grep -i '^set-auth-token:'
+PPP_TOKEN="paste-the-set-auth-token-value-here"
+
+# Optional. The slicer binary; give a full path for an AppImage.
+# PPP_SLICER="prusa-slicer"
+
+# Optional. Where fetched models are cached (pruned after a day).
+# PPP_DOWNLOAD_DIR="$HOME/.cache/ppp/models"
+CONF
+  chmod 600 "$conf"
+  echo "created $conf (mode 600) — edit PPP_BASE and PPP_TOKEN"
+fi
+
+echo
+echo "Done. Set PPP_BASE and PPP_TOKEN in $conf, then click 'Open in PrusaSlicer'"
+echo "on any ticket. Trouble? tail -f \"\${XDG_STATE_HOME:-\$HOME/.local/state}/ppp/slicer.log\""

--- a/scripts/prusa-open.sh
+++ b/scripts/prusa-open.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# ppp → PrusaSlicer bridge. Handles a `ppp://slice/<id>` link by fetching the
+# model from a Pretty Please Print instance and opening it in a local slicer.
+#
+# Runs ON THE PERSON'S OWN MACHINE — the one with the printer, PrusaSlicer, and
+# a browser — not on the server. It is the whole reason "Open in PrusaSlicer"
+# can exist at all: PrusaSlicer's own `prusaslicer://open?file=` refuses any
+# URL that is not printables.com/thingiverse.com/cults3d.com, and there is no
+# setting to add a self-hosted host to that list. So instead of asking the
+# slicer to download, this downloads the bytes itself and hands the slicer a
+# *local file*, which has no domain to check. See docs/prusaslicer.md.
+#
+# Installed as the handler for the `ppp://` scheme by install-slicer-handler.sh.
+# Invoked by the desktop environment with one argument: the clicked URL.
+#
+# Config lives at $PPP_SLICER_CONF (default ~/.config/ppp/slicer.conf) and sets:
+#   PPP_BASE          the instance, e.g. https://print.example         (required)
+#   PPP_TOKEN         a bearer token from a sign-in response            (required)
+#   PPP_SLICER        the slicer binary            (default: prusa-slicer)
+#   PPP_DOWNLOAD_DIR  where fetched models land    (default: ~/.cache/ppp/models)
+#
+# The token IS the session token — signing out of the app revokes it. Get one
+# with, and keep it out of your shell history:
+#   curl -si $PPP_BASE/api/auth/sign-in/username \
+#     -H 'content-type: application/json' \
+#     -d '{"username":"you","password":"..."}' | grep -i '^set-auth-token:'
+#
+# Failures are made loud rather than swallowed: a protocol handler has no
+# terminal, so every error goes to a log AND a desktop notification (when
+# notify-send exists), because a click that silently does nothing is the worst
+# possible outcome — indistinguishable from "not installed".
+
+set -euo pipefail
+
+CONF="${PPP_SLICER_CONF:-$HOME/.config/ppp/slicer.conf}"
+LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ppp"
+LOG="$LOG_DIR/slicer.log"
+mkdir -p "$LOG_DIR"
+
+# --- loud failure -----------------------------------------------------------
+# Log with a timestamp, pop a desktop notification if we can, and leave a copy
+# on stderr for the case where this was run from a terminal to debug it.
+note() {
+  printf '%s  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >>"$LOG"
+}
+fail() {
+  note "ERROR: $1"
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send -u critical "Open in PrusaSlicer failed" "$1" || true
+  fi
+  printf 'prusa-open: %s\n' "$1" >&2
+  exit 1
+}
+
+# --- config -----------------------------------------------------------------
+[ -f "$CONF" ] || fail "no config at $CONF — run install-slicer-handler.sh first"
+
+# A token in a world-readable file is a credential anyone on the box can read.
+# Warn rather than refuse: on a single-user workstation it is a papercut, not a
+# breach, and refusing outright would strand somebody mid-print.
+if command -v stat >/dev/null 2>&1; then
+  # GNU stat, then BSD/macOS stat. The last two octal digits are the group and
+  # other bits; any non-zero there means someone besides the owner can read it.
+  perms="$(stat -c '%a' "$CONF" 2>/dev/null || stat -f '%Lp' "$CONF" 2>/dev/null || echo '')"
+  case "$perms" in
+    *[1-7][0-7] | *[0-7][1-7]) note "WARNING: $CONF is group/world-readable ($perms) — chmod 600 it" ;;
+  esac
+fi
+
+# shellcheck disable=SC1090
+. "$CONF"
+
+: "${PPP_BASE:?PPP_BASE is not set in $CONF}"
+: "${PPP_TOKEN:?PPP_TOKEN is not set in $CONF}"
+SLICER="${PPP_SLICER:-prusa-slicer}"
+DOWNLOAD_DIR="${PPP_DOWNLOAD_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/ppp/models}"
+
+# --- parse the link ---------------------------------------------------------
+# Accept ppp://slice/<id>, with or without a trailing slash. The id is the ONLY
+# thing taken from the URL, and it is validated to digits before it is ever put
+# in a request path — so a hostile link cannot smuggle anything into the fetch.
+url="${1:-}"
+[ -n "$url" ] || fail "no URL given — this is invoked by clicking a ppp:// link"
+
+id="${url#ppp://slice/}"
+id="${id%/}"
+case "$id" in
+  "" | *[!0-9]*) fail "not a model link: $url (expected ppp://slice/<number>)" ;;
+esac
+
+command -v curl >/dev/null 2>&1 || fail "curl is not installed"
+command -v "$SLICER" >/dev/null 2>&1 ||
+  fail "slicer '$SLICER' not found on PATH — set PPP_SLICER in $CONF (AppImage users: give the full path)"
+
+# --- fetch ------------------------------------------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+hdr="$tmp/headers"
+body="$tmp/body"
+
+note "fetching story $id from $PPP_BASE"
+# No --fail: let curl succeed on any HTTP status and read the code from -w, so
+# the `case` below can answer 401 and 404 in words rather than "curl (22)". A
+# non-zero exit here is a real transport failure — DNS, connection refused —
+# and that is what the `|| fail` catches.
+code="$(
+  curl -sS \
+    -o "$body" -D "$hdr" -w '%{http_code}' \
+    -H "Authorization: Bearer $PPP_TOKEN" \
+    "$PPP_BASE/api/models/$id" 2>"$tmp/err"
+)" || fail "could not reach $PPP_BASE: $(tr -d '\r' <"$tmp/err" | tail -n1)"
+
+case "$code" in
+  200) : ;;
+  401) fail "not authorised (HTTP 401) — the token in $CONF is missing, expired, or was revoked by signing out" ;;
+  404) fail "story $id is not there, or not one this account may see (HTTP 404)" ;;
+  *)   fail "server returned HTTP $code for story $id" ;;
+esac
+
+# The download route sets Content-Disposition with the original filename; take
+# it from there. `basename` is the traversal guard — even a hostile header can
+# only name a file, never a path.
+name="$(
+  grep -i '^content-disposition:' "$hdr" | tr -d '\r' |
+    sed -n 's/.*filename="\([^"]*\)".*/\1/p' | head -n1
+)"
+name="$(basename "${name:-model-$id.stl}")"
+case "$name" in "" | .*) name="model-$id.stl" ;; esac
+
+mkdir -p "$DOWNLOAD_DIR"
+# Prune anything older than a day so the cache cannot grow without bound. Done
+# before the move so the file we are about to open is never a prune target.
+find "$DOWNLOAD_DIR" -maxdepth 1 -type f -mtime +1 -delete 2>/dev/null || true
+
+out="$DOWNLOAD_DIR/PPP-$((100 + id))-$name"
+mv "$body" "$out"
+note "saved $out"
+
+# --- open -------------------------------------------------------------------
+# --single-instance so a second click loads the model into the window already
+# open rather than starting a race between two PrusaSlicers over the same file.
+note "opening in $SLICER"
+setsid "$SLICER" --single-instance "$out" >>"$LOG" 2>&1 &
+note "handed off story $id"

--- a/scripts/verify-queue.ts
+++ b/scripts/verify-queue.ts
@@ -498,6 +498,15 @@ async function main() {
   let storyPage = rendered(await (await client.go(`${APP}/story/${regret.id}`)).text());
   check("the requester is offered the control", storyPage.includes("Withdraw this request"));
 
+  // The "Open in PrusaSlicer" bridge is a bare ppp:// link the story page
+  // carries; a local helper handles it (docs/prusaslicer.md). Assert the link
+  // is present and carries this ticket's id, so the wiring cannot silently
+  // rot — the click's other half lives outside the app and cannot be tested
+  // here, but a missing or misnumbered link is the failure that would matter.
+  check("the story page offers Open in PrusaSlicer",
+        storyPage.includes(`ppp://slice/${regret.id}`),
+        "the ppp:// bridge link is missing or has the wrong id");
+
   const adminView = rendered(await (await ruben.go(`${APP}/story/${regret.id}`)).text());
   check("the printer owner is not — it is not their request",
         !adminView.includes("Withdraw this request"),

--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Fact, Notice, StatusChip } from "@/components/ui";
 import { AdminActions } from "@/components/admin-actions";
 import { Conversation } from "@/components/conversation";
 import { ModelViewer } from "@/components/model-viewer";
+import { OpenInSlicer } from "@/components/open-in-slicer";
 import { Toast } from "@/components/toast";
 import { WithdrawStory } from "@/components/withdraw-story";
 
@@ -73,6 +74,12 @@ export default async function StoryPage({
                 </span>
               ))}
             </div>
+
+            {/* Send the model to a PrusaSlicer on the viewer's own machine.
+                The bytes are fetched by a local helper, not by the slicer —
+                see the component and docs/prusaslicer.md for why. */}
+            <OpenInSlicer storyId={story.id} />
+
             <Conversation
               storyId={story.id}
               comments={story.comments}

--- a/src/components/open-in-slicer.tsx
+++ b/src/components/open-in-slicer.tsx
@@ -1,0 +1,60 @@
+import { storyRef } from "@/lib/scope";
+
+/**
+ * "Open in PrusaSlicer" — a link to the `ppp://` scheme a helper on the
+ * viewer's own machine handles.
+ *
+ * Why a bare `<a>` to a custom scheme rather than a download, a signed URL, or
+ * PrusaSlicer's own `prusaslicer://open?file=` deep link:
+ *
+ *   - `prusaslicer://` only downloads from a hardcoded allowlist
+ *     (printables.com, thingiverse.com, cults3d.com) and there is no setting
+ *     to add to it — a self-hosted instance can never be on that list. See
+ *     docs/prusaslicer.md.
+ *   - So the file is fetched by a small helper the printer owner installs
+ *     once (`scripts/prusa-open.sh`), which hands PrusaSlicer a *local* path.
+ *     A local file has no domain to check, so the allowlist never applies —
+ *     that is the design, not a loophole.
+ *
+ * This link therefore adds nothing to the server and needs no client bundle:
+ * clicking it invokes the OS protocol handler, which is not a fetch, so the
+ * CSP does not govern it and there is no JavaScript here. On a machine with no
+ * helper installed the click simply does nothing — the copy says as much, and
+ * links to the one-time setup.
+ *
+ * The link carries only the numeric id. The base URL and the credential live
+ * in the helper's own config on the owner's machine, never in the page.
+ */
+export function OpenInSlicer({ storyId }: { storyId: number }) {
+  return (
+    <details className="group mt-[13.2px]">
+      <summary className="stamp inline-flex cursor-pointer list-none items-center gap-[8px] rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-sun">
+        {/* An unadorned wedge, not a brand mark — nothing here claims to be Prusa's. */}
+        <span aria-hidden className="font-mono text-[15px] leading-none">▸</span>
+        Open in PrusaSlicer
+      </summary>
+
+      <div className="mt-[8.8px] rounded-card border-[3px] border-ink bg-cream-2 p-[13.2px]">
+        <a
+          href={`ppp://slice/${storyId}`}
+          className="stamp inline-block cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[18px] py-[8px] text-[14px] font-bold text-cream hover:bg-cherry"
+        >
+          Send {storyRef(storyId)} to the slicer
+        </a>
+        <p className="m-0 mt-[8.8px] font-mono text-[11px] leading-[1.5] text-ink-2">
+          Opens PrusaSlicer on <strong>this</strong> machine. Needs the one-time
+          helper — see{" "}
+          <a
+            href="https://github.com/danileau/prettypleaseprint/blob/main/docs/prusaslicer.md"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="underline underline-offset-2 hover:text-cherry-dk"
+          >
+            the setup
+          </a>
+          . Nothing happens if it is not installed.
+        </p>
+      </div>
+    </details>
+  );
+}


### PR DESCRIPTION
Builds on the JSON API from #23 (merged). Every ticket now has an **Open in
PrusaSlicer** control: one click hands the model to a slicer running on the
clicker's own machine.

[`docs/prusaslicer.md`](https://github.com/danileau/prettypleaseprint/blob/prusaslicer-open/docs/prusaslicer.md)
is the setup and the full reasoning.

## Why not the obvious deep link

PrusaSlicer's own `prusaslicer://open?file=<url>` only downloads from a
**hardcoded allowlist** — printables.com, thingiverse.com, cults3d.com — with
no setting to add a host. The requests to make it configurable were closed as
*not planned* ([#13752](https://github.com/prusa3d/PrusaSlicer/issues/13752),
[#14313](https://github.com/prusa3d/PrusaSlicer/issues/14313)). A self-hosted
instance can never be on that list, and the check is on the URL string it is
handed — before any request — so there is no header on a request to us that
could be dressed up as Printables.

So the bytes are fetched by a **small helper on the person's own machine**,
which hands the slicer a **local file**. A local file has no domain to check,
so the allowlist never applies — that is the design, not a bypass.

```
click ──ppp://slice/104──▶ prusa-open.sh ──GET /api/models/104──▶ this app
                           writes /tmp/…/PPP-104-clip.stl
                           prusa-slicer --single-instance <that file>
```

## What's here

- **`scripts/prusa-open.sh`** — handles a `ppp://slice/<id>` link: reads a
  bearer token from `~/.config/ppp/slicer.conf`, fetches the model, names it
  from `Content-Disposition` (basename-guarded), and launches the slicer with
  `--single-instance`. The id is validated to digits before it touches a
  request path. Failures are **loud** — a log line plus a desktop notification —
  because a protocol handler has no terminal, and a silent click is
  indistinguishable from "not installed".
- **`scripts/install-slicer-handler.sh`** — registers the `ppp://` scheme on
  Linux (XDG `.desktop`) and writes a mode-`600` config skeleton. macOS and
  Windows registration are documented, not scripted.
- **`src/components/open-in-slicer.tsx`** — the control on the story page. Adds
  nothing to the server and no client bundle: a custom-scheme link invokes the
  OS handler rather than making a request, so the CSP does not govern it (there
  is no `navigate-to` directive to relax). No helper installed → the click does
  nothing, and the copy says so.

Works with OrcaSlicer or any slicer that opens a file from the command line —
the helper opens whatever `PPP_SLICER` points at.

## Testing

- The handler was exercised end-to-end against a stub instance + stub slicer:
  happy path (correct local file, `--single-instance`), path-traversal refusal
  (`ppp://slice/../etc/passwd`), 404, 401, connection-refused, missing-config,
  and trailing-slash tolerance — each with the right message.
- The installer was run in an isolated `HOME`: correct absolute-path `.desktop`,
  `xdg-mime` registration, and a mode-`600` config.
- `verify:queue` gains a check that the story page carries the
  `ppp://slice/<id>` link with the right id (**98 checks, 0 failed**). The
  click's other half lives outside the app and can't be tested here, but a
  missing or misnumbered link is the failure that would matter.
- `typecheck`, `check:links`, `verify:api` (99), `verify:upload` (53),
  `probe:security` (91) all pass on this base.