### PR TITLE
Find the slicer wherever Linux put it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Notable changes. Every entry names a released version; deployments pin
   below and hands the slicer a *local file* — which has no domain to check. It
   adds nothing to the server and needs no client bundle: a `ppp://` link invokes
   the OS handler rather than making a request, so the CSP does not govern it.
+  The helper finds PrusaSlicer across the ways Linux installs it — a binary on
+  `PATH`, a Flatpak, or an AppImage in the usual folders — and takes an explicit
+  `PPP_SLICER` (a name, an AppImage path, or `flatpak run …`) when it cannot.
   Docs at [`docs/prusaslicer.md`](docs/prusaslicer.md); works with OrcaSlicer or
   any slicer that opens a file from the command line.
 

--- a/docs/prusaslicer.md
+++ b/docs/prusaslicer.md
@@ -57,9 +57,35 @@ That registers `ppp://` links to open with
 ```sh
 PPP_BASE="https://print.example"      # your instance, no trailing slash
 PPP_TOKEN="…"                          # a bearer token — see below
-# PPP_SLICER="prusa-slicer"            # or the full path to an AppImage
+# PPP_SLICER=…                         # only if auto-detect misses — see below
 # PPP_DOWNLOAD_DIR="$HOME/.cache/ppp/models"
 ```
+
+### Finding the slicer
+
+Left unset, the helper looks for PrusaSlicer in the places it usually is, in
+order: a binary on `PATH` (`prusa-slicer`, `prusaslicer`, `PrusaSlicer`), a
+Flatpak install, then an AppImage in `~/Applications`, `~/Downloads` or
+`~/.local/bin`. On most machines that just works — including a Flathub install,
+which nothing puts on `PATH`.
+
+Set `PPP_SLICER` only when that misses, in whichever form matches your install:
+
+```sh
+PPP_SLICER="prusa-slicer"                             # a binary name
+PPP_SLICER="$HOME/Applications/PrusaSlicer-2.9.0.AppImage"  # an AppImage
+PPP_SLICER="flatpak run com.prusa3d.PrusaSlicer"      # a Flatpak
+PPP_SLICER="orca-slicer"                              # or any other slicer
+```
+
+A multi-word command (the Flatpak form) is split on spaces and run as-is, so
+a path that itself contains spaces is the one thing this cannot express — put
+the AppImage somewhere without them.
+
+**Flatpak note:** the slicer must be allowed to read the downloaded file. The
+default `PPP_DOWNLOAD_DIR` is under `~/.cache`, which a Flatpak with home access
+can see; if yours is sandboxed tighter, grant it with
+`flatpak override --user --filesystem=xdg-cache/ppp com.prusa3d.PrusaSlicer`.
 
 Get a token by signing in — and keep it out of your shell history:
 
@@ -96,7 +122,9 @@ indistinguishable from one that was never wired up. Common lines:
 | `no config at …` | The installer has not run, or `$PPP_SLICER_CONF` points elsewhere. |
 | `not authorised (HTTP 401)` | The token is wrong, expired, or was revoked by signing out. Mint a new one. |
 | `story N … not one this account may see (HTTP 404)` | That ticket is not yours, or does not exist. |
-| `slicer '…' not found on PATH` | Set `PPP_SLICER` to the binary — an AppImage needs its full path. |
+| `could not find PrusaSlicer` | Auto-detect missed it. Set `PPP_SLICER` — see *Finding the slicer* above. |
+| `slicer '…' is not runnable` | `PPP_SLICER` points at something that is not a command or an executable file. |
+| loads then says *empty file* / *loading failed* | The bytes did arrive; the slicer could not read them (a truncated or non-model file). Check the ticket's file. |
 | `WARNING: … is group/world-readable` | `chmod 600 ~/.config/ppp/slicer.conf`. |
 
 ## macOS and Windows

--- a/scripts/install-slicer-handler.sh
+++ b/scripts/install-slicer-handler.sh
@@ -94,8 +94,15 @@ PPP_BASE="https://print.example"
 #     -d '{"username":"you","password":"..."}' | grep -i '^set-auth-token:'
 PPP_TOKEN="paste-the-set-auth-token-value-here"
 
-# Optional. The slicer binary; give a full path for an AppImage.
-# PPP_SLICER="prusa-slicer"
+# Optional. Left unset, the helper finds PrusaSlicer on its own — a binary on
+# PATH (prusa-slicer / prusaslicer / PrusaSlicer), a Flatpak install, or an
+# AppImage in ~/Applications, ~/Downloads or ~/.local/bin. Set it only to point
+# somewhere else, in any of these forms:
+#   PPP_SLICER="prusa-slicer"                              # a binary name
+#   PPP_SLICER="$HOME/Applications/PrusaSlicer-2.9.0.AppImage"   # an AppImage
+#   PPP_SLICER="flatpak run com.prusa3d.PrusaSlicer"      # a Flatpak
+#   PPP_SLICER="orca-slicer"                              # any slicer works
+# (A path containing spaces is the one form this cannot express.)
 
 # Optional. Where fetched models are cached (pruned after a day).
 # PPP_DOWNLOAD_DIR="$HOME/.cache/ppp/models"

--- a/scripts/prusa-open.sh
+++ b/scripts/prusa-open.sh
@@ -73,8 +73,47 @@ fi
 
 : "${PPP_BASE:?PPP_BASE is not set in $CONF}"
 : "${PPP_TOKEN:?PPP_TOKEN is not set in $CONF}"
-SLICER="${PPP_SLICER:-prusa-slicer}"
 DOWNLOAD_DIR="${PPP_DOWNLOAD_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/ppp/models}"
+
+# --- locate the slicer ------------------------------------------------------
+# There is no one name for "PrusaSlicer on Linux": a distro package is
+# `prusa-slicer`, the official download is an AppImage nobody puts on PATH, and
+# Flathub installs it as an app id you reach through `flatpak run`. Defaulting
+# to a single binary name meant the common cases all failed with "not found".
+#
+# PPP_SLICER may therefore be a bare name, a full path to an AppImage, or a
+# multi-word command like "flatpak run com.prusa3d.PrusaSlicer" — it is split
+# on whitespace into a command + args. Left unset, the cases above are probed
+# in turn. (A path containing spaces is the one thing this cannot express; put
+# the AppImage somewhere without them.)
+if [ -n "${PPP_SLICER:-}" ]; then
+  read -r -a SLICER_CMD <<<"$PPP_SLICER"
+else
+  SLICER_CMD=()
+  # 1. a binary on PATH, under the names distros and builds actually use.
+  for cand in prusa-slicer prusaslicer PrusaSlicer prusa-slicer-gui; do
+    if command -v "$cand" >/dev/null 2>&1; then SLICER_CMD=("$cand"); break; fi
+  done
+  # 2. a Flatpak install.
+  if [ "${#SLICER_CMD[@]}" -eq 0 ] && command -v flatpak >/dev/null 2>&1 &&
+    flatpak info com.prusa3d.PrusaSlicer >/dev/null 2>&1; then
+    SLICER_CMD=(flatpak run com.prusa3d.PrusaSlicer)
+  fi
+  # 3. an AppImage in the usual spots. A glob that matches nothing stays a
+  #    literal with a `*` in it, which is never -x, so it is simply skipped.
+  if [ "${#SLICER_CMD[@]}" -eq 0 ]; then
+    for g in \
+      "$HOME"/Applications/*[Pp]rusa*[Ss]licer*.AppImage \
+      "$HOME"/Downloads/*[Pp]rusa*[Ss]licer*.AppImage \
+      "$HOME"/.local/bin/*[Pp]rusa*[Ss]licer*.AppImage \
+      /opt/*[Pp]rusa*[Ss]licer*/*.AppImage; do
+      [ -x "$g" ] && { SLICER_CMD=("$g"); break; }
+    done
+  fi
+fi
+
+[ "${#SLICER_CMD[@]}" -gt 0 ] || fail \
+  "could not find PrusaSlicer. Set PPP_SLICER in $CONF — a binary name, the full path to an AppImage, or 'flatpak run com.prusa3d.PrusaSlicer'."
 
 # --- parse the link ---------------------------------------------------------
 # Accept ppp://slice/<id>, with or without a trailing slash. The id is the ONLY
@@ -90,8 +129,11 @@ case "$id" in
 esac
 
 command -v curl >/dev/null 2>&1 || fail "curl is not installed"
-command -v "$SLICER" >/dev/null 2>&1 ||
-  fail "slicer '$SLICER' not found on PATH — set PPP_SLICER in $CONF (AppImage users: give the full path)"
+# The head of the command has to be runnable — a binary on PATH, or a file we
+# can execute (an AppImage). Everything after it is arguments to that.
+slicer_head="${SLICER_CMD[0]}"
+command -v "$slicer_head" >/dev/null 2>&1 || [ -x "$slicer_head" ] ||
+  fail "slicer '$slicer_head' is not runnable — fix PPP_SLICER in $CONF (a name on PATH, an AppImage path, or 'flatpak run com.prusa3d.PrusaSlicer')"
 
 # --- fetch ------------------------------------------------------------------
 tmp="$(mktemp -d)"
@@ -126,6 +168,11 @@ name="$(
     sed -n 's/.*filename="\([^"]*\)".*/\1/p' | head -n1
 )"
 name="$(basename "${name:-model-$id.stl}")"
+# Make the on-disk name safe for every launcher. This is only the local temp
+# file's name — the app keeps the real display name — so we can be strict:
+# spaces to underscores (Flatpak's entrypoint splits its argument on spaces and
+# mangles a path that contains one), and nothing outside a conservative set.
+name="$(printf '%s' "$name" | tr ' ' '_' | tr -cd 'A-Za-z0-9._-')"
 case "$name" in "" | .*) name="model-$id.stl" ;; esac
 
 mkdir -p "$DOWNLOAD_DIR"
@@ -140,6 +187,6 @@ note "saved $out"
 # --- open -------------------------------------------------------------------
 # --single-instance so a second click loads the model into the window already
 # open rather than starting a race between two PrusaSlicers over the same file.
-note "opening in $SLICER"
-setsid "$SLICER" --single-instance "$out" >>"$LOG" 2>&1 &
+note "opening with: ${SLICER_CMD[*]}"
+setsid "${SLICER_CMD[@]}" --single-instance "$out" >>"$LOG" 2>&1 &
 note "handed off story $id"


### PR DESCRIPTION
Follow-up to #24, from testing it on a real machine: **Open in PrusaSlicer**
failed with `"prusaslicer" not found in PATH` on a completely normal install.

## Two real failures, both fixed

**1. The slicer was there, the helper just couldn't find it.** The default
assumed a binary named `prusa-slicer` on `PATH` — the one case that is often
*not* true. The official download is an AppImage nobody adds to `PATH`, and
Flathub installs it as an app id you reach through `flatpak run`. The helper
now probes all three, in order:

- a binary on `PATH` (`prusa-slicer`, `prusaslicer`, `PrusaSlicer`);
- a Flatpak install (`com.prusa3d.PrusaSlicer`);
- an AppImage in `~/Applications`, `~/Downloads`, `~/.local/bin`.

And `PPP_SLICER`, when set, may now be a bare name, an AppImage path, **or a
multi-word command** like `flatpak run com.prusa3d.PrusaSlicer` — split on
spaces and run as-is. (Previously it had to be a single binary, so the Flatpak
form was inexpressible.)

**2. A filename with a space arrived mangled.** PrusaSlicer's Flatpak
entrypoint splits its argument on spaces, so `cable clip.stl` reached the
slicer as a doubled, broken path — *"no such file"*. The on-disk name is only
the local temp file (the app keeps the real display name), so it is now
sanitised to a conservative set with spaces folded to underscores, which every
launcher handles.

## Verified against a real Flatpak PrusaSlicer

The dev box happened to have PrusaSlicer installed via Flathub, so this was
tested against the genuine article, not a stub:

- auto-detected and launched it; the model **opened in PrusaSlicer** (Flatpak
  form correctly winning over an AppImage when both are present);
- before the filename fix, the launch failed with the exact doubled-path error;
  after it, PrusaSlicer ingested the file.

Failure branches still each exit with the message that names the fix: nothing
found, an unrunnable `PPP_SLICER`, 404, 401, path-traversal (`ppp://slice/../x`),
missing config, no argument.

`docs/prusaslicer.md` gains a **Finding the slicer** section and a Flatpak
filesystem note; the config skeleton documents the three `PPP_SLICER` forms.