### PR TITLE
Accept 3MF files whose geometry lives in a component part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Fixed
+
+- **3MF files with geometry in a separate part were refused.** The validator
+  read only the archive's root `3D/3dmodel.model` and counted vertices there,
+  so a 3MF written in the *production extension* shape — each object's mesh in
+  its own `3D/Objects/*.model`, the root merely referencing them — looked empty
+  and was rejected as "not a model". That shape is what Bambu Studio, OrcaSlicer
+  multi-object plates and several CAD exporters emit, so a lot of perfectly
+  printable files bounced. It now reads every `*.model` part in the archive
+  (which also covers exporters that name the root part something other than
+  `3dmodel.model`), summing geometry across them, with the zip-bomb guard still
+  applied to the total. Component transforms are not applied, so an assembly's
+  reported bounding box may be a few mm loose — a deliberate trade, since the
+  dimensions are display-only and accepting the file beats refusing it. A
+  regression test covers a production-extension 3MF end to end.
+
 ### Added
 
 - **Open a model straight in PrusaSlicer**, from a control on every ticket. A

--- a/scripts/verify-models.ts
+++ b/scripts/verify-models.ts
@@ -92,6 +92,38 @@ function threeMf(x: number, y: number, z: number, unit = "millimeter"): Uint8Arr
   });
 }
 
+/**
+ * A 3MF in the shape the *production extension* emits: the root part carries no
+ * geometry of its own, only a component that references a mesh in a separate
+ * `3D/Objects/*.model` part. Bambu Studio, OrcaSlicer multi-object plates and
+ * several CAD exporters write this — and it was being refused because the
+ * validator read only the root part. Regression guard for that bug.
+ */
+function threeMfProduction(x: number, y: number, z: number): Uint8Array {
+  const p = [
+    [0, 0, 0], [x, 0, 0], [x, y, 0], [0, y, 0],
+    [0, 0, z], [x, 0, z], [x, y, z], [0, y, z],
+  ];
+  const objectPart =
+    `<?xml version="1.0" encoding="UTF-8"?>\n<model unit="millimeter">\n<resources>` +
+    `<object id="2" type="model"><mesh><vertices>` +
+    p.map((v) => `<vertex x="${v[0]}" y="${v[1]}" z="${v[2]}"/>`).join("") +
+    `</vertices><triangles>` +
+    boxTriangles(1, 1, 1).map(() => `<triangle v1="0" v2="1" v3="2"/>`).join("") +
+    `</triangles></mesh></object></resources>\n</model>`;
+  const root =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<model unit="millimeter" xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06">\n` +
+    `<resources><object id="1" type="model"><components>` +
+    `<component objectid="2" p:path="/3D/Objects/object_1.model"/>` +
+    `</components></object></resources><build><item objectid="1"/></build>\n</model>`;
+  return zipSync({
+    "[Content_Types].xml": new TextEncoder().encode(`<?xml version="1.0"?><Types/>`),
+    "3D/3dmodel.model": new TextEncoder().encode(root),
+    "3D/Objects/object_1.model": new TextEncoder().encode(objectPart),
+  });
+}
+
 const ok = (r: ReturnType<typeof inspectModel>) => (r.ok ? r : null);
 const why = (r: ReturnType<typeof inspectModel>): Rejection | "accepted" =>
   r.ok ? "accepted" : r.reason;
@@ -119,6 +151,13 @@ check("3MF unit attribute is honoured (inch -> mm)",
 
 const microns = inspectModel("tiny.3mf", threeMf(10000, 20000, 5000, "micron"));
 check("3MF micron unit is honoured", ok(microns)?.dims === "10 × 20 × 5 mm", ok(microns)?.dims);
+
+// The bug this guards: a production-extension 3MF (geometry in a separate
+// component part) was refused because only the root part was read.
+const prod = inspectModel("plate.3mf", threeMfProduction(30, 20, 10));
+check("3MF production extension accepted (geometry in a component part)", prod.ok, why(prod));
+check("its dimensions come from the referenced part",
+      ok(prod)?.dims === "30 × 20 × 10 mm", ok(prod)?.dims);
 
 // A binary STL whose 80-byte header begins with the word "solid" — the classic
 // way a naive sniffer misreads the format.

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -154,33 +154,12 @@ const UNIT_TO_MM: Record<string, number> = {
   meter: 1000,
 };
 
-function measure3mf(bytes: Uint8Array): { box: Box; triangles: number } | null {
-  let files: Record<string, Uint8Array>;
-  try {
-    let inflated = 0;
-    files = unzipSync(bytes, {
-      filter: (file) => {
-        inflated += file.originalSize ?? 0;
-        if (inflated > MAX_INFLATED_BYTES) {
-          throw new Error("archive inflates to an implausible size");
-        }
-        // Only the model part is needed; thumbnails and metadata are skipped.
-        return /3dmodel\.model$/i.test(file.name);
-      },
-    });
-  } catch {
-    return null;
-  }
-
-  const key = Object.keys(files).find((k) => /3dmodel\.model$/i.test(k));
-  if (!key) return null;
-
-  const xml = new TextDecoder("utf-8", { fatal: false }).decode(files[key]!);
-
+/** Pull the bounding box and triangle count out of one `<model>` part's XML. */
+function measureModelPart(xml: string, box: Box): { vertices: number; triangles: number } {
+  // Each part declares its own unit — a component part need not match the root.
   const unit = /<model[^>]*\bunit\s*=\s*"([^"]+)"/i.exec(xml)?.[1]?.toLowerCase();
   const scale = UNIT_TO_MM[unit ?? "millimeter"] ?? 1;
 
-  const box = emptyBox();
   let vertices = 0;
   // Attribute order is not fixed by the spec, so each is matched separately
   // within the tag rather than assuming x, y, z appear in order.
@@ -195,8 +174,53 @@ function measure3mf(bytes: Uint8Array): { box: Box; triangles: number } | null {
     expand(box, parseFloat(x) * scale, parseFloat(y) * scale, parseFloat(z) * scale);
     vertices++;
   }
+  return { vertices, triangles: (xml.match(/<triangle\b/g) ?? []).length };
+}
 
-  const triangles = (xml.match(/<triangle\b/g) ?? []).length;
+function measure3mf(bytes: Uint8Array): { box: Box; triangles: number } | null {
+  let files: Record<string, Uint8Array>;
+  try {
+    let inflated = 0;
+    files = unzipSync(bytes, {
+      filter: (file) => {
+        // EVERY model part, not only `3dmodel.model`. The 3MF production
+        // extension (Bambu, OrcaSlicer multi-object plates, several CAD
+        // exporters) puts each object's geometry in its own
+        // `3D/Objects/*.model` and leaves the root part merely referencing
+        // them — so reading the root alone finds no geometry and the whole
+        // file was being refused. Some exporters also name the root part
+        // something other than `3dmodel.model`. Reading any `*.model` covers
+        // both. Nothing is ever written from these names (storage keys are
+        // generated), so an odd or traversal-shaped member name is harmless.
+        if (!/\.model$/i.test(file.name)) return false;
+        inflated += file.originalSize ?? 0;
+        if (inflated > MAX_INFLATED_BYTES) {
+          throw new Error("archive inflates to an implausible size");
+        }
+        return true;
+      },
+    });
+  } catch {
+    return null;
+  }
+
+  const box = emptyBox();
+  let vertices = 0;
+  let triangles = 0;
+  for (const name of Object.keys(files)) {
+    if (!/\.model$/i.test(name)) continue;
+    const xml = new TextDecoder("utf-8", { fatal: false }).decode(files[name]!);
+    const part = measureModelPart(xml, box);
+    vertices += part.vertices;
+    triangles += part.triangles;
+  }
+
+  // Component transforms (<component>/<item> matrices) are deliberately not
+  // applied: this measures the raw union of every part's vertices, so an
+  // assembly whose components are translated or rotated may report a slightly
+  // loose box. That is the right trade — the dimensions are display-only and
+  // already disclaimed as approximate, and accepting the file beats refusing a
+  // perfectly printable model over a bounding box that is a few mm out.
   return vertices > 0 ? { box, triangles } : null;
 }
 


### PR DESCRIPTION
**Reported:** `.3mf` uploads refused. **Found:** a structural gap in the
validator, not a systemic upload failure.

## Diagnosis

A real PrusaSlicer 3MF export uploads fine end-to-end (verified against the
live deployment — HTTP 200, dimensions computed). So the pipeline works; the
failing files have a *shape* the validator didn't handle.

`measure3mf` read only the archive's root `3D/3dmodel.model` and counted
`<vertex>` there. A 3MF written in the **production extension** puts each
object's mesh in its own `3D/Objects/*.model` part and leaves the root merely
referencing them via `<component>` — so the root has no geometry, the validator
measured zero vertices, and the file was rejected as `not_a_model`.

That shape is what **Bambu Studio, OrcaSlicer** (multi-object plates) and
several CAD exporters emit. Reproduced before touching anything:

| 3MF shape | before | after |
| --- | --- | --- |
| geometry inline in root part | ✅ accepted | ✅ accepted |
| production extension (geometry in a component part) | ❌ `not_a_model` | ✅ accepted |
| root part named something other than `3dmodel.model` | ❌ `not_a_model` | ✅ accepted |

## Fix

`measure3mf` now reads **every** `*.model` part in the archive and sums the
geometry, each part honouring its own `unit`. Deliberately conservative about
the rest:

- The **zip-bomb guard** still accumulates the inflated size across the matched
  parts and fires before inflating.
- **Nothing is written from a member name** (storage keys are generated), so an
  odd or traversal-shaped part name stays harmless — the existing traversal and
  zip-bomb rejections are unchanged.
- **Component/item transforms are not applied.** This takes the raw union of
  every part's vertices, so an assembly with translated components may report a
  slightly loose bounding box — the right trade for a figure that is
  display-only and already disclaimed as approximate.

## Tests

`verify:models` gains a production-extension fixture and asserts it's accepted
with dimensions read from the referenced part. **29 → 31 checks, 0 failed** —
and every prior rejection (empty, wrong extension, STL-renamed-`.3mf`, no
geometry, traversal name, zip bomb) still passes unchanged.

## Note

This fixes the validator on `main`. The live instance won't accept these files
until it's redeployed from a build that includes this.