### PR TITLE
Feature requests: a parallel 'frr' backlog, triaged like prints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,10 @@ jobs:
         run: npm run verify:upload
       - name: Admin queue and the status flow
         run: npm run verify:queue
+      # The 'frr' feature-request track — the same board/queue/flow mechanics as
+      # prints, on its own tables. Drives the real forms exactly as verify:queue.
+      - name: Feature requests, filed and triaged
+        run: npm run verify:frr
       # The second front door onto the same operations. Runs against the built
       # image, which is the only place the production CSP is in force — the
       # console's inline-script nonce and its stylesheet-in-a-file are both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Added
+
+- **A feature-request track — the 'frr' backlog.** Anyone can file a feature
+  request (title, description, priority, category) at `/frr`, and the printer
+  owner triages it exactly as they triage a print: the same board, an
+  owner-only queue, a forward-only status flow (Requested → Accepted → In
+  progress → Shipped → Done, or Declined), the conversation, notifications and
+  the audit trail. The requester can withdraw their own while nobody has
+  started on it.
+
+  It is a deliberate parallel of the print backlog, not a fold into it. New
+  tables (`featureRequest`, `featureComment`) and a `src/lib/features.ts`
+  service that mirrors `stories.ts`; the print flow, upload, viewer and API are
+  untouched. The pure rules (`featureScope`, `FEATURE_FLOW`,
+  `assertFeatureTransition`, `featureRef`) sit beside the print ones in
+  `scope.ts`, kept separate on purpose so a change to one backlog cannot
+  quietly bend the other. Shared infrastructure is extended additively: a
+  notification can now reference a feature (`featureId`) and the Activity feed
+  routes to `/frr` or `/story` accordingly; the audit trail gains `feature.*`
+  verbs. `npm run verify:frr` (51 checks) drives the real forms end to end and
+  runs in CI. There is no JSON API for it yet — see
+  [`docs/feature-requests.md`](docs/feature-requests.md).
+
+
 ### Fixed
 
 - **3MF files with geometry in a separate part were refused.** The validator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ maintainer — so the bar is not "be an expert", it is "leave it working".
 
 ## The contract
 
-Seven verification suites, all of which run in CI **against the built container
+Eight verification suites, all of which run in CI **against the built container
 image** rather than a dev server. They are the specification; if a change makes
 one fail, that is the change talking.
 
@@ -14,6 +14,7 @@ npm run verify:models     # upload validator vs. hostile fixtures — needs noth
 npm run verify:auth       # registration, sign-in, password reset
 npm run verify:upload     # upload → board → story
 npm run verify:queue      # admin queue, status flow, conversation, access
+npm run verify:frr        # the feature-request track: file, triage, the flow
 npm run verify:api        # the JSON API, the OpenAPI document, the console
 npm run verify:passkey    # WebAuthn ceremonies in a real browser
 npm run probe:security    # OWASP-mapped probes

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ that: there is no multi-tenancy, no billing, and no queue theory.
   auto-framed, drag to rotate.
 - **An audit trail** of everything that changes who can get in or what happens
   to someone's model, readable at `/admin/audit`, never edited or deleted.
+- **Ask for features, triaged like the backlog** — a parallel "frr" board at
+  `/frr` where anyone files a feature request (title, priority, category) and
+  the owner moves it through the same stages, conversation, notifications and
+  audit trail a print goes through. Its own tables; the print flow is untouched.
+  See **[Feature requests](docs/feature-requests.md)**.
 - **Drive it over HTTP** — every ticket, transition, comment and notification
   is a JSON endpoint, described by an OpenAPI 3.1 document and callable from a
   Swagger console at `/docs`. Same session, same scope, same audit trail as the
@@ -340,12 +345,13 @@ has no outbound internet, set `HIBP_DISABLED=true` — and only then.
 | **[Authentication](docs/authentication.md)** | invite-only registration, passwords, passkeys, resets, and why each decision went the way it did |
 | **[Architecture](docs/architecture.md)** | the viewer, upload validation, decisions taken against the design handoff, and the file layout |
 | **[Deployment](docs/deployment.md)** | containers, reverse proxies, the deploy wizard, TLS, first run |
+| **[Feature requests](docs/feature-requests.md)** | the `/frr` track — file a request, triage it exactly like the print backlog |
 | **[The API](docs/api.md)** | the JSON surface, bearer tokens, the OpenAPI document and the console at `/docs` |
 | **[Open in PrusaSlicer](docs/prusaslicer.md)** | the one-click "send to the slicer" bridge, the helper, and why the deep link cannot be used |
 | **[Development](docs/development.md)** | stack, local setup, the verification suites, CI |
 | **[Security audit](docs/security-audit.md)** | the OWASP Top 10 assessment, findings, and residual risk accepted |
 | **[Security policy](SECURITY.md)** | how to report a vulnerability |
-| **[Contributing](CONTRIBUTING.md)** | the seven suites are the contract; what a good change looks like |
+| **[Contributing](CONTRIBUTING.md)** | the eight suites are the contract; what a good change looks like |
 | **[Changelog](CHANGELOG.md)** | what changed in each release |
 
 ## Security
@@ -364,7 +370,7 @@ something, see [SECURITY.md](SECURITY.md).
 
 ## Contributing
 
-Issues and pull requests are welcome. The seven verification suites in
+Issues and pull requests are welcome. The eight verification suites in
 `scripts/` are the contract — `npm run verify:auth`, `verify:upload`,
 `verify:queue`, `verify:models`, `verify:passkey` and `probe:security` all run
 in CI against the built container image, not a dev server. If a change makes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,6 +196,7 @@ src/app/
   notifications.ts       the Activity feed, scoped by recipient
   api.ts                 the JSON boundary: 401/403, Origin, wire format
   openapi.ts             the OpenAPI 3.1 document, app half + Better Auth half
+  features.ts            every operation on a feature request — the 'frr' track
 src/app/
   board/                 the kanban backlog, scoped per role
   upload/                dropzone, wish form, XHR progress
@@ -205,6 +206,7 @@ src/app/
   api/notifications/     the Activity feed
   api/openapi.json/      the document
   docs/                  the Swagger console (a route, not a page)
+  frr/                   the feature-request track: board, new, queue, [id]
 scripts/
   deploy-wizard.sh       pick an image, verify it, deploy, auto-rollback
   vendor-swagger.ts      copies Swagger UI into public/docs at build time
@@ -213,6 +215,7 @@ scripts/
   verify-upload.ts       upload -> board -> story
   verify-passkey.ts      WebAuthn in a real browser
   verify-api.ts          the JSON API, the document and the console
+  verify-frr.ts          the feature-request track, filed and triaged
   security-probe.ts      OWASP-mapped security probes
 src/app/admin/
   invites/               the guest list

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,6 +36,7 @@ npm run verify:models         # upload validator vs. hostile fixtures (no server
 npm run verify:auth           # registration, sign-in and password reset, end to end
 npm run verify:upload         # upload -> board -> story, end to end
 npm run verify:queue          # the admin queue, status flow and conversation
+npm run verify:frr            # the feature-request track (file, triage, the flow)
 npm run verify:api            # the JSON API, the OpenAPI document and the console
 npm run verify:passkey        # WebAuthn ceremonies in a real browser
 npm run probe:security        # 91 OWASP-mapped security probes

--- a/docs/feature-requests.md
+++ b/docs/feature-requests.md
@@ -1,0 +1,80 @@
+# Feature requests — the 'frr' track
+
+[← back to the README](../README.md)
+
+A second backlog, alongside the print one: anyone can file a feature request,
+and the printer owner triages it through the same stages, conversation,
+notifications and audit trail a print goes through. It lives at **`/frr`**.
+
+## For everyone
+
+- **`/frr`** — the rail. Your own requests (the owner sees everyone's), one
+  column per stage, with anything closed gathered under *Closed* so you keep
+  your history without a second page.
+- **`/frr/new`** — file one: a title, what-and-why, a **priority**
+  (low / medium / high) and a **category** (UI / API / bug / other).
+- **`/frr/[id]`** — the request in full: where it sits in the flow, the
+  conversation, and — while nobody has started on it — a **Withdraw** control
+  for the person who filed it.
+
+## For the owner
+
+- **`/frr/queue`** — triage. *Waiting on you* (still `Requested`) comes first,
+  ordered high-priority first; everything in flight is a list with one control
+  each. Owner-only — a client gets a 404, exactly like the print queue.
+- Move a request one step at a time: **Requested → Accepted → In progress →
+  Shipped → Done**, or **Decline** it (terminal, and only from `Requested`).
+  Every move notifies the requester and writes an audit row.
+
+## How it mirrors the print backlog
+
+The point of the feature was "handle them exactly as the current backlog", so
+the 'frr' track is a deliberate parallel of the print one rather than a new set
+of ideas:
+
+| Print backlog | Feature track |
+| --- | --- |
+| `Story` | `FeatureRequest` |
+| `PPP-104` | `FRR-104` (`featureRef`) |
+| `storyScope` | `featureScope` — a client sees their own, the owner sees all |
+| `FLOW` (Requested→…→Done) | `FEATURE_FLOW` (Requested→Accepted→In progress→Shipped→Done) |
+| `assertTransition` | `assertFeatureTransition` — forward-only, one step, Declined from Requested |
+| `/board` `/queue` `/story/[id]` | `/frr` `/frr/queue` `/frr/[id]` |
+| `src/lib/stories.ts` | `src/lib/features.ts` |
+
+The pure rules sit beside the print ones in
+[`src/lib/scope.ts`](../src/lib/scope.ts), and are **kept parallel rather than
+merged into one generic helper on purpose**: the print rules are load-bearing
+and exercised directly by the suites, so a shared cleverness that a change to
+one backlog could quietly bend for the other is a worse trade than a little
+duplication. The *shape* is identical — that is what makes the owner's
+experience the same — but each backlog stays independently legible and
+testable.
+
+## What it shares, and what stays separate
+
+- **Its own tables** — `featureRequest` and `featureComment`. `Story` and the
+  print flow are untouched; there is no `kind` flag threading feature logic
+  through the upload, the viewer or the API.
+- **Shared infrastructure, extended additively** — one `Notification` row can
+  point at a story *or* a feature (a nullable `featureId`), and the Activity
+  feed routes to `/story` or `/frr` on whichever is set. The audit trail gains
+  `feature.*` verbs. Neither change alters how a print behaves.
+- **No file.** A feature request is text; there is nothing in object storage,
+  so withdrawing one just removes the row and its conversation.
+
+## Verifying it
+
+`npm run verify:frr` drives the real forms the way a JavaScript-off browser
+does — file, triage, the whole flow, decline, the conversation, withdrawal,
+and the scope rule (a client cannot see or comment on another's request; the
+owner cannot withdraw one). It is the print `verify:queue`'s sibling and runs
+in CI against the built image.
+
+## Not built (yet)
+
+There is **no JSON API** for feature requests. The print backlog has one (see
+[the API](api.md)); the feature track is UI-only for now, because the request
+was specifically about filing and triaging on the board. The service layer in
+`src/lib/features.ts` is already shaped like `stories.ts`, so adding
+`/api/features` later is the same exercise the print API was — say the word.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "shots": "tsx scripts/screenshot.ts",
     "env:container": "tsx scripts/use-container-env.ts",
     "verify:queue": "tsx scripts/verify-queue.ts",
+    "verify:frr": "tsx scripts/verify-frr.ts",
     "verify:api": "tsx scripts/verify-api.ts",
     "vendor:swagger": "tsx scripts/vendor-swagger.ts"
   },

--- a/prisma/migrations/20260825161629_feature_requests/migration.sql
+++ b/prisma/migrations/20260825161629_feature_requests/migration.sql
@@ -1,0 +1,58 @@
+-- CreateEnum
+CREATE TYPE "FeatureStatus" AS ENUM ('Requested', 'Accepted', 'InProgress', 'Shipped', 'Done', 'Declined');
+
+-- CreateEnum
+CREATE TYPE "FeaturePriority" AS ENUM ('low', 'medium', 'high');
+
+-- CreateEnum
+CREATE TYPE "FeatureCategory" AS ENUM ('ui', 'api', 'bug', 'other');
+
+-- AlterTable
+ALTER TABLE "notification" ADD COLUMN     "featureId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "featureRequest" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "status" "FeatureStatus" NOT NULL DEFAULT 'Requested',
+    "priority" "FeaturePriority" NOT NULL DEFAULT 'medium',
+    "category" "FeatureCategory" NOT NULL DEFAULT 'other',
+    "requesterId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "featureRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "featureComment" (
+    "id" TEXT NOT NULL,
+    "featureId" INTEGER NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "featureComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "featureRequest_requesterId_idx" ON "featureRequest"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "featureRequest_status_idx" ON "featureRequest"("status");
+
+-- CreateIndex
+CREATE INDEX "featureComment_featureId_idx" ON "featureComment"("featureId");
+
+-- AddForeignKey
+ALTER TABLE "notification" ADD CONSTRAINT "notification_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "featureRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "featureRequest" ADD CONSTRAINT "featureRequest_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "featureComment" ADD CONSTRAINT "featureComment_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "featureRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "featureComment" ADD CONSTRAINT "featureComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,10 @@ model User {
   comments      Comment[]
   notifications Notification[]
 
+  /// The 'frr' feature-request track — a parallel backlog to the print one.
+  featureRequests FeatureRequest[]
+  featureComments FeatureComment[]
+
   @@index([role])
   @@map("user")
 }
@@ -317,10 +321,84 @@ model Notification {
   recipient   User     @relation(fields: [recipientId], references: [id], onDelete: Cascade)
   storyId     Int?
   story       Story?   @relation(fields: [storyId], references: [id], onDelete: Cascade)
+  /// A notification points at a print story OR a feature request (or neither,
+  /// for a withdrawal). The two id columns are mutually exclusive in practice;
+  /// the Activity feed routes to /story or /frr on whichever is set.
+  featureId   Int?
+  feature     FeatureRequest? @relation(fields: [featureId], references: [id], onDelete: Cascade)
   text        String
   read        Boolean  @default(false)
   createdAt   DateTime @default(now())
 
   @@index([recipientId, read])
   @@map("notification")
+}
+
+// ===========================================================================
+// Feature requests — the 'frr' track
+//
+// A parallel backlog: users file feature requests, the printer owner triages
+// them with the same flow, conversation, notifications and audit trail as a
+// print. Kept in its own tables rather than folded into Story, which stays
+// purely about printed models. The status flow mirrors the print one's shape
+// (forward-only, one step, Done leaves the board, Declined terminal from
+// Requested) with feature-appropriate names — see FEATURE_FLOW in scope.ts.
+// ===========================================================================
+
+enum FeatureStatus {
+  Requested
+  Accepted
+  InProgress
+  Shipped
+  Done
+  Declined
+}
+
+enum FeaturePriority {
+  low
+  medium
+  high
+}
+
+enum FeatureCategory {
+  ui
+  api
+  bug
+  other
+}
+
+model FeatureRequest {
+  /// Autoincrement so the display ref stays "FRR-" + (100 + id).
+  id          Int             @id @default(autoincrement())
+  title       String
+  description String          @default("")
+  status      FeatureStatus   @default(Requested)
+  priority    FeaturePriority @default(medium)
+  category    FeatureCategory @default(other)
+
+  requesterId String
+  requester   User   @relation(fields: [requesterId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  comments      FeatureComment[]
+  notifications Notification[]
+
+  @@index([requesterId])
+  @@index([status])
+  @@map("featureRequest")
+}
+
+model FeatureComment {
+  id        String         @id @default(cuid())
+  featureId Int
+  feature   FeatureRequest @relation(fields: [featureId], references: [id], onDelete: Cascade)
+  authorId  String
+  author    User           @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  body      String
+  createdAt DateTime       @default(now())
+
+  @@index([featureId])
+  @@map("featureComment")
 }

--- a/scripts/verify-frr.ts
+++ b/scripts/verify-frr.ts
@@ -1,0 +1,334 @@
+import "./_env";
+/**
+ * End-to-end check of the feature-request track — the 'frr' backlog.
+ *
+ *   npm run verify:frr
+ *
+ * Drives the real forms the way a browser with JavaScript off does, exactly as
+ * verify:queue does for prints — because the whole point of this feature is
+ * that the owner handles a request the same way they handle a print. What is
+ * asserted is what a person observes: a status code, a database row, what the
+ * page says, who was notified, what the audit trail recorded.
+ *
+ * DESTRUCTIVE: wipes users, features and stories. Development database only.
+ */
+import { db } from "../src/lib/db";
+import {
+  FEATURE_BOARD,
+  featureRef as refOf,
+  nextFeatureStatus,
+} from "../src/lib/scope";
+import { ensureCredentials, signInWithPassword, usernameFor } from "./_accounts";
+
+const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
+
+let passed = 0;
+const failures: string[] = [];
+function check(name: string, ok: boolean, detail = "") {
+  console.info(`  ${ok ? "ok  " : "FAIL"}  ${name}${ok || !detail ? "" : `\n          ${detail}`}`);
+  ok ? passed++ : failures.push(name);
+}
+const section = (t: string) =>
+  console.info(`\n── ${t} ${"─".repeat(Math.max(0, 54 - t.length))}`);
+
+const unescapeHtml = (s: string) =>
+  s.replace(/&quot;/g, '"').replace(/&#x27;|&#39;/g, "'")
+    .replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+
+class Browser {
+  jar = new Map<string, string>();
+  private store(r: Response) {
+    for (const line of r.headers.getSetCookie()) {
+      const [pair] = line.split(";");
+      const i = pair!.indexOf("=");
+      const k = pair!.slice(0, i).trim();
+      const v = pair!.slice(i + 1).trim();
+      if (!v || line.includes("Max-Age=0")) this.jar.delete(k);
+      else this.jar.set(k, v);
+    }
+  }
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { origin: APP };
+    if (this.jar.size) h.cookie = [...this.jar].map(([k, v]) => `${k}=${v}`).join("; ");
+    return h;
+  }
+  async raw(url: string, init: RequestInit = {}) {
+    const r = await fetch(url, { ...init, redirect: "manual", headers: { ...(init.headers ?? {}), ...this.headers() } });
+    this.store(r);
+    return r;
+  }
+  async go(url: string, init: RequestInit = {}) {
+    let r = await this.raw(url, init);
+    for (let i = 0; i < 8; i++) {
+      const loc = r.headers.get("location");
+      if (!loc || r.status < 300 || r.status >= 400) break;
+      r = await this.raw(new URL(loc, url).toString());
+    }
+    return r;
+  }
+  /** Replay a server-action form the way a JS-less browser does. */
+  async submit(url: string, html: string, formIndex: number, values: Record<string, string>) {
+    const forms = html.match(/<form\b[\s\S]*?<\/form>/g) ?? [];
+    const form = forms[formIndex];
+    if (!form) throw new Error(`no form #${formIndex} on ${url}`);
+    const body = new FormData();
+    for (const tag of form.match(/<input\b[^>]*>/g) ?? []) {
+      if (!tag.includes('type="hidden"')) continue;
+      const n = /name="([^"]*)"/.exec(tag)?.[1];
+      const v = /value="([^"]*)"/.exec(tag)?.[1] ?? "";
+      if (n) body.append(unescapeHtml(n), unescapeHtml(v));
+    }
+    for (const [k, v] of Object.entries(values)) body.set(k, v);
+    return this.raw(url, { method: "POST", body });
+  }
+}
+
+const rendered = (html: string) => html.replace(/<!--\s*-->/g, "");
+function paramOf(location: string | null, key: string): string {
+  if (!location) return "";
+  const q = location.split("?")[1] ?? "";
+  return new URLSearchParams(q).get(key) ?? "";
+}
+function formIndexContaining(html: string, marker: string): number {
+  const forms = html.match(/<form\b[\s\S]*?<\/form>/g) ?? [];
+  return forms.findIndex((f) => f.includes(marker));
+}
+
+async function signIn(user: { id: string; email: string }): Promise<Browser> {
+  const b = new Browser();
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  await ensureCredentials(APP, user.id, usernameFor(user.email));
+  await signInWithPassword(b, APP, usernameFor(user.email));
+  return b;
+}
+
+async function makeFeature(requesterId: string, title: string, status = "Requested") {
+  return db.featureRequest.create({
+    data: {
+      title, status: status as never, requesterId,
+      description: "because it would help", priority: "medium", category: "other",
+    },
+  });
+}
+
+async function main() {
+  section("setup");
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  await db.auditEvent.deleteMany();
+  await db.notification.deleteMany();
+  await db.featureComment.deleteMany();
+  await db.featureRequest.deleteMany();
+  await db.story.deleteMany();
+  await db.verification.deleteMany();
+  await db.session.deleteMany();
+  await db.invite.deleteMany();
+  await db.user.deleteMany({ where: { role: "client" } });
+
+  const admin = await db.user.findFirst({ where: { role: "admin" } });
+  if (!admin) throw new Error("No admin — run npm run db:seed");
+  const ayla = await db.user.create({
+    data: { email: "ayla@office.example", name: "Ayla Berg", initials: "AY", role: "client", emailVerified: true, invitedById: admin.id },
+  });
+  const mallory = await db.user.create({
+    data: { email: "mallory@office.example", name: "Mallory Quint", initials: "MQ", role: "client", emailVerified: true, invitedById: admin.id },
+  });
+
+  const ruben = await signIn(admin);
+  const client = await signIn(ayla);
+  const other = await signIn(mallory);
+  console.info(`  admin=${admin.email}  client=${ayla.email}  third=${mallory.email}`);
+
+  // ------------------------------------------------------------------
+  section("filing a request through the form");
+  const newPage = await (await client.go(`${APP}/frr/new`)).text();
+  const formIdx = formIndexContaining(newPage, 'name="title"');
+  check("the requester is offered the new-request form", formIdx >= 0);
+  await client.submit(`${APP}/frr/new`, newPage, formIdx, {
+    title: "Dark mode for the board",
+    description: "Easier on the eyes in the workshop at night.",
+    priority: "high",
+    category: "ui",
+  });
+  const filed = await db.featureRequest.findFirst({ where: { title: "Dark mode for the board" } });
+  check("it is stored", !!filed, "the request was not created");
+  check("owned by the requester, from the session", filed?.requesterId === ayla.id);
+  check("it starts Requested", filed?.status === "Requested", String(filed?.status));
+  check("the priority and category are kept", filed?.priority === "high" && filed?.category === "ui");
+  check("the owner is notified",
+        (await db.notification.count({ where: { recipientId: admin.id, featureId: filed!.id } })) > 0);
+  check("and it is audited",
+        (await db.auditEvent.count({ where: { action: "feature.created", subject: refOf(filed!.id) } })) === 1);
+
+  // A posted requesterId is ignored — the session decides.
+  const spoofPage = await (await client.go(`${APP}/frr/new`)).text();
+  await client.submit(`${APP}/frr/new`, spoofPage, formIndexContaining(spoofPage, 'name="title"'), {
+    title: "Filed as someone else", description: "x", priority: "low", category: "other",
+    requesterId: admin.id, status: "Done",
+  });
+  const spoofed = await db.featureRequest.findFirst({ where: { title: "Filed as someone else" } });
+  check("a posted requesterId is ignored", spoofed?.requesterId === ayla.id, String(spoofed?.requesterId));
+  check("a posted status is ignored; new requests are Requested", spoofed?.status === "Requested", String(spoofed?.status));
+
+  // ------------------------------------------------------------------
+  section("the queue is owner-only");
+  const denied = await client.go(`${APP}/frr/queue`);
+  check("a client gets 404, not 403", denied.status === 404, `status ${denied.status}`);
+  const queue = await (await ruben.go(`${APP}/frr/queue`)).text();
+  check("the owner sees the request waiting", rendered(queue).includes("Dark mode for the board"));
+
+  // ------------------------------------------------------------------
+  section("scope: a client sees their own, the owner sees all");
+  const mine = await makeFeature(ayla.id, "Bulk upload");
+  const theirs = await makeFeature(mallory.id, "Not Ayla's idea");
+  const aylaBoard = rendered(await (await client.go(`${APP}/frr`)).text());
+  check("the client's board has their own", aylaBoard.includes("Bulk upload"));
+  check("and not somebody else's", !aylaBoard.includes("Not Ayla's idea"));
+  const adminBoard = rendered(await (await ruben.go(`${APP}/frr`)).text());
+  check("the owner's board has both", adminBoard.includes("Bulk upload") && adminBoard.includes("Not Ayla's idea"));
+  const peek = await client.go(`${APP}/frr/${theirs.id}`);
+  check("reading another client's request is 404, not 403", peek.status === 404, `status ${peek.status}`);
+
+  // ------------------------------------------------------------------
+  section("the flow, forwards only, one step");
+  const flowFR = await makeFeature(ayla.id, "Keyboard shortcuts");
+  // A client cannot move it.
+  const detail = await (await client.go(`${APP}/frr/${flowFR.id}`)).text();
+  check("a client is not offered the owner controls", !detail.includes("Accept it"));
+
+  const adminDetail = await (await ruben.go(`${APP}/frr/${flowFR.id}`)).text();
+  const acceptIdx = formIndexContaining(adminDetail, "Accept it");
+  check("the owner is offered Accept it", acceptIdx >= 0);
+  const accepted = await ruben.submit(`${APP}/frr/${flowFR.id}`, adminDetail, acceptIdx, {});
+  check("Requested → Accepted",
+        (await db.featureRequest.findUnique({ where: { id: flowFR.id } }))?.status === "Accepted");
+  check("the requester is notified",
+        (await db.notification.count({ where: { recipientId: ayla.id, featureId: flowFR.id } })) > 0);
+  check("the toast names who was told",
+        paramOf(accepted.headers.get("location"), "toast").includes("Ayla Berg notified"),
+        paramOf(accepted.headers.get("location"), "toast"));
+  check("and it is audited",
+        (await db.auditEvent.count({ where: { action: "feature.status_changed", subject: refOf(flowFR.id) } })) === 1);
+
+  // Walk the rest of the flow via the queue's "Move to …" buttons.
+  for (const expected of ["InProgress", "Shipped", "Done"]) {
+    const q = await (await ruben.go(`${APP}/frr/queue`)).text();
+    const idx = formIndexContaining(q, `name="id" value="${flowFR.id}"`);
+    // The advance form for this id is the first one containing its id.
+    check(`a control exists to advance ${refOf(flowFR.id)}`, idx >= 0);
+    await ruben.submit(`${APP}/frr/queue`, q, idx, { id: String(flowFR.id) });
+    const row = await db.featureRequest.findUnique({ where: { id: flowFR.id } });
+    check(`advanced to ${expected}`, row?.status === expected, String(row?.status));
+  }
+  check("Done is the end of the flow", nextFeatureStatus("Done") === null);
+
+  // A bare POST cannot drive it past Done.
+  const past = await ruben.raw(`${APP}/frr/${flowFR.id}`, {
+    method: "POST",
+    body: (() => { const f = new FormData(); f.set("id", String(flowFR.id)); return f; })(),
+  });
+  void past;
+  check("nothing moves past Done",
+        (await db.featureRequest.findUnique({ where: { id: flowFR.id } }))?.status === "Done");
+
+  // ------------------------------------------------------------------
+  section("declining, terminal and only from Requested");
+  const fresh = await makeFeature(ayla.id, "Export to CSV");
+  const fd = await (await ruben.go(`${APP}/frr/${fresh.id}`)).text();
+  const declineIdx = formIndexContaining(fd, "Yes, decline it");
+  check("the decline control is offered on a Requested item", declineIdx >= 0);
+  await ruben.submit(`${APP}/frr/${fresh.id}`, fd, declineIdx, {});
+  check("Requested → Declined",
+        (await db.featureRequest.findUnique({ where: { id: fresh.id } }))?.status === "Declined");
+  check("declining is audited",
+        (await db.auditEvent.count({ where: { action: "feature.declined", subject: refOf(fresh.id) } })) === 1);
+
+  const accForDecline = await makeFeature(ayla.id, "Already accepted", "Accepted");
+  const declineLate = await ruben.raw(`${APP}/frr/${accForDecline.id}`, {
+    method: "POST",
+    body: (() => { const f = new FormData(); f.set("id", String(accForDecline.id)); return f; })(),
+  });
+  void declineLate;
+  check("an accepted request stays accepted (no bare-POST decline)",
+        (await db.featureRequest.findUnique({ where: { id: accForDecline.id } }))?.status === "Accepted");
+
+  // ------------------------------------------------------------------
+  section("the conversation");
+  const talk = await makeFeature(ayla.id, "Talk about this one");
+  let page = await (await client.go(`${APP}/frr/${talk.id}`)).text();
+  const sayIdx = formIndexContaining(page, 'name="body"');
+  check("a client gets a composer on their own request", sayIdx >= 0);
+  await client.submit(`${APP}/frr/${talk.id}`, page, sayIdx, { body: "Could this include the queue too?" });
+  const thread = await db.featureComment.findMany({ where: { featureId: talk.id } });
+  check("the comment is stored", thread.length === 1);
+  check("attributed to the client", thread[0]?.authorId === ayla.id);
+  check("the owner is told", (await db.notification.count({
+    where: { recipientId: admin.id, featureId: talk.id }, // created + comment
+  })) >= 1);
+  check("the client is not told about their own comment",
+        (await db.notification.count({ where: { recipientId: ayla.id, featureId: talk.id } })) === 0);
+
+  // Another client cannot comment on a request they cannot see.
+  const intruder = await other.raw(`${APP}/frr/${talk.id}`, {
+    method: "POST",
+    body: (() => { const f = new FormData(); f.set("featureId", String(talk.id)); f.set("body", "hi"); return f; })(),
+  });
+  void intruder;
+  check("another client cannot comment on a request they cannot see",
+        (await db.featureComment.count({ where: { authorId: mallory.id } })) === 0);
+
+  // Hostile body is escaped, not rendered.
+  page = await (await client.go(`${APP}/frr/${talk.id}`)).text();
+  await client.submit(`${APP}/frr/${talk.id}`, page, formIndexContaining(page, 'name="body"'),
+    { body: "<script>alert(1)</script>" });
+  page = await (await client.go(`${APP}/frr/${talk.id}`)).text();
+  check("a hostile comment body is escaped, not rendered", !page.includes("<script>alert(1)</script>"));
+
+  // ------------------------------------------------------------------
+  section("the requester can withdraw their own, while untouched");
+  const regret = await makeFeature(ayla.id, "Changed my mind");
+  const rp = await (await client.go(`${APP}/frr/${regret.id}`)).text();
+  const wIdx = formIndexContaining(rp, "Yes, withdraw it");
+  check("the requester is offered withdraw", wIdx >= 0);
+  await client.submit(`${APP}/frr/${regret.id}`, rp, wIdx, { id: String(regret.id) });
+  check("withdrawing removes it", (await db.featureRequest.count({ where: { id: regret.id } })) === 0);
+  check("and it is audited",
+        (await db.auditEvent.count({ where: { action: "feature.withdrawn", subject: refOf(regret.id) } })) === 1);
+
+  const started = await makeFeature(ayla.id, "Too late", "InProgress");
+  const sp = await (await client.go(`${APP}/frr/${started.id}`)).text();
+  check("a started request offers no withdrawal", !sp.includes("Yes, withdraw it"));
+  const forceWithdraw = await client.raw(`${APP}/frr/${started.id}`, {
+    method: "POST",
+    body: (() => { const f = new FormData(); f.set("id", String(started.id)); return f; })(),
+  });
+  void forceWithdraw;
+  check("and a bare POST cannot force it",
+        (await db.featureRequest.count({ where: { id: started.id } })) === 1);
+
+  const adminForce = await ruben.raw(`${APP}/frr/${mine.id}`, {
+    method: "POST",
+    body: (() => { const f = new FormData(); f.set("id", String(mine.id)); return f; })(),
+  });
+  void adminForce;
+  check("the owner cannot withdraw somebody's request",
+        (await db.featureRequest.count({ where: { id: mine.id } })) === 1);
+
+  // ------------------------------------------------------------------
+  section("the board draws the four live rails, closed items leave");
+  const board = rendered(await (await ruben.go(`${APP}/frr`)).text());
+  for (const rail of FEATURE_BOARD) {
+    const label = rail === "InProgress" ? "In progress" : rail;
+    check(`the board draws the ${label} rail`, board.includes(label));
+  }
+  check("Done is not a rail (it is under Closed)", board.includes("Closed"));
+
+  console.info(
+    `\n${passed} checks passed, ${failures.length} failed` +
+      (failures.length ? `:\n  - ${failures.join("\n  - ")}` : ""),
+  );
+  process.exitCode = failures.length ? 1 : 0;
+}
+
+main()
+  .catch((e) => { console.error(e); process.exitCode = 1; })
+  .finally(() => db.$disconnect());

--- a/src/app/actions/features.ts
+++ b/src/app/actions/features.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { requireAdmin, requireUser } from "@/lib/authz";
+import {
+  FeatureProblem,
+  addFeatureComment as postComment,
+  advanceFeature as advance,
+  createFeature as create,
+  declineFeature as decline,
+  featureIdOr400,
+  withdrawFeature as withdraw,
+} from "@/lib/features";
+
+/**
+ * The feature-request forms, as plain server actions.
+ *
+ * Adapters, exactly like `src/app/actions/stories.ts`: the rules live in
+ * `src/lib/features.ts`; this reads a `FormData`, calls the operation, and
+ * turns the outcome into a redirect with a toast. Everything works with
+ * JavaScript off.
+ */
+
+function back(to: string, params: Record<string, string>): never {
+  redirect(`${to}?${new URLSearchParams(params).toString()}`);
+}
+
+/** A same-origin absolute path from the form, or a fallback. Open-redirect guard. */
+function safeFrom(from: FormDataEntryValue | null, fallback: string): string {
+  const raw = typeof from === "string" ? from : "";
+  return raw.startsWith("/") && !raw.startsWith("//") ? raw.split("?")[0]! : fallback;
+}
+
+/** File a new request, then land on its detail page. */
+export async function createFeature(formData: FormData): Promise<void> {
+  const user = await requireUser();
+  try {
+    const feature = await create(user, {
+      title: formData.get("title") ?? "",
+      description: formData.get("description") ?? "",
+      priority: formData.get("priority") ?? "medium",
+      category: formData.get("category") ?? "other",
+    });
+    back(`/frr/${feature.id}`, { sent: "1" });
+  } catch (error) {
+    if (error instanceof FeatureProblem) back("/frr/new", { error: error.message });
+    throw error;
+  }
+}
+
+async function ownerStep(
+  formData: FormData,
+  op: (id: number) => Promise<{ toast: string }>,
+): Promise<never> {
+  const from = safeFrom(formData.get("from"), "/frr/queue");
+  try {
+    const id = featureIdOr400(formData.get("id"));
+    const { toast } = await op(id);
+    back(from, { toast });
+  } catch (error) {
+    if (error instanceof FeatureProblem) back(from, { error: error.message });
+    throw error;
+  }
+}
+
+export async function advanceFeature(formData: FormData): Promise<void> {
+  const admin = await requireAdmin();
+  await ownerStep(formData, async (id) => {
+    const done = await advance(admin, id);
+    return { toast: `“${done.title}” → ${done.to === "InProgress" ? "In progress" : done.to} · ${done.requesterName} notified` };
+  });
+}
+
+export async function declineFeature(formData: FormData): Promise<void> {
+  const admin = await requireAdmin();
+  await ownerStep(formData, async (id) => {
+    const done = await decline(admin, id);
+    return { toast: `Declined · ${done.requesterName} notified` };
+  });
+}
+
+/** The requester takes their own back; lands on the board. */
+export async function withdrawFeature(formData: FormData): Promise<void> {
+  const user = await requireUser();
+  const id = featureIdOr400(formData.get("id"));
+  try {
+    const done = await withdraw(user, id);
+    back("/frr", { toast: `${done.ref} withdrawn.` });
+  } catch (error) {
+    if (error instanceof FeatureProblem) back(`/frr/${id}`, { toast: error.message });
+    throw error;
+  }
+}
+
+/** Say something on a request. */
+export async function addFeatureComment(formData: FormData): Promise<void> {
+  const actor = await requireUser();
+  const id = featureIdOr400(formData.get("featureId"));
+  try {
+    await postComment(actor, id, formData.get("body") ?? "");
+  } catch (error) {
+    if (error instanceof FeatureProblem) {
+      if (error.status === 404) redirect("/frr");
+      back(`/frr/${id}`, { error: error.message });
+    }
+    throw error;
+  }
+  back(`/frr/${id}`, { toast: "Sent" });
+}

--- a/src/app/frr/[id]/page.tsx
+++ b/src/app/frr/[id]/page.tsx
@@ -1,0 +1,181 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { requireUser, printerName } from "@/lib/authz";
+import { FEATURE_FLOW, featureLabel, featureRef } from "@/lib/scope";
+import { findFeature, listFeatureComments } from "@/lib/features";
+import { withdrawFeature } from "@/app/actions/features";
+import { relativeTime, PRIORITY_CHIP, CATEGORY_LABEL } from "@/lib/catalog";
+import { AppHeader } from "@/components/app-header";
+import { Fact, Notice, StatusChip } from "@/components/ui";
+import { FeatureActions } from "@/components/feature-actions";
+import { FeatureConversation } from "@/components/feature-conversation";
+import { Toast } from "@/components/toast";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * A feature request in full — the print `/story/[id]`'s sibling: the ask, where
+ * it sits in the flow, the conversation, and (for the owner) the controls to
+ * move it along. Scoped by `findFeature`, so a client asking after someone
+ * else's request gets 404, not 403.
+ */
+export default async function FeaturePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ sent?: string; toast?: string; error?: string }>;
+}) {
+  const [{ id }, { sent, toast, error }] = await Promise.all([params, searchParams]);
+  const featureId = Number(id);
+  if (!Number.isInteger(featureId)) notFound();
+
+  const user = await requireUser(`/frr/${id}`);
+  // 404 (not 403) for a request that is not the caller's to see — a 403 would
+  // confirm it exists. Same decision the story page makes.
+  const feature = await findFeature(user, featureId);
+  if (!feature) notFound();
+  const comments = await listFeatureComments(user, featureId);
+  const owner = await printerName();
+
+  const priority = PRIORITY_CHIP[feature.priority] ?? PRIORITY_CHIP.medium!;
+  const currentIndex = (FEATURE_FLOW as readonly string[]).indexOf(feature.status);
+  const canWithdraw =
+    feature.requester.id === user.id &&
+    (feature.status === "Requested" || feature.status === "Declined");
+
+  return (
+    <>
+      <AppHeader user={user} active="/frr" />
+
+      <main className="mx-auto w-full max-w-[900px] px-[26.4px] pb-[80px] pt-[35.2px]">
+        <Link
+          href="/frr"
+          className="inline-block font-mono text-[12px] font-bold uppercase tracking-[0.08em] text-ink-2 underline underline-offset-4 hover:text-cherry-dk"
+        >
+          ← Back to requests
+        </Link>
+
+        <div className="mt-[13.2px] mb-[8.8px] flex flex-wrap items-center gap-[8.8px]">
+          <span className="rounded-chip border-2 border-ink bg-porcelain px-[11px] py-[3px] font-mono text-[12px] font-bold tracking-[0.06em] text-ink">
+            {featureRef(feature.id)}
+          </span>
+          <StatusChip status={feature.status} label={featureLabel(feature.status)} />
+          <span className={`rounded-chip border-2 border-ink px-[11px] py-[3px] font-mono text-[11.5px] font-bold uppercase tracking-[0.06em] text-ink ${priority.bg}`}>
+            {priority.label}
+          </span>
+          <span className="rounded-chip border-2 border-ink bg-aqua-wash px-[11px] py-[3px] font-mono text-[11.5px] font-bold uppercase tracking-[0.06em] text-ink">
+            {CATEGORY_LABEL[feature.category] ?? feature.category}
+          </span>
+        </div>
+
+        <h1 className="m-0 mb-[13.2px] text-[32px] leading-[1.05] text-ink">{feature.title}</h1>
+
+        {feature.description && (
+          <p className="m-0 mb-[22px] whitespace-pre-wrap text-[16px] leading-[1.6] text-ink-2">
+            {feature.description}
+          </p>
+        )}
+
+        <div className="rounded-panel border-[3px] border-ink bg-porcelain p-[22px] shadow-stamp">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-[17.6px]">
+            <Fact label="Asked by">{feature.requester.name}</Fact>
+            <Fact label="Priority">{priority.label}</Fact>
+            <Fact label="Category">{CATEGORY_LABEL[feature.category] ?? feature.category}</Fact>
+            <Fact label="Filed">{relativeTime(feature.createdAt)}</Fact>
+          </div>
+        </div>
+
+        <section className="mt-[26.4px]">
+          <h2 className="m-0 mb-[13.2px] font-display text-[22px] text-ink">Where it&rsquo;s at</h2>
+          {feature.status === "Declined" ? (
+            <p className="m-0 rounded-card border-[3px] border-ink bg-cream-3 px-[17.6px] py-[13.2px] text-[15px] text-ink-2">
+              This one was declined {relativeTime(feature.updatedAt)}.
+            </p>
+          ) : (
+            <ol className="m-0 flex list-none flex-col p-0">
+              {FEATURE_FLOW.map((step, i) => {
+                const done = currentIndex >= 0 && i < currentIndex;
+                const now = i === currentIndex;
+                return (
+                  <li key={step} className="flex items-start gap-[13.2px]">
+                    <div className="flex flex-none flex-col items-center">
+                      <span
+                        aria-hidden
+                        className={`h-[20px] w-[20px] rounded-full border-[3px] border-ink ${
+                          done ? "bg-mint" : now ? "bg-sun" : "bg-cream-3"
+                        }`}
+                      />
+                      {i < FEATURE_FLOW.length - 1 && (
+                        <span
+                          aria-hidden
+                          className={`w-[4px] flex-1 ${done ? "bg-mint" : "bg-cream-3"}`}
+                          style={{ minHeight: "26px" }}
+                        />
+                      )}
+                    </div>
+                    <div className="pb-[17.6px]">
+                      <div className={`font-display text-[17px] ${done || now ? "text-ink" : "text-ink-3"}`}>
+                        {featureLabel(step)}
+                      </div>
+                      <div className="mt-[3px] font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-ink-3">
+                        {now ? "now" : done ? "cleared" : "waiting"}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+        </section>
+
+        {canWithdraw && (
+          <form action={withdrawFeature} className="mt-[13.2px]">
+            <input type="hidden" name="id" value={feature.id} />
+            <details className="group">
+              <summary className="inline-block cursor-pointer list-none font-mono text-[12px] font-bold uppercase tracking-[0.06em] text-ink-3 underline underline-offset-4 hover:text-cherry-dk">
+                Withdraw this request
+              </summary>
+              <div className="mt-[8.8px] rounded-card border-[3px] border-ink bg-cream-2 p-[13.2px]">
+                <p className="m-0 mb-[8px] text-[14px] text-ink-2">
+                  This removes it and its conversation. Only while nobody has started on it.
+                </p>
+                <button
+                  type="submit"
+                  className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-cherry-wash"
+                >
+                  Yes, withdraw it
+                </button>
+              </div>
+            </details>
+          </form>
+        )}
+
+        {user.role === "admin" && (
+          <section className="mt-[26.4px] rounded-panel border-[3px] border-ink bg-aqua-wash p-[22px] shadow-stamp">
+            <h2 className="m-0 mb-[13.2px] font-display text-[20px] text-ink">
+              {feature.status === "Requested" ? "This one needs a yes" : "Move it along"}
+            </h2>
+            {error && (
+              <div className="mb-[13.2px]">
+                <Notice tone="warn">{error}</Notice>
+              </div>
+            )}
+            <FeatureActions featureId={feature.id} status={feature.status} from={`/frr/${feature.id}`} />
+          </section>
+        )}
+
+        <FeatureConversation
+          featureId={feature.id}
+          comments={comments}
+          viewerRole={user.role}
+          ownerName={owner}
+        />
+      </main>
+
+      {sent && <Toast>Filed · {owner} has been notified</Toast>}
+      {toast && <Toast>{toast}</Toast>}
+    </>
+  );
+}

--- a/src/app/frr/new/page.tsx
+++ b/src/app/frr/new/page.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+
+import { requireUser, printerName } from "@/lib/authz";
+import {
+  FEATURE_PRIORITIES,
+  FEATURE_CATEGORIES,
+  DEFAULT_FEATURE_PRIORITY,
+  DEFAULT_FEATURE_CATEGORY,
+  PRIORITY_CHIP,
+  CATEGORY_LABEL,
+} from "@/lib/catalog";
+import { createFeature } from "@/app/actions/features";
+import { AppHeader } from "@/components/app-header";
+import { Kicker, Label, Input, Notice } from "@/components/ui";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * File a feature request. A plain server-rendered form posting to the
+ * `createFeature` action — no file to carry, so unlike an upload it needs no
+ * client bundle and works with JavaScript off. Title, description, priority
+ * and category, exactly as the catalogue defines them; the server validates
+ * against the same schema the form renders from.
+ */
+export default async function NewFeaturePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const [{ error }, user] = await Promise.all([searchParams, requireUser("/frr/new")]);
+  const owner = await printerName();
+
+  return (
+    <>
+      <AppHeader user={user} active="/frr" />
+
+      <main className="mx-auto w-full max-w-[780px] px-[26.4px] pb-[80px] pt-[35.2px]">
+        <Link
+          href="/frr"
+          className="inline-block font-mono text-[12px] font-bold uppercase tracking-[0.08em] text-ink-2 underline underline-offset-4 hover:text-cherry-dk"
+        >
+          ← Back to requests
+        </Link>
+
+        <div className="mt-[13.2px] mb-[22px]">
+          <Kicker>New request</Kicker>
+          <h1 className="m-0 mt-[6px] font-display text-[30px] leading-[1.05] text-ink">
+            Ask for a feature
+          </h1>
+          <p className="m-0 mt-[8px] text-[15px] text-ink-2">
+            Say what you are hoping for and why. {owner} sees it on the board and takes
+            it from there.
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-[17.6px]">
+            <Notice tone="warn">{error}</Notice>
+          </div>
+        )}
+
+        <form action={createFeature} className="flex flex-col gap-[17.6px]">
+          <div>
+            <Label htmlFor="title">Title</Label>
+            <Input id="title" name="title" required maxLength={120} placeholder="A short summary" />
+          </div>
+
+          <div>
+            <Label htmlFor="description">What &amp; why</Label>
+            <textarea
+              id="description"
+              name="description"
+              required
+              maxLength={4000}
+              rows={6}
+              placeholder="What you'd like, and what it would let you do."
+              className="w-full rounded-card border-[3px] border-ink bg-porcelain px-[15px] py-[12px] text-[16px] leading-[1.5] text-ink placeholder:text-ink-3"
+            />
+          </div>
+
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-[17.6px]">
+            <div>
+              <Label htmlFor="priority">Priority</Label>
+              <select
+                id="priority"
+                name="priority"
+                defaultValue={DEFAULT_FEATURE_PRIORITY}
+                className="w-full rounded-card border-[3px] border-ink bg-porcelain px-[15px] py-[12px] text-[16px] text-ink"
+              >
+                {FEATURE_PRIORITIES.map((p) => (
+                  <option key={p} value={p}>
+                    {PRIORITY_CHIP[p]?.label ?? p}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="category">Category</Label>
+              <select
+                id="category"
+                name="category"
+                defaultValue={DEFAULT_FEATURE_CATEGORY}
+                className="w-full rounded-card border-[3px] border-ink bg-porcelain px-[15px] py-[12px] text-[16px] text-ink"
+              >
+                {FEATURE_CATEGORIES.map((c) => (
+                  <option key={c} value={c}>
+                    {CATEGORY_LABEL[c] ?? c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[28px] py-[13px] text-[16px] font-bold text-cream hover:bg-cherry"
+            >
+              File the request
+            </button>
+          </div>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/src/app/frr/page.tsx
+++ b/src/app/frr/page.tsx
@@ -1,0 +1,122 @@
+import Link from "next/link";
+
+import { requireUser, printerName } from "@/lib/authz";
+import { FEATURE_BOARD, featureLabel } from "@/lib/scope";
+import { listFeatures } from "@/lib/features";
+import { AppHeader } from "@/components/app-header";
+import { FeatureCard } from "@/components/feature-card";
+import { Kicker } from "@/components/ui";
+import { Toast } from "@/components/toast";
+import type { FeatureStatus } from "@prisma/client";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * The feature-request rail — the 'frr' track's board, the print `/board`'s
+ * sibling. One rail per stage in flow order; `Done` and `Declined` leave the
+ * rail and gather in a "Closed" strip below, so a requester still sees their
+ * own history without a separate page.
+ *
+ * Scoped by `featureScope` in the query: a client's own requests never leave
+ * the database, the owner sees everyone's.
+ */
+const RAIL: Record<string, { bar: string; note: string }> = {
+  Requested: { bar: "bg-chrome", note: "waiting on a yes" },
+  Accepted: { bar: "bg-aqua", note: "agreed, queued" },
+  InProgress: { bar: "bg-sun", note: "being built" },
+  Shipped: { bar: "bg-cherry", note: "released — go and check" },
+};
+
+export default async function FeatureBoardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ toast?: string }>;
+}) {
+  const [{ toast }, user] = await Promise.all([searchParams, requireUser("/frr")]);
+  const owner = await printerName();
+
+  const features = await listFeatures(user);
+  const isAdmin = user.role === "admin";
+
+  const closed = features.filter((f) => f.status === "Done" || f.status === "Declined");
+  const byStatus = (status: FeatureStatus) => features.filter((f) => f.status === status);
+
+  return (
+    <>
+      <AppHeader user={user} active="/frr" />
+
+      <main className="mx-auto w-full max-w-[1180px] px-[26.4px] pb-[80px] pt-[35.2px]">
+        <div className="mb-[26.4px] flex flex-wrap items-end justify-between gap-[13.2px]">
+          <div>
+            <Kicker>Feature requests</Kicker>
+            <h1 className="m-0 mt-[6px] font-display text-[30px] leading-[1.05] text-ink">
+              {isAdmin ? "Everything asked for" : "What you've asked for"}
+            </h1>
+            <p className="m-0 mt-[8px] max-w-[60ch] text-[15px] text-ink-2">
+              Ask for a change to Pretty Please Print, and follow it through the same
+              stages a print goes through. {owner} sees each one and moves it along.
+            </p>
+          </div>
+          <Link
+            href="/frr/new"
+            className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[22px] py-[11px] text-[15px] font-bold text-cream hover:bg-cherry"
+          >
+            + New request
+          </Link>
+        </div>
+
+        {features.length === 0 ? (
+          <div className="rounded-panel border-[3px] border-dashed border-ink-3 bg-cream-2 px-[26.4px] py-[35.2px] text-center">
+            <p className="m-0 font-display text-[19px] text-ink">Nothing here yet</p>
+            <p className="m-0 mt-[6px] text-[15px] text-ink-2">
+              The first idea goes on the board the moment you file it.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-[17.6px]">
+            {FEATURE_BOARD.map((status) => {
+              const rail = RAIL[status]!;
+              const items = byStatus(status);
+              return (
+                <section key={status} className="flex flex-col gap-[11px]">
+                  <div className="rounded-card border-[3px] border-ink bg-porcelain">
+                    <div className={`h-[8px] rounded-t-[5px] border-b-[3px] border-ink ${rail.bar}`} />
+                    <div className="px-[13.2px] py-[8.8px]">
+                      <div className="flex items-baseline justify-between gap-[8px]">
+                        <span className="font-display text-[16px] text-ink">
+                          {featureLabel(status)}
+                        </span>
+                        <span className="font-mono text-[12px] font-bold text-ink-3">
+                          {items.length}
+                        </span>
+                      </div>
+                      <p className="m-0 font-mono text-[11px] uppercase tracking-[0.05em] text-ink-3">
+                        {rail.note}
+                      </p>
+                    </div>
+                  </div>
+                  {items.map((f) => (
+                    <FeatureCard key={f.id} feature={f} showRequester={isAdmin} />
+                  ))}
+                </section>
+              );
+            })}
+          </div>
+        )}
+
+        {closed.length > 0 && (
+          <section className="mt-[35.2px]">
+            <h2 className="m-0 mb-[13.2px] font-display text-[20px] text-ink">Closed</h2>
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-[17.6px] opacity-80">
+              {closed.map((f) => (
+                <FeatureCard key={f.id} feature={f} showRequester={isAdmin} />
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+
+      {toast && <Toast>{toast}</Toast>}
+    </>
+  );
+}

--- a/src/app/frr/queue/page.tsx
+++ b/src/app/frr/queue/page.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+
+import { db } from "@/lib/db";
+import { requireAdmin } from "@/lib/authz";
+import { featureLabel, featureRef } from "@/lib/scope";
+import { FEATURE_FIELDS } from "@/lib/features";
+import { relativeTime, PRIORITY_CHIP, CATEGORY_LABEL } from "@/lib/catalog";
+import { AppHeader } from "@/components/app-header";
+import { FeatureActions } from "@/components/feature-actions";
+import { Kicker, Notice, StatusChip } from "@/components/ui";
+import { Toast } from "@/components/toast";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * The owner's triage for feature requests — the print `/queue`'s sibling.
+ * "Waiting on you" (still `Requested`) comes first and loudest and vanishes
+ * when empty; everything already accepted is a list to scan with one control
+ * each. Admin-only: `requireAdmin` answers 404 to a client.
+ */
+export default async function FeatureQueuePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ toast?: string; error?: string }>;
+}) {
+  const [{ toast, error }, admin] = await Promise.all([searchParams, requireAdmin()]);
+
+  const features = await db.featureRequest.findMany({
+    select: FEATURE_FIELDS,
+    orderBy: { createdAt: "asc" },
+  });
+
+  // Priority order for the eye: high first. Within a priority, oldest first.
+  const rank = { high: 0, medium: 1, low: 2 } as Record<string, number>;
+  const waiting = features
+    .filter((f) => f.status === "Requested")
+    .sort((a, b) => (rank[a.priority]! - rank[b.priority]!));
+  const moving = features.filter(
+    (f) => f.status !== "Requested" && f.status !== "Done" && f.status !== "Declined",
+  );
+
+  return (
+    <>
+      <AppHeader user={admin} active="/frr/queue" />
+
+      <main className="mx-auto w-full max-w-[1180px] px-[26.4px] pb-[80px] pt-[35.2px]">
+        <Kicker>Feature requests</Kicker>
+        <h1 className="m-0 mt-[6px] mb-[22px] font-display text-[30px] leading-[1.05] text-ink">
+          Requests to triage
+        </h1>
+
+        {error && (
+          <div className="mb-[17.6px]">
+            <Notice tone="warn">{error}</Notice>
+          </div>
+        )}
+
+        {waiting.length > 0 && (
+          <section className="mb-[35.2px]">
+            <h2 className="m-0 mb-[13.2px] font-display text-[22px] text-ink">Waiting on you</h2>
+            <div className="flex flex-col gap-[13.2px]">
+              {waiting.map((f) => {
+                const priority = PRIORITY_CHIP[f.priority] ?? PRIORITY_CHIP.medium!;
+                return (
+                  <div
+                    key={f.id}
+                    className="rounded-panel border-[3px] border-ink bg-porcelain p-[17.6px] shadow-stamp"
+                  >
+                    <div className="mb-[8px] flex flex-wrap items-center gap-[8px]">
+                      <Link
+                        href={`/frr/${f.id}`}
+                        className="font-mono text-[12px] font-bold tracking-[0.08em] text-ink-3 underline underline-offset-2 hover:text-cherry-dk"
+                      >
+                        {featureRef(f.id)}
+                      </Link>
+                      <span className={`rounded-chip border-2 border-ink px-[8px] py-[1px] font-mono text-[10.5px] font-bold uppercase tracking-[0.06em] text-ink ${priority.bg}`}>
+                        {priority.label}
+                      </span>
+                      <span className="rounded-chip border-2 border-ink bg-aqua-wash px-[8px] py-[1px] font-mono text-[10.5px] font-bold uppercase tracking-[0.06em] text-ink">
+                        {CATEGORY_LABEL[f.category] ?? f.category}
+                      </span>
+                    </div>
+                    <Link href={`/frr/${f.id}`} className="font-display text-[19px] text-ink hover:text-cherry-dk">
+                      {f.title}
+                    </Link>
+                    <p className="m-0 mt-[6px] mb-[13.2px] line-clamp-3 text-[15px] leading-[1.5] text-ink-2">
+                      {f.description}
+                    </p>
+                    <div className="flex flex-wrap items-center justify-between gap-[13.2px]">
+                      <span className="font-mono text-[11.5px] text-ink-3">
+                        {f.requester.name} · {relativeTime(f.createdAt)}
+                      </span>
+                      <FeatureActions featureId={f.id} status={f.status} from="/frr/queue" />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        <section>
+          <h2 className="m-0 mb-[13.2px] font-display text-[22px] text-ink">In flight</h2>
+          {moving.length === 0 ? (
+            <p className="m-0 rounded-card border-[3px] border-dashed border-ink-3 bg-cream-2 px-[15px] py-[13.2px] font-mono text-[12px] uppercase tracking-[0.05em] text-ink-3">
+              Nothing accepted and in progress
+            </p>
+          ) : (
+            <div className="flex flex-col gap-[11px]">
+              {moving.map((f) => (
+                <div
+                  key={f.id}
+                  className="flex flex-wrap items-center justify-between gap-[13.2px] rounded-card border-[3px] border-ink bg-porcelain px-[15px] py-[13.2px]"
+                >
+                  <div className="min-w-[220px] flex-1">
+                    <div className="mb-[4px] flex flex-wrap items-center gap-[8px]">
+                      <Link href={`/frr/${f.id}`} className="font-mono text-[12px] font-bold text-ink-3 underline underline-offset-2 hover:text-cherry-dk">
+                        {featureRef(f.id)}
+                      </Link>
+                      <StatusChip status={f.status} label={featureLabel(f.status)} />
+                    </div>
+                    <Link href={`/frr/${f.id}`} className="font-display text-[16px] text-ink hover:text-cherry-dk">
+                      {f.title}
+                    </Link>
+                  </div>
+                  <FeatureActions featureId={f.id} status={f.status} from="/frr/queue" />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+
+      {toast && <Toast>{toast}</Toast>}
+    </>
+  );
+}

--- a/src/components/activity-menu.tsx
+++ b/src/components/activity-menu.tsx
@@ -9,6 +9,7 @@ export type FeedItem = {
   when: string;
   read: boolean;
   storyId: number | null;
+  featureId: number | null;
 };
 
 /**
@@ -94,6 +95,16 @@ export function ActivityMenu({
                 type="button"
                 onClick={() => {
                   if (!item.read) startTransition(() => void markRead(item.id));
+                  // Take them to whatever the notification is about. A feature
+                  // request goes to /frr, a print to /story; a reference-less
+                  // one (a withdrawal) just marks read.
+                  const href =
+                    item.featureId !== null
+                      ? `/frr/${item.featureId}`
+                      : item.storyId !== null
+                        ? `/story/${item.storyId}`
+                        : null;
+                  if (href) window.location.assign(href);
                 }}
                 className={`flex cursor-pointer gap-[13.2px] rounded-card border-2 border-transparent px-[13.2px] py-[11px] text-left hover:border-ink hover:bg-cream-2 ${
                   item.read ? "bg-transparent" : "bg-sun-wash"

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -21,11 +21,13 @@ const NAV: Record<Actor["role"], Array<{ label: string; href: string }>> = {
     { label: "The rail", href: "/board" },
     { label: "Order up", href: "/upload" },
     { label: "My orders", href: "/me" },
+    { label: "Requests", href: "/frr" },
   ],
   admin: [
     { label: "The pass", href: "/queue" },
     { label: "The rail", href: "/board" },
     { label: "The books", href: "/me" },
+    { label: "Requests", href: "/frr/queue" },
     { label: "Guest list", href: "/admin/invites" },
     { label: "Audit", href: "/admin/audit" },
   ],
@@ -53,6 +55,7 @@ export async function AppHeader({
     when: relativeTime(n.createdAt),
     read: n.read,
     storyId: n.storyId,
+    featureId: n.featureId,
   }));
   const unread = items.filter((i) => !i.read).length;
 

--- a/src/components/feature-actions.tsx
+++ b/src/components/feature-actions.tsx
@@ -1,0 +1,70 @@
+import { advanceFeature, declineFeature } from "@/app/actions/features";
+import { featureLabel, nextFeatureStatus } from "@/lib/scope";
+import type { FeatureStatus } from "@prisma/client";
+
+/**
+ * The printer owner's controls for one feature request — the print
+ * `AdminActions`' sibling, minus the flag (a feature has no "model problem";
+ * declining or a comment covers "not like this").
+ *
+ * Plain forms posting to server actions, so the panel works with JavaScript
+ * off. Decline sits behind a `<details>` disclosure because it is terminal.
+ */
+export function FeatureActions({
+  featureId,
+  status,
+  from,
+}: {
+  featureId: number;
+  status: FeatureStatus;
+  from: string;
+}) {
+  const next = nextFeatureStatus(status);
+  const isNew = status === "Requested";
+
+  if (status === "Declined") {
+    return (
+      <p className="m-0 font-mono text-[11.5px] uppercase tracking-[0.06em] text-ink-3">
+        Declined — nothing further
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-start gap-[8px]">
+      {next && (
+        <form action={advanceFeature}>
+          <input type="hidden" name="id" value={featureId} />
+          <input type="hidden" name="from" value={from} />
+          <button
+            type="submit"
+            className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[18px] py-[8px] text-[14px] font-bold text-cream hover:bg-cherry"
+          >
+            {isNew ? "Accept it" : `Move to ${featureLabel(next)}`}
+          </button>
+        </form>
+      )}
+
+      {isNew && (
+        <details className="group">
+          <summary className="stamp inline-block cursor-pointer list-none rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-sun">
+            Decline
+          </summary>
+          <form action={declineFeature} className="mt-[8.8px]">
+            <input type="hidden" name="id" value={featureId} />
+            <input type="hidden" name="from" value={from} />
+            <p className="m-0 mb-[8px] font-mono text-[11.5px] text-ink-2">
+              This closes it. The requester is told.
+            </p>
+            <button
+              type="submit"
+              className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cream-2 px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-cherry-wash"
+            >
+              Yes, decline it
+            </button>
+          </form>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/components/feature-card.tsx
+++ b/src/components/feature-card.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+
+import { relativeTime, PRIORITY_CHIP, CATEGORY_LABEL } from "@/lib/catalog";
+import { featureRef } from "@/lib/scope";
+import type { FeatureRow } from "@/lib/features";
+
+/**
+ * A feature request, as a ticket on the 'frr' rail — the print `StoryCard`'s
+ * sibling. No filament stripe (there is no file); the left edge carries the
+ * priority colour instead, and the category rides where the material chip does
+ * on a print, so the two boards read the same at a glance.
+ *
+ * `showRequester` carries the scope rule into the design, exactly as
+ * `showUploader` does: a client only ever sees their own, so their name on
+ * every card would be noise.
+ */
+export function FeatureCard({
+  feature,
+  showRequester,
+}: {
+  feature: FeatureRow;
+  showRequester: boolean;
+}) {
+  const priority = PRIORITY_CHIP[feature.priority] ?? PRIORITY_CHIP.medium!;
+
+  return (
+    <Link
+      href={`/frr/${feature.id}`}
+      className="ticket group block rounded-card border-[3px] border-ink bg-porcelain shadow-stamp transition-transform hover:-translate-y-[2px] hover:shadow-stamp-lg"
+    >
+      {/* Priority worn as the edge stripe, where a print wears its filament. */}
+      <span
+        aria-hidden
+        className={`block h-[8px] rounded-t-[7px] border-b-[3px] border-ink ${priority.bg}`}
+      />
+
+      <div className="px-[15px] py-[13.2px]">
+        <div className="mb-[8.8px] flex flex-wrap items-center gap-[6px]">
+          <span className="whitespace-nowrap font-mono text-[12px] font-bold tracking-[0.08em] text-ink-3">
+            {featureRef(feature.id)}
+          </span>
+          <span className="rounded-chip border-2 border-ink bg-cream-2 px-[8px] py-[1px] font-mono text-[10.5px] font-bold uppercase tracking-[0.06em] text-ink">
+            {priority.label}
+          </span>
+        </div>
+
+        <div className="mb-[11px] font-display text-[15.5px] leading-[1.2] text-ink">
+          {feature.title}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-[6px]">
+          <span className="rounded-chip border-2 border-ink bg-aqua-wash px-[9px] py-[2px] font-mono text-[11px] font-bold uppercase tracking-[0.05em] text-ink">
+            {CATEGORY_LABEL[feature.category] ?? feature.category}
+          </span>
+          {feature._count.comments > 0 && (
+            <span className="rounded-chip border-2 border-ink bg-cream-2 px-[9px] py-[2px] font-mono text-[11px] font-bold text-ink">
+              {feature._count.comments} 💬
+            </span>
+          )}
+        </div>
+
+        <div className="mt-[11px] flex items-center gap-[8px] border-t-2 border-dashed border-rule pt-[8px] font-mono text-[11px] text-ink-3">
+          {showRequester && (
+            <span
+              aria-hidden
+              className="inline-flex h-[20px] w-[20px] flex-none items-center justify-center rounded-full border-2 border-ink bg-aqua text-[9.5px] font-bold text-ink"
+            >
+              {feature.requester.initials}
+            </span>
+          )}
+          <span className="truncate">
+            {showRequester
+              ? `${feature.requester.name} · ${relativeTime(feature.createdAt)}`
+              : relativeTime(feature.createdAt)}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/feature-conversation.tsx
+++ b/src/components/feature-conversation.tsx
@@ -1,0 +1,90 @@
+import { addFeatureComment } from "@/app/actions/features";
+import { relativeTime } from "@/lib/catalog";
+import type { FeatureCommentRow } from "@/lib/features";
+
+/**
+ * The thread on a feature request — the print `Conversation`'s sibling, posting
+ * to the feature comment action with a `featureId`. Kept parallel rather than
+ * generalised so each backlog's conversation stays self-contained.
+ */
+export function FeatureConversation({
+  featureId,
+  comments,
+  viewerRole,
+  ownerName,
+}: {
+  featureId: number;
+  comments: FeatureCommentRow[];
+  viewerRole: "client" | "admin";
+  ownerName: string;
+}) {
+  return (
+    <section className="mt-[26.4px]">
+      <h2 className="m-0 mb-[13.2px] font-display text-[22px] text-ink">Talk it over</h2>
+
+      {comments.length === 0 ? (
+        <p className="m-0 mb-[13.2px] rounded-card border-[3px] border-dashed border-ink-3 bg-cream-2 px-[15px] py-[13.2px] font-mono text-[12px] uppercase tracking-[0.05em] text-ink-3">
+          Nothing said yet
+        </p>
+      ) : (
+        <ol className="m-0 mb-[13.2px] flex list-none flex-col gap-[11px] p-0">
+          {comments.map((c) => {
+            const fromOwner = c.author.role === "admin";
+            return (
+              <li key={c.id} className="flex items-start gap-[11px]">
+                <span
+                  aria-hidden
+                  className={`mt-[3px] inline-flex h-[32px] w-[32px] flex-none items-center justify-center rounded-full border-[3px] border-ink font-mono text-[11px] font-bold text-ink ${
+                    fromOwner ? "bg-sun" : "bg-aqua"
+                  }`}
+                >
+                  {c.author.initials}
+                </span>
+                <div
+                  className={`flex-1 rounded-card border-[3px] border-ink p-[13.2px] shadow-stamp ${
+                    fromOwner ? "bg-sun-wash" : "bg-porcelain"
+                  }`}
+                >
+                  <p className="m-0 mb-[4px] font-mono text-[11px] font-bold uppercase tracking-[0.06em] text-ink-3">
+                    {c.author.name}
+                    {fromOwner ? " · the printer" : ""} · {relativeTime(c.createdAt)}
+                  </p>
+                  {/* React escapes this; a hostile body renders as text. */}
+                  <p className="m-0 whitespace-pre-wrap text-[15.5px] leading-[1.5] text-ink">
+                    {c.body}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      <form action={addFeatureComment} className="flex flex-wrap gap-[8.8px]">
+        <input type="hidden" name="featureId" value={featureId} />
+        <label htmlFor={`say-${featureId}`} className="sr-only">
+          Add to the conversation
+        </label>
+        <input
+          id={`say-${featureId}`}
+          name="body"
+          required
+          maxLength={2000}
+          autoComplete="off"
+          placeholder={
+            viewerRole === "admin"
+              ? "Ask a question, or say what you changed…"
+              : `Reply to ${ownerName}…`
+          }
+          className="min-w-[200px] flex-[1_1_260px] rounded-card border-[3px] border-ink bg-porcelain px-[15px] py-[11px] text-[16px] text-ink placeholder:text-ink-3"
+        />
+        <button
+          type="submit"
+          className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-aqua px-[24px] py-[11px] text-[15px] font-bold text-ink hover:bg-sun"
+        >
+          Send
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -185,13 +185,20 @@ const CHIP_SKIN: Record<string, string> = {
   Delivery: "bg-cherry text-ink",
   Done: "bg-mint text-ink",
   Declined: "bg-cream-3 text-ink-2",
+  // Feature-request states (see FEATURE_FLOW). Reuse the print palette's roles:
+  // sun = in-progress/warning, cherry = wants-you-to-act.
+  InProgress: "bg-sun text-ink",
+  Shipped: "bg-cherry text-ink",
 };
 
 export function StatusChip({
   status,
+  label,
   className = "",
 }: {
   status: string;
+  /** Display text when it differs from the enum value (e.g. "In progress"). */
+  label?: string;
   className?: string;
 }) {
   return (
@@ -200,7 +207,7 @@ export function StatusChip({
         CHIP_SKIN[status] ?? CHIP_SKIN.Requested
       } ${className}`}
     >
-      {status}
+      {label ?? status}
     </span>
   );
 }

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -41,7 +41,13 @@ export type AuditAction =
   | "story.flag_cleared"
   | "comment.added"
   | "file.downloaded"
-  | "file.refused";
+  | "file.refused"
+  // feature requests (the 'frr' track)
+  | "feature.created"
+  | "feature.status_changed"
+  | "feature.declined"
+  | "feature.withdrawn"
+  | "feature.comment_added";
 
 function clientIp(h: Headers): string | null {
   return clientIpFrom(h, ipSource());

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -18,6 +18,15 @@ export {
   nextStatus,
   assertTransition,
   AuthzError,
+  // feature-request rules (the 'frr' track)
+  featureScope,
+  featureRef,
+  featureLabel,
+  FEATURE_FLOW,
+  FEATURE_BOARD,
+  isFeatureTerminal,
+  nextFeatureStatus,
+  assertFeatureTransition,
   type Actor,
 } from "@/lib/scope";
 
@@ -126,12 +135,15 @@ export const printerName = cache(async (): Promise<string> => {
 export async function notify(opts: {
   recipientId: string;
   storyId?: number;
+  /** A feature request this is about, for the 'frr' track. */
+  featureId?: number;
   text: string;
 }): Promise<void> {
   await db.notification.create({
     data: {
       recipientId: opts.recipientId,
       storyId: opts.storyId ?? null,
+      featureId: opts.featureId ?? null,
       text: opts.text,
     },
   });

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -94,3 +94,52 @@ export function relativeTime(date: Date): string {
   }
   return "just now";
 }
+
+// ---------------------------------------------------------------------------
+// Feature requests — the 'frr' track
+//
+// The fixed choices a feature request is made from, exactly like the print
+// catalogue above: the form renders from these and the server validates
+// against them, so the two cannot drift.
+// ---------------------------------------------------------------------------
+
+export const FEATURE_PRIORITIES = ["low", "medium", "high"] as const;
+export const DEFAULT_FEATURE_PRIORITY = "medium";
+
+export const FEATURE_CATEGORIES = ["ui", "api", "bug", "other"] as const;
+export const DEFAULT_FEATURE_CATEGORY = "other";
+
+/** How each priority reads and colours, loudest first. */
+export const PRIORITY_CHIP: Record<string, { bg: string; label: string }> = {
+  high: { bg: "bg-cherry", label: "High" },
+  medium: { bg: "bg-sun", label: "Medium" },
+  low: { bg: "bg-chrome", label: "Low" },
+};
+
+/** Human labels for the category enum. */
+export const CATEGORY_LABEL: Record<string, string> = {
+  ui: "UI",
+  api: "API",
+  bug: "Bug",
+  other: "Other",
+};
+
+const priorityValues = FEATURE_PRIORITIES as unknown as [string, ...string[]];
+const categoryValues = FEATURE_CATEGORIES as unknown as [string, ...string[]];
+
+export const FeatureWishSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(3, "Give it a title — a few words is plenty.")
+    .max(120, "Keep the title under 120 characters."),
+  description: z
+    .string()
+    .trim()
+    .min(1, "Say what you are hoping for.")
+    .max(4000, "That description is very long."),
+  priority: z.enum(priorityValues),
+  category: z.enum(categoryValues),
+});
+
+export type FeatureWish = z.infer<typeof FeatureWishSchema>;

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,362 @@
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import type { FeatureStatus, Prisma } from "@prisma/client";
+
+import { db } from "@/lib/db";
+import { record } from "@/lib/audit";
+import { notify, printerName, printerOwner } from "@/lib/authz";
+import {
+  AuthzError,
+  assertFeatureTransition,
+  featureLabel,
+  featureRef,
+  featureScope,
+  nextFeatureStatus,
+  type Actor,
+} from "@/lib/scope";
+import { FeatureWishSchema } from "@/lib/catalog";
+import { BodySchema } from "@/lib/stories";
+
+/**
+ * Everything that can happen to a feature request — the 'frr' track.
+ *
+ * A deliberate mirror of `src/lib/stories.ts`: same shape, same four rules
+ * (role checked every time, transitions through `assertFeatureTransition`, the
+ * requester always told, an audit row after the change commits), so the owner
+ * handles a feature request exactly as they handle a print. Kept parallel
+ * rather than generalised because the print service is load-bearing and
+ * separately tested — a shared abstraction would couple two backlogs that are
+ * better off independent.
+ *
+ * As in `stories.ts`, nothing here knows about redirects or HTTP status pages.
+ * A refusal leaves as a `FeatureProblem` carrying a sentence for a person; the
+ * server action turns it into a toast.
+ */
+
+export class FeatureProblem extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+    this.name = "FeatureProblem";
+  }
+}
+
+const problem = (status: number, message: string) => new FeatureProblem(status, message);
+
+function asProblem(error: unknown): never {
+  if (error instanceof AuthzError) throw problem(403, error.message);
+  throw error;
+}
+
+export const FeatureIdSchema = z.coerce.number().int().positive();
+
+/** Parse a path segment or form field into a feature id, or refuse it. */
+export function featureIdOr400(raw: unknown): number {
+  const parsed = FeatureIdSchema.safeParse(raw);
+  if (!parsed.success) throw problem(400, "That is not a request.");
+  return parsed.data;
+}
+
+function refresh(id: number) {
+  revalidatePath("/frr");
+  revalidatePath("/frr/queue");
+  revalidatePath(`/frr/${id}`);
+}
+
+const firstName = (name: string) => name.trim().split(/\s+/)[0] ?? name;
+
+// ---------------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------------
+
+/** Every column a representation of a feature request is built from. */
+export const FEATURE_FIELDS = {
+  id: true,
+  title: true,
+  description: true,
+  status: true,
+  priority: true,
+  category: true,
+  createdAt: true,
+  updatedAt: true,
+  requesterId: true,
+  requester: { select: { id: true, name: true, initials: true } },
+  _count: { select: { comments: true } },
+} satisfies Prisma.FeatureRequestSelect;
+
+export type FeatureRow = Prisma.FeatureRequestGetPayload<{ select: typeof FEATURE_FIELDS }>;
+
+/** The requests this actor may see — their own, or all of them for the owner. */
+export function listFeatures(actor: Actor): Promise<FeatureRow[]> {
+  return db.featureRequest.findMany({
+    where: featureScope(actor),
+    select: FEATURE_FIELDS,
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+/** One request, under the caller's scope; null if it is not theirs to see. */
+export function findFeature(actor: Actor, id: number): Promise<FeatureRow | null> {
+  return db.featureRequest.findFirst({
+    where: { AND: [{ id }, featureScope(actor)] },
+    select: FEATURE_FIELDS,
+  });
+}
+
+export async function getFeature(actor: Actor, id: number): Promise<FeatureRow> {
+  const feature = await findFeature(actor, id);
+  if (!feature) throw problem(404, "That request no longer exists.");
+  return feature;
+}
+
+/** The owner's view of a request for an action on it. Role is the control. */
+async function loadForAdmin(actor: Actor, id: number) {
+  if (actor.role !== "admin") {
+    throw problem(403, "Only the printer owner moves a request along.");
+  }
+  const feature = await db.featureRequest.findUnique({
+    where: { id },
+    include: { requester: { select: { id: true, name: true } } },
+  });
+  if (!feature) throw problem(404, "That request no longer exists.");
+  return feature;
+}
+
+// ---------------------------------------------------------------------------
+// The requester's actions
+// ---------------------------------------------------------------------------
+
+/**
+ * File a feature request. The requester comes from the session, never the
+ * body. The owner is told, and it is audited — exactly as an upload is.
+ */
+export async function createFeature(actor: Actor, input: unknown) {
+  const parsed = FeatureWishSchema.safeParse(input);
+  if (!parsed.success) {
+    throw problem(400, parsed.error.issues[0]?.message ?? "Check the form.");
+  }
+  const { title, description, priority, category } = parsed.data;
+
+  const feature = await db.featureRequest.create({
+    data: {
+      title,
+      description,
+      priority: priority as Prisma.FeatureRequestCreateInput["priority"],
+      category: category as Prisma.FeatureRequestCreateInput["category"],
+      status: "Requested",
+      requesterId: actor.id,
+    },
+    select: FEATURE_FIELDS,
+  });
+
+  const owner = await printerOwner();
+  if (owner && owner.id !== actor.id) {
+    await notify({
+      recipientId: owner.id,
+      featureId: feature.id,
+      text: `${actor.name} filed a request — “${title}”.`,
+    });
+  }
+
+  await record({
+    action: "feature.created",
+    actor,
+    subject: featureRef(feature.id),
+    detail: { title, priority, category },
+  });
+
+  refresh(feature.id);
+  return feature;
+}
+
+/**
+ * The requester withdraws their own, while nobody has acted on it —
+ * `Requested` or `Declined`. Mirrors withdrawing a print, minus the file:
+ * there is nothing in object storage to remove. Comments and notifications
+ * cascade at the database.
+ */
+export async function withdrawFeature(actor: Actor, id: number) {
+  const feature = await db.featureRequest.findFirst({
+    where: { AND: [{ id }, featureScope(actor)] },
+    select: { id: true, title: true, status: true, requesterId: true },
+  });
+  if (!feature) throw problem(404, "That request no longer exists.");
+
+  if (feature.requesterId !== actor.id) {
+    throw problem(403, "Only the person who asked for it can withdraw it.");
+  }
+
+  if (feature.status !== "Requested" && feature.status !== "Declined") {
+    throw problem(
+      409,
+      `${featureRef(feature.id)} is already ${featureLabel(feature.status).toLowerCase()} — ` +
+        `ask ${await printerName()} instead.`,
+    );
+  }
+
+  const ref = featureRef(feature.id);
+  const owner = await printerOwner();
+
+  await db.featureRequest.delete({ where: { id: feature.id } });
+
+  if (owner && feature.status === "Requested" && owner.id !== actor.id) {
+    await notify({ recipientId: owner.id, text: `${actor.name} withdrew ${ref} — “${feature.title}”.` });
+  }
+
+  await record({
+    action: "feature.withdrawn",
+    actor,
+    subject: ref,
+    detail: { title: feature.title, wasStatus: feature.status },
+  });
+
+  refresh(feature.id);
+  return { id: feature.id, ref, title: feature.title, wasStatus: feature.status };
+}
+
+// ---------------------------------------------------------------------------
+// The owner's actions
+// ---------------------------------------------------------------------------
+
+/** Move a request one step along the flow. Both "Accept it" and every later hop. */
+export async function advanceFeature(actor: Actor, id: number) {
+  const feature = await loadForAdmin(actor, id);
+
+  const next = nextFeatureStatus(feature.status);
+  if (!next) throw problem(409, `${featureLabel(feature.status)} is the end of the line.`);
+
+  try {
+    assertFeatureTransition(actor, feature.status, next);
+  } catch (e) {
+    asProblem(e);
+  }
+
+  await db.featureRequest.update({ where: { id: feature.id }, data: { status: next } });
+
+  await notify({
+    recipientId: feature.requesterId,
+    featureId: feature.id,
+    text: `${firstName(actor.name)} moved “${feature.title}” to ${featureLabel(next)}.`,
+  });
+  await record({
+    action: "feature.status_changed",
+    actor,
+    subject: featureRef(feature.id),
+    detail: { from: feature.status, to: next, title: feature.title },
+  });
+
+  refresh(feature.id);
+  return {
+    id: feature.id,
+    ref: featureRef(feature.id),
+    title: feature.title,
+    from: feature.status,
+    to: next,
+    requesterName: feature.requester.name,
+  };
+}
+
+/** Decline. Terminal, and only reachable from `Requested`. */
+export async function declineFeature(actor: Actor, id: number) {
+  const feature = await loadForAdmin(actor, id);
+
+  try {
+    assertFeatureTransition(actor, feature.status, "Declined");
+  } catch (e) {
+    asProblem(e);
+  }
+
+  await db.featureRequest.update({ where: { id: feature.id }, data: { status: "Declined" } });
+
+  await notify({
+    recipientId: feature.requesterId,
+    featureId: feature.id,
+    text: `${firstName(actor.name)} declined “${feature.title}”.`,
+  });
+  await record({
+    action: "feature.declined",
+    actor,
+    subject: featureRef(feature.id),
+    detail: { title: feature.title },
+  });
+
+  refresh(feature.id);
+  return {
+    id: feature.id,
+    ref: featureRef(feature.id),
+    title: feature.title,
+    from: feature.status,
+    to: "Declined" as FeatureStatus,
+    requesterName: feature.requester.name,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The conversation
+// ---------------------------------------------------------------------------
+
+export const FEATURE_COMMENT_FIELDS = {
+  id: true,
+  featureId: true,
+  body: true,
+  createdAt: true,
+  author: { select: { id: true, name: true, initials: true, role: true } },
+} satisfies Prisma.FeatureCommentSelect;
+
+export type FeatureCommentRow = Prisma.FeatureCommentGetPayload<{
+  select: typeof FEATURE_COMMENT_FIELDS;
+}>;
+
+/** The thread on a request the caller can see. Oldest first. */
+export async function listFeatureComments(actor: Actor, id: number): Promise<FeatureCommentRow[]> {
+  await getFeature(actor, id); // scoped: refuses before any comment is read
+  return db.featureComment.findMany({
+    where: { featureId: id },
+    select: FEATURE_COMMENT_FIELDS,
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+/**
+ * Say something on a request. Both sides may write; the notification goes to
+ * the other side. Scoped through `featureScope`, so a client naming another
+ * person's request is told it does not exist.
+ */
+export async function addFeatureComment(actor: Actor, id: number, rawBody: unknown) {
+  const parsed = BodySchema.safeParse(typeof rawBody === "string" ? rawBody : "");
+  if (!parsed.success) {
+    throw problem(400, parsed.error.issues[0]?.message ?? "Check that again.");
+  }
+  const body = parsed.data;
+
+  const feature = await db.featureRequest.findFirst({
+    where: { AND: [{ id }, featureScope(actor)] },
+    select: { id: true, title: true, requesterId: true },
+  });
+  if (!feature) throw problem(404, "That request no longer exists.");
+
+  const comment = await db.featureComment.create({
+    data: { featureId: feature.id, authorId: actor.id, body },
+    select: FEATURE_COMMENT_FIELDS,
+  });
+
+  const recipientId =
+    actor.role === "admin" ? feature.requesterId : (await printerOwner())?.id;
+  if (recipientId && recipientId !== actor.id) {
+    await notify({
+      recipientId,
+      featureId: feature.id,
+      text: `${firstName(actor.name)} commented on “${feature.title}”.`,
+    });
+  }
+
+  await record({
+    action: "feature.comment_added",
+    actor,
+    subject: featureRef(feature.id),
+    detail: { title: feature.title, length: body.length },
+  });
+
+  revalidatePath(`/frr/${feature.id}`);
+  return comment;
+}

--- a/src/lib/scope.ts
+++ b/src/lib/scope.ts
@@ -6,7 +6,7 @@
  * imported by tests and probes and exercised directly, rather than being
  * re-implemented (and drifting) wherever they need checking.
  */
-import type { Prisma, StoryStatus } from "@prisma/client";
+import type { FeatureStatus, Prisma, StoryStatus } from "@prisma/client";
 
 export type Actor = {
   id: string;
@@ -102,5 +102,100 @@ export function assertTransition(
   }
   if (nextStatus(from) !== to) {
     throw new AuthzError(`${from} → ${to} is not a step along the flow.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Feature requests — the 'frr' track
+//
+// The same pure rules as the print backlog above, for the parallel
+// feature-request flow. Kept here beside them, and deliberately NOT merged
+// into one generic helper: the print rules are load-bearing and exercised
+// directly by the suites, so the two stay legible and independently testable
+// rather than sharing a cleverness that a change to one could quietly bend for
+// the other. The *shape* is identical on purpose — forward-only, one step,
+// Done leaves the board, Declined terminal from Requested — so the owner
+// handles a feature request exactly as they handle a print.
+// ---------------------------------------------------------------------------
+
+/**
+ * A feature request's flow. Same shape as `FLOW`, feature-appropriate names.
+ * `Shipped` is "released, go and check it"; `Done` is "closed and off the
+ * board", the way `Delivery`/`Done` work for a print.
+ */
+export const FEATURE_FLOW = [
+  "Requested",
+  "Accepted",
+  "InProgress",
+  "Shipped",
+  "Done",
+] as const satisfies readonly FeatureStatus[];
+
+/** The board columns — the flow minus its terminal state. */
+export const FEATURE_BOARD = FEATURE_FLOW.slice(0, -1) as readonly FeatureStatus[];
+
+/**
+ * Display labels. The enum can carry no space, so `InProgress` is written out
+ * for people. Everything else reads as-is.
+ */
+export const FEATURE_STATUS_LABEL: Record<FeatureStatus, string> = {
+  Requested: "Requested",
+  Accepted: "Accepted",
+  InProgress: "In progress",
+  Shipped: "Shipped",
+  Done: "Done",
+  Declined: "Declined",
+};
+
+export const featureLabel = (status: FeatureStatus): string =>
+  FEATURE_STATUS_LABEL[status] ?? status;
+
+/**
+ * Display ref: FRR-101 for feature request 1. Recognisable when pasted into
+ * chat, and parallel to `PPP-` for a print.
+ */
+export const featureRef = (id: number) => `FRR-${100 + id}`;
+
+/**
+ * The scope rule, mirroring `storyScope`:
+ *   Client -> only their own requests
+ *   Admin  -> everything
+ */
+export function featureScope(actor: Actor): Prisma.FeatureRequestWhereInput {
+  return actor.role === "admin" ? {} : { requesterId: actor.id };
+}
+
+export function isFeatureTerminal(status: FeatureStatus): boolean {
+  return status === FEATURE_FLOW[FEATURE_FLOW.length - 1] || status === "Declined";
+}
+
+export function nextFeatureStatus(current: FeatureStatus): FeatureStatus | null {
+  const i = (FEATURE_FLOW as readonly string[]).indexOf(current);
+  if (i < 0 || i === FEATURE_FLOW.length - 1) return null;
+  return FEATURE_FLOW[i + 1]!;
+}
+
+/**
+ * Only the owner moves a request, only forwards, only one step at a time.
+ * `Declined` is reachable from `Requested` alone.
+ */
+export function assertFeatureTransition(
+  actor: Actor,
+  from: FeatureStatus,
+  to: FeatureStatus,
+): void {
+  if (actor.role !== "admin") {
+    throw new AuthzError("Only the printer owner moves a request along.");
+  }
+  if (to === "Declined") {
+    if (from !== "Requested") {
+      throw new AuthzError(`Cannot decline a request that is already ${featureLabel(from)}.`);
+    }
+    return;
+  }
+  if (nextFeatureStatus(from) !== to) {
+    throw new AuthzError(
+      `${featureLabel(from)} → ${featureLabel(to)} is not a step along the flow.`,
+    );
   }
 }


### PR DESCRIPTION
Requested: a mode where users file feature requests and the owner sees and
handles them **exactly as the current backlog**. This builds that as a
deliberate parallel track at **`/frr`** — its own tables, mirroring the print
board/queue/flow/conversation/notifications/audit — so the well-tested print
path is untouched.

Decided up front with the requester: separate `FeatureRequest` track (not a
`kind` flag on `Story`); feature-appropriate status names; title + description
+ **priority** + **category**.

## What a user gets

| | |
| --- | --- |
| `/frr` | the rail — your own requests (owner sees all), one column per stage, closed items in a *Closed* strip |
| `/frr/new` | file one: title, what-and-why, priority (low/med/high), category (UI/API/bug/other) |
| `/frr/[id]` | the request in full — flow tracker, conversation, and *Withdraw* while untouched |
| `/frr/queue` | **owner-only** triage; *Waiting on you* first, high-priority first |

Flow: **Requested → Accepted → In progress → Shipped → Done**, or **Decline**
(terminal, only from Requested). Every move notifies the requester and audits.

## How it mirrors the print backlog

One-to-one, which is what makes the owner's experience identical:

| Print | Feature |
| --- | --- |
| `Story` / `Comment` | `FeatureRequest` / `FeatureComment` |
| `PPP-104` | `FRR-104` |
| `storyScope` | `featureScope` (client → own, owner → all) |
| `FLOW` / `assertTransition` | `FEATURE_FLOW` / `assertFeatureTransition` |
| `src/lib/stories.ts` | `src/lib/features.ts` |
| `/board` `/queue` `/story/[id]` | `/frr` `/frr/queue` `/frr/[id]` |

The pure rules sit **beside** the print ones in `scope.ts`, kept parallel
rather than merged into a generic helper on purpose — the print rules are
load-bearing and separately tested, and a shared cleverness that a change to
one backlog could bend for the other is a worse trade than a little duplication.

## Blast radius on the print path: additive only

- **New tables** `featureRequest` / `featureComment`. `Story`, upload, the
  viewer and the JSON API are untouched — no `kind` branching anywhere.
- **Notification** gains a nullable `featureId`; the Activity feed routes to
  `/frr` or `/story` on whichever is set. Audit trail gains `feature.*` verbs.
  `notify()` takes an optional `featureId`. Nav gets a *Requests* entry.
  `StatusChip` gains an optional `label` (so `InProgress` → "In progress").
- None of it changes how a print behaves.

## Tests

`npm run verify:frr` — **51 checks**, the print `verify:queue`'s sibling:
files a request through the form, proves the requester comes from the session
(a posted `requesterId`/`status` is ignored), owner-only queue (404 to a
client), scope (a client can't see/comment on another's — 404 not 403), the
full forward-only flow, decline-only-from-Requested, the conversation
(notify the other side, hostile body escaped), and withdrawal (requester only,
untouched only, owner can't). Wired into CI beside `verify:queue`.

Every existing suite passes unchanged: **queue 98 · upload 53 · models 32 ·
api 99 · probes 91 · passkey 13 · auth all**. Rendered in a real browser —
board, queue and detail all in the diner design, zero console errors.

## Deliberately not built

**No JSON API** for feature requests (the print backlog has one). The request
was about filing and triaging on the board; the service layer is already shaped
like `stories.ts`, so `/api/features` is the same exercise later. Called out in
[`docs/feature-requests.md`](https://github.com/danileau/prettypleaseprint/blob/feature-requests/docs/feature-requests.md).

## Note on scope

CONTRIBUTING says features beyond "3D print requests for a small office" are
usually declined — a feature tracker is arguably that. Built because the owner
explicitly asked; flagging it so the boundary stays a conscious call.