### PR TITLE
FRR-104: change a feature request's priority after filing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Notable changes. Every entry names a released version; deployments pin
 
 ### Added
 
+- **A feature request's priority can be changed after it is filed** (FRR-104).
+  Requirements shift, so a request's priority is a knob rather than a
+  one-shot: the requester may re-set the priority of their own request while it
+  is still live (not `Done`/`Declined`), and the printer owner may re-set any,
+  any time, since triaging by priority is their job. The change notifies the
+  other side, is written to the audit trail (`feature.priority_changed`), and
+  is refused for a request that is not yours or is already closed. Priority
+  lives only on feature requests; prints are unaffected.
+
 - **A feature-request track — the 'frr' backlog.** Anyone can file a feature
   request (title, description, priority, category) at `/frr`, and the printer
   owner triages it exactly as they triage a print: the same board, an

--- a/docs/feature-requests.md
+++ b/docs/feature-requests.md
@@ -14,8 +14,9 @@ notifications and audit trail a print goes through. It lives at **`/frr`**.
 - **`/frr/new`** — file one: a title, what-and-why, a **priority**
   (low / medium / high) and a **category** (UI / API / bug / other).
 - **`/frr/[id]`** — the request in full: where it sits in the flow, the
-  conversation, and — while nobody has started on it — a **Withdraw** control
-  for the person who filed it.
+  conversation, a **priority** control (the requester may change it while the
+  request is still live; the owner may change any, any time), and — while
+  nobody has started on it — a **Withdraw** control for the person who filed it.
 
 ## For the owner
 

--- a/scripts/verify-frr.ts
+++ b/scripts/verify-frr.ts
@@ -314,6 +314,55 @@ async function main() {
         (await db.featureRequest.count({ where: { id: mine.id } })) === 1);
 
   // ------------------------------------------------------------------
+  section("priority is editable after filing");
+  // `mine` is Ayla's, still Requested. The requester changes it through the
+  // rendered form.
+  const beforePriority = (await db.featureRequest.findUnique({ where: { id: mine.id } }))?.priority;
+  const pPage = await (await client.go(`${APP}/frr/${mine.id}`)).text();
+  const pIdx = formIndexContaining(pPage, 'name="priority"');
+  check("the requester is offered a priority control on their own request", pIdx >= 0);
+  await client.submit(`${APP}/frr/${mine.id}`, pPage, pIdx, { id: String(mine.id), priority: "high" });
+  check("the requester changes their own request's priority",
+        (await db.featureRequest.findUnique({ where: { id: mine.id } }))?.priority === "high",
+        `was ${beforePriority}`);
+  check("the change is audited",
+        (await db.auditEvent.count({ where: { action: "feature.priority_changed", subject: refOf(mine.id) } })) === 1);
+  check("the owner is notified of the requester's change",
+        (await db.notification.count({
+          where: { recipientId: admin.id, featureId: mine.id },
+        })) >= 1);
+
+  // An invalid priority is refused. Replay the real form (so the action runs)
+  // but override the select to a value it never offers.
+  const badPage = await (await client.go(`${APP}/frr/${mine.id}`)).text();
+  await client.submit(`${APP}/frr/${mine.id}`, badPage,
+    formIndexContaining(badPage, 'name="priority"'), { id: String(mine.id), priority: "urgent" });
+  check("an invalid priority is refused",
+        (await db.featureRequest.findUnique({ where: { id: mine.id } }))?.priority === "high");
+
+  // Another client cannot even see the request, so is never offered the
+  // control; scope makes the guard unreachable through the UI.
+  const intruderView = await other.go(`${APP}/frr/${mine.id}`);
+  check("another client cannot see the request (404), so cannot reprioritise it",
+        intruderView.status === 404 &&
+        (await db.featureRequest.findUnique({ where: { id: mine.id } }))?.priority === "high",
+        `status ${intruderView.status}`);
+
+  // The owner can change any request's priority, through the same form.
+  const ownerView = await (await ruben.go(`${APP}/frr/${mine.id}`)).text();
+  const ownerPIdx = formIndexContaining(ownerView, 'name="priority"');
+  check("the owner is offered the priority control too", ownerPIdx >= 0);
+  await ruben.submit(`${APP}/frr/${mine.id}`, ownerView, ownerPIdx, { id: String(mine.id), priority: "medium" });
+  check("the owner can change any request's priority",
+        (await db.featureRequest.findUnique({ where: { id: mine.id } }))?.priority === "medium");
+
+  // A closed request offers the requester no priority control.
+  const closedPr = await makeFeature(ayla.id, "Long since closed", "Done");
+  const closedPage = await (await client.go(`${APP}/frr/${closedPr.id}`)).text();
+  check("a Done request offers the requester no priority control",
+        !closedPage.includes("Change priority"));
+
+  // ------------------------------------------------------------------
   section("the board draws the four live rails, closed items leave");
   const board = rendered(await (await ruben.go(`${APP}/frr`)).text());
   for (const rail of FEATURE_BOARD) {

--- a/src/app/actions/features.ts
+++ b/src/app/actions/features.ts
@@ -7,6 +7,7 @@ import {
   FeatureProblem,
   addFeatureComment as postComment,
   advanceFeature as advance,
+  changeFeaturePriority as reprioritise,
   createFeature as create,
   declineFeature as decline,
   featureIdOr400,
@@ -89,6 +90,25 @@ export async function withdrawFeature(formData: FormData): Promise<void> {
     back("/frr", { toast: `${done.ref} withdrawn.` });
   } catch (error) {
     if (error instanceof FeatureProblem) back(`/frr/${id}`, { toast: error.message });
+    throw error;
+  }
+}
+
+/**
+ * Change a request's priority. Open to the requester (own, still live) and the
+ * owner; the service decides. Lands back where the form was posted from.
+ */
+export async function changeFeaturePriority(formData: FormData): Promise<void> {
+  const user = await requireUser();
+  const from = safeFrom(formData.get("from"), "/frr");
+  const id = featureIdOr400(formData.get("id"));
+  try {
+    const done = await reprioritise(user, id, formData.get("priority") ?? "");
+    back(from, {
+      toast: done.unchanged ? `Already ${done.to} priority.` : `Priority → ${done.to}.`,
+    });
+  } catch (error) {
+    if (error instanceof FeatureProblem) back(from, { error: error.message });
     throw error;
   }
 }

--- a/src/app/frr/[id]/page.tsx
+++ b/src/app/frr/[id]/page.tsx
@@ -2,10 +2,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { requireUser, printerName } from "@/lib/authz";
-import { FEATURE_FLOW, featureLabel, featureRef } from "@/lib/scope";
+import { FEATURE_FLOW, featureLabel, featureRef, isFeatureTerminal } from "@/lib/scope";
 import { findFeature, listFeatureComments } from "@/lib/features";
-import { withdrawFeature } from "@/app/actions/features";
-import { relativeTime, PRIORITY_CHIP, CATEGORY_LABEL } from "@/lib/catalog";
+import { changeFeaturePriority, withdrawFeature } from "@/app/actions/features";
+import { relativeTime, PRIORITY_CHIP, CATEGORY_LABEL, FEATURE_PRIORITIES } from "@/lib/catalog";
 import { AppHeader } from "@/components/app-header";
 import { Fact, Notice, StatusChip } from "@/components/ui";
 import { FeatureActions } from "@/components/feature-actions";
@@ -44,6 +44,11 @@ export default async function FeaturePage({
   const canWithdraw =
     feature.requester.id === user.id &&
     (feature.status === "Requested" || feature.status === "Declined");
+  // Reprioritise: the owner any time, the requester on their own while it is
+  // still live. Matches `changeFeaturePriority` in the service.
+  const canReprioritise =
+    user.role === "admin" ||
+    (feature.requester.id === user.id && !isFeatureTerminal(feature.status));
 
   return (
     <>
@@ -85,6 +90,44 @@ export default async function FeaturePage({
             <Fact label="Category">{CATEGORY_LABEL[feature.category] ?? feature.category}</Fact>
             <Fact label="Filed">{relativeTime(feature.createdAt)}</Fact>
           </div>
+
+          {/* Change the priority after filing. A plain form + submit, so it
+              works with JS off; no auto-submit-on-change. */}
+          {canReprioritise && (
+            <form
+              action={changeFeaturePriority}
+              className="mt-[17.6px] flex flex-wrap items-end gap-[8.8px] border-t-2 border-dashed border-rule pt-[17.6px]"
+            >
+              <input type="hidden" name="id" value={feature.id} />
+              <input type="hidden" name="from" value={`/frr/${feature.id}`} />
+              <div>
+                <label
+                  htmlFor="priority"
+                  className="mb-[4px] block font-mono text-[11px] font-bold uppercase tracking-[0.1em] text-ink-3"
+                >
+                  Change priority
+                </label>
+                <select
+                  id="priority"
+                  name="priority"
+                  defaultValue={feature.priority}
+                  className="rounded-card border-[3px] border-ink bg-porcelain px-[13px] py-[8px] text-[15px] font-bold text-ink"
+                >
+                  {FEATURE_PRIORITIES.map((p) => (
+                    <option key={p} value={p}>
+                      {PRIORITY_CHIP[p]?.label ?? p}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="submit"
+                className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-aqua px-[18px] py-[9px] text-[14px] font-bold text-ink hover:bg-sun"
+              >
+                Set
+              </button>
+            </form>
+          )}
         </div>
 
         <section className="mt-[26.4px]">

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -45,6 +45,7 @@ export type AuditAction =
   // feature requests (the 'frr' track)
   | "feature.created"
   | "feature.status_changed"
+  | "feature.priority_changed"
   | "feature.declined"
   | "feature.withdrawn"
   | "feature.comment_added";

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -12,10 +12,11 @@ import {
   featureLabel,
   featureRef,
   featureScope,
+  isFeatureTerminal,
   nextFeatureStatus,
   type Actor,
 } from "@/lib/scope";
-import { FeatureWishSchema } from "@/lib/catalog";
+import { FEATURE_PRIORITIES, FeatureWishSchema } from "@/lib/catalog";
 import { BodySchema } from "@/lib/stories";
 
 /**
@@ -212,6 +213,76 @@ export async function withdrawFeature(actor: Actor, id: number) {
 
   refresh(feature.id);
   return { id: feature.id, ref, title: feature.title, wasStatus: feature.status };
+}
+
+/**
+ * Change a request's priority after it has been filed. Requirements change,
+ * so a "low" from last month may be "high" today, and re-filing to fix a
+ * dropdown would be silly.
+ *
+ * Who may: the **requester** on their own request while it is still live (not
+ * `Done`/`Declined` — a closed request's priority is history, not a knob), and
+ * the **owner** on any request, at any time, because triaging by priority is
+ * their job. Anyone else — a client naming somebody else's id — is refused,
+ * and indistinguishably from "does not exist" via `featureScope`.
+ */
+export async function changeFeaturePriority(actor: Actor, id: number, rawPriority: unknown) {
+  const priority = typeof rawPriority === "string" ? rawPriority : "";
+  if (!(FEATURE_PRIORITIES as readonly string[]).includes(priority)) {
+    throw problem(400, "That is not a priority.");
+  }
+
+  // Scoped read: a client asking after another's request is told it does not
+  // exist, not that they may not touch it.
+  const feature = await db.featureRequest.findFirst({
+    where: { AND: [{ id }, featureScope(actor)] },
+    select: { id: true, title: true, status: true, priority: true, requesterId: true },
+  });
+  if (!feature) throw problem(404, "That request no longer exists.");
+
+  if (actor.role !== "admin" && feature.requesterId !== actor.id) {
+    throw problem(403, "Only the person who asked for it, or the printer owner, can reprioritise it.");
+  }
+  if (actor.role !== "admin" && isFeatureTerminal(feature.status)) {
+    throw problem(
+      409,
+      `${featureRef(feature.id)} is ${featureLabel(feature.status).toLowerCase()} — its priority is settled.`,
+    );
+  }
+
+  if (priority === feature.priority) {
+    // A no-op change writes nothing and tells nobody — pressing a select back
+    // onto its current value is not an event.
+    return { id: feature.id, ref: featureRef(feature.id), title: feature.title, from: feature.priority, to: priority, unchanged: true };
+  }
+
+  await db.featureRequest.update({
+    where: { id: feature.id },
+    data: { priority: priority as Prisma.FeatureRequestUpdateInput["priority"] },
+  });
+
+  // Tell the other side, the same direction a comment does: a requester's
+  // change reaches the owner (who triages by it); the owner's reaches the
+  // requester (whose ask it re-ranks).
+  const owner = await printerOwner();
+  const recipientId = actor.role === "admin" ? feature.requesterId : owner?.id;
+  if (recipientId && recipientId !== actor.id) {
+    await notify({
+      recipientId,
+      featureId: feature.id,
+      text: `${firstName(actor.name)} set “${feature.title}” to ${priority} priority.`,
+    });
+  }
+
+  await record({
+    action: "feature.priority_changed",
+    actor,
+    subject: featureRef(feature.id),
+    detail: { title: feature.title, from: feature.priority, to: priority },
+  });
+
+  refresh(feature.id);
+  return { id: feature.id, ref: featureRef(feature.id), title: feature.title, from: feature.priority, to: priority, unchanged: false };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements **FRR-104** — "change the priority of a request".

**Interpretation:** priority is a field on **feature requests** only (the `/frr`
track); print requests have no priority. So this makes a feature request's
`priority` **editable after filing**, rather than adding priority to prints.

## Behaviour
- **Requester** may re-set the priority of their **own** request while it is
  still live (not `Done`/`Declined`).
- **Owner** may re-set **any** request's priority at any time (triage).
- Refusals mirror the rest of the feature service: cross-requester → `403`, a
  closed request (for the requester) → `409`, an unknown value → `400`; setting
  the same value is a silent no-op. The change notifies the other side and
  writes a `feature.priority_changed` audit row (`{ from, to }`).

## Shape
- `changeFeaturePriority(actor, id, priority)` in `src/lib/features.ts` — same
  pattern as the existing operations (scoped read, `FeatureProblem`, notify,
  audit after commit).
- Thin server action in `src/app/actions/features.ts`.
- Inline priority `<select>` + **Set** on the feature detail page, shown to
  whoever may change it. Plain form, works with JS off.
- No touch to the print (`Story`) side.

## Tests
`verify:frr` gains a *priority is editable after filing* section — **60 checks,
0 failed**: requester changes own (stored + audited + owner notified), invalid
value refused, another client can't see or touch it, owner changes any, and a
Done request offers no control. `verify:queue` still **98/0**. `tsc`, `build`
and `check:links` clean.