### PR TITLE
Owner-managed benefits: define and prefer the tip options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
       # prints, on its own tables. Drives the real forms exactly as verify:queue.
       - name: Feature requests, filed and triaged
         run: npm run verify:frr
+      # Owner-managed benefits (the tip catalogue): admin CRUD, the upload form
+      # rendering the list + preferences, and server-side tip validation.
+      - name: Benefits, owner-managed
+        run: npm run verify:benefits
       # The second front door onto the same operations. Runs against the built
       # image, which is the only place the production CSP is in force — the
       # console's inline-script nonce and its stylesheet-in-a-file are both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Notable changes. Every entry names a released version; deployments pin
 
 ### Added
 
+- **The benefits (tip options) are owner-managed.** What used to be a hardcoded
+  list of tips ("A beer", "A coffee", …) is now data the printer owner edits at
+  `/admin/benefits`: add, rename, retire/restore, and mark which they currently
+  **prefer** — the preferred ones are starred on the upload form under a
+  "*Danilo currently prefers: …*" line so people pick what the owner actually
+  wants. `Story.tip` stays a plain string, so editing or retiring a benefit
+  never rewrites a request that already offered it; a retired one is kept rather
+  than deleted. The upload endpoint validates the tip against the current
+  *active* list server-side, so the managed catalogue — not the form — is
+  authoritative. New `Benefit` table, seeded with the previous five tips on
+  first run (idempotently, never clobbering the owner's edits). `verify:benefits`
+  covers it (19 checks); every change is audited (`benefit.created`,
+  `benefit.updated`).
+
 - **A feature request's priority can be changed after it is filed** (FRR-104).
   Requirements shift, so a request's priority is a knob rather than a
   one-shot: the requester may re-set the priority of their own request while it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ Notable changes. Every entry names a released version; deployments pin
   other side, is written to the audit trail (`feature.priority_changed`), and
   is refused for a request that is not yours or is already closed. Priority
   lives only on feature requests; prints are unaffected.
+- **Print an old request again (FRR-102).** Re-queue any of your past tickets —
+  a test print that worked, a declined one you have since fixed — as a fresh
+  `Requested` request, without finding and re-uploading the file. The stored
+  model is copied server-side to a new object (`copyModel`), so the new ticket
+  and the original own independent files: withdrawing one never touches the
+  other's. A "Print again" control on the story page; audited as
+  `story.requeued`; the owner is notified as for any new request.
+
+### Changed
+
+- **Withdraw now reaches Accepted (FRR-101).** A requester could only withdraw
+  a `Requested` or `Declined` ticket; the window now also includes `Accepted`,
+  so plans can still change after the owner has said yes but before the print
+  reaches the bed. `Printing`/`Delivery`/`Done` are still refused — the
+  material is committed by then — and the owner is notified when an accepted
+  request is pulled. The `DELETE /api/stories/{id}` route inherits the wider
+  window automatically.
+
+### Added
 
 - **A feature-request track — the 'frr' backlog.** Anyone can file a feature
   request (title, description, priority, category) at `/frr`, and the printer

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ that: there is no multi-tenancy, no billing, and no queue theory.
   conversation and the uploaded file go with it.
 - **Talk on the ticket** — a conversation thread per request, so "can you do it
   in teal" lives with the model rather than in a chat app.
+- **Owner-managed benefits** — the "what's in it for you" tips are the printer
+  owner's to define at `/admin/benefits`, and the ones they mark *preferred* are
+  starred on the upload form so people know what the owner actually wants. Editing
+  or retiring a benefit never rewrites a past request's tip.
 - **Revoke access when someone leaves** — suspends the account, signs them out
   everywhere and refuses new sign-ins, while keeping their tickets, comments
   and history. Reversible, and audited.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "env:container": "tsx scripts/use-container-env.ts",
     "verify:queue": "tsx scripts/verify-queue.ts",
     "verify:frr": "tsx scripts/verify-frr.ts",
+    "verify:benefits": "tsx scripts/verify-benefits.ts",
     "verify:api": "tsx scripts/verify-api.ts",
     "vendor:swagger": "tsx scripts/vendor-swagger.ts"
   },

--- a/prisma/migrations/20260826190854_benefits/migration.sql
+++ b/prisma/migrations/20260826190854_benefits/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "benefit" (
+    "id" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "preferred" BOOLEAN NOT NULL DEFAULT false,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "benefit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "benefit_label_key" ON "benefit"("label");
+
+-- CreateIndex
+CREATE INDEX "benefit_active_sortOrder_idx" ON "benefit"("active", "sortOrder");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -402,3 +402,24 @@ model FeatureComment {
   @@index([featureId])
   @@map("featureComment")
 }
+
+/// A "benefit" — the tip a requester offers the printer owner ("what's in it
+/// for you"). Owner-managed data, replacing the old hardcoded TIPS const, so
+/// the owner defines the list and marks which ones they currently prefer.
+///
+/// `Story.tip` stays a plain string with no FK: a past request keeps the exact
+/// tip it was made with even after the list is edited or a benefit retired.
+/// `active` retires a benefit without deleting that history; `preferred` is
+/// what the upload form highlights.
+model Benefit {
+  id        String   @id @default(cuid())
+  label     String   @unique
+  preferred Boolean  @default(false)
+  active    Boolean  @default(true)
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([active, sortOrder])
+  @@map("benefit")
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -72,6 +72,27 @@ async function main() {
 
   console.info(`Printer owner ready: ${admin.name} <${admin.email}>`);
 
+  // The default benefits (tip options). Idempotent and non-destructive: an
+  // upsert per label with an empty update, so a re-run (the migrator runs the
+  // seed on every deploy) never overwrites the owner's edits — a renamed,
+  // retired or preferred benefit is left exactly as they set it, and a retired
+  // default is not resurrected. New default labels are appended.
+  const DEFAULT_BENEFITS = [
+    "A beer",
+    "A coffee",
+    "A spool of filament",
+    "Nerd stuff",
+    "Nothing, sorry",
+  ];
+  for (let i = 0; i < DEFAULT_BENEFITS.length; i++) {
+    await db.benefit.upsert({
+      where: { label: DEFAULT_BENEFITS[i]! },
+      update: {},
+      create: { label: DEFAULT_BENEFITS[i]!, sortOrder: i + 1 },
+    });
+  }
+  console.info(`Benefits ready: ${DEFAULT_BENEFITS.length} default tip(s) present.`);
+
   // A `credential` account with a password is the thing that makes signing in
   // possible. A passkey creates no such row, so somebody who enrolled one and
   // never set a password still counts as needing this — which is correct: the

--- a/scripts/verify-benefits.ts
+++ b/scripts/verify-benefits.ts
@@ -1,0 +1,247 @@
+import "./_env";
+/**
+ * End-to-end check of the owner-managed benefits (the tip catalogue).
+ *
+ *   npm run verify:benefits
+ *
+ * Drives the real admin forms the way a JavaScript-off browser does, and the
+ * real upload endpoint, asserting what a person observes: the DB row, what the
+ * upload form shows, and what the server accepts. `src/lib/benefits.ts` is
+ * `server-only` so it cannot be imported here — everything goes through HTTP.
+ *
+ * DESTRUCTIVE: wipes users, stories and benefits. Development database only.
+ */
+import { db } from "../src/lib/db";
+import { ensureCredentials, signInWithPassword, usernameFor } from "./_accounts";
+
+const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
+
+let passed = 0;
+const failures: string[] = [];
+function check(name: string, ok: boolean, detail = "") {
+  console.info(`  ${ok ? "ok  " : "FAIL"}  ${name}${ok || !detail ? "" : `\n          ${detail}`}`);
+  ok ? passed++ : failures.push(name);
+}
+const section = (t: string) =>
+  console.info(`\n── ${t} ${"─".repeat(Math.max(0, 54 - t.length))}`);
+
+const unescapeHtml = (s: string) =>
+  s.replace(/&quot;/g, '"').replace(/&#x27;|&#39;/g, "'")
+    .replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+
+class Browser {
+  jar = new Map<string, string>();
+  private store(r: Response) {
+    for (const line of r.headers.getSetCookie()) {
+      const [pair] = line.split(";");
+      const i = pair!.indexOf("=");
+      const k = pair!.slice(0, i).trim();
+      const v = pair!.slice(i + 1).trim();
+      if (!v || line.includes("Max-Age=0")) this.jar.delete(k);
+      else this.jar.set(k, v);
+    }
+  }
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { origin: APP };
+    if (this.jar.size) h.cookie = [...this.jar].map(([k, v]) => `${k}=${v}`).join("; ");
+    return h;
+  }
+  async raw(url: string, init: RequestInit = {}) {
+    const r = await fetch(url, { ...init, redirect: "manual", headers: { ...(init.headers ?? {}), ...this.headers() } });
+    this.store(r);
+    return r;
+  }
+  async go(url: string, init: RequestInit = {}) {
+    let r = await this.raw(url, init);
+    for (let i = 0; i < 8; i++) {
+      const loc = r.headers.get("location");
+      if (!loc || r.status < 300 || r.status >= 400) break;
+      r = await this.raw(new URL(loc, url).toString());
+    }
+    return r;
+  }
+  /** Replay one server-action form (its hidden inputs + overrides). */
+  async submit(url: string, html: string, formIndex: number, values: Record<string, string>) {
+    const forms = html.match(/<form\b[\s\S]*?<\/form>/g) ?? [];
+    const form = forms[formIndex];
+    if (!form) throw new Error(`no form #${formIndex} on ${url}`);
+    const body = new FormData();
+    for (const tag of form.match(/<input\b[^>]*>/g) ?? []) {
+      if (!tag.includes('type="hidden"')) continue;
+      const n = /name="([^"]*)"/.exec(tag)?.[1];
+      const v = /value="([^"]*)"/.exec(tag)?.[1] ?? "";
+      if (n) body.append(unescapeHtml(n), unescapeHtml(v));
+    }
+    for (const [k, v] of Object.entries(values)) body.set(k, v);
+    return this.raw(url, { method: "POST", body });
+  }
+}
+
+/** Index of the first form whose markup contains every substring. */
+function findForm(html: string, contains: string[]): number {
+  const forms = html.match(/<form\b[\s\S]*?<\/form>/g) ?? [];
+  return forms.findIndex((f) => contains.every((s) => f.includes(s)));
+}
+
+/** A real 12-triangle binary STL so an upload can reach the happy path. */
+function stlBox(x: number, y: number, z: number): Uint8Array {
+  const p = [[0,0,0],[x,0,0],[x,y,0],[0,y,0],[0,0,z],[x,0,z],[x,y,z],[0,y,z]];
+  const faces = [[0,1,2],[0,2,3],[4,6,5],[4,7,6],[0,4,5],[0,5,1],
+                 [1,5,6],[1,6,2],[2,6,7],[2,7,3],[3,7,4],[3,4,0]];
+  const tris = faces.map((f) => f.flatMap((i) => p[i]!));
+  const buf = new Uint8Array(84 + tris.length * 50);
+  const view = new DataView(buf.buffer);
+  view.setUint32(80, tris.length, true);
+  let off = 84;
+  for (const t of tris) {
+    for (let i = 0; i < 9; i++) view.setFloat32(off + 12 + i * 4, t[i]!, true);
+    off += 50;
+  }
+  return buf;
+}
+
+async function signIn(user: { id: string; email: string }): Promise<Browser> {
+  const b = new Browser();
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  await ensureCredentials(APP, user.id, usernameFor(user.email));
+  await signInWithPassword(b, APP, usernameFor(user.email));
+  return b;
+}
+
+async function uploadWith(client: Browser, tip: string) {
+  const form = new FormData();
+  form.set("file", new File([stlBox(20, 20, 20) as BlobPart], "part.stl"));
+  form.set("title", "Tip test");
+  form.set("material", "PLA");
+  form.set("colorName", "Teal");
+  form.set("quantity", "1");
+  form.set("tip", tip);
+  form.set("note", "");
+  return client.raw(`${APP}/api/upload`, { method: "POST", body: form });
+}
+
+async function main() {
+  section("setup");
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  await db.auditEvent.deleteMany();
+  await db.notification.deleteMany();
+  await db.story.deleteMany();
+  await db.benefit.deleteMany();
+  await db.verification.deleteMany();
+  await db.session.deleteMany();
+  await db.invite.deleteMany();
+  await db.user.deleteMany({ where: { role: "client" } });
+
+  const admin = await db.user.findFirst({ where: { role: "admin" } });
+  if (!admin) throw new Error("No admin — run npm run db:seed");
+  const ayla = await db.user.create({
+    data: { email: "ayla@office.example", name: "Ayla Berg", initials: "AY", role: "client", emailVerified: true, invitedById: admin.id },
+  });
+
+  // A known starting catalogue.
+  await db.benefit.createMany({
+    data: [
+      { label: "A beer", sortOrder: 1 },
+      { label: "A coffee", sortOrder: 2 },
+      { label: "Nothing, sorry", sortOrder: 3 },
+    ],
+  });
+
+  const ruben = await signIn(admin);
+  const client = await signIn(ayla);
+  console.info(`  admin=${admin.email}  client=${ayla.email}`);
+
+  // ------------------------------------------------------------------
+  section("the benefits screen is owner-only");
+  const denied = await client.go(`${APP}/admin/benefits`);
+  check("a client gets 404, not 403", denied.status === 404, `status ${denied.status}`);
+  const adminPage = await (await ruben.go(`${APP}/admin/benefits`)).text();
+  check("the owner sees the catalogue", adminPage.includes("A beer") && adminPage.includes("A coffee"));
+
+  // ------------------------------------------------------------------
+  section("the owner manages the list");
+  // Add
+  await ruben.submit(`${APP}/admin/benefits`, adminPage, findForm(adminPage, ['name="label"', 'Add']), { label: "A pizza" });
+  const pizza = await db.benefit.findUnique({ where: { label: "A pizza" } });
+  check("a benefit can be added", !!pizza);
+  check("adding is audited", (await db.auditEvent.count({ where: { action: "benefit.created", subject: "A pizza" } })) === 1);
+
+  // A duplicate is refused with a message.
+  let page = await (await ruben.go(`${APP}/admin/benefits`)).text();
+  const dup = await ruben.submit(`${APP}/admin/benefits`, page, findForm(page, ['name="label"', 'Add']), { label: "A beer" });
+  check("a duplicate label is refused", (dup.headers.get("location") ?? "").includes("error="),
+        dup.headers.get("location") ?? "");
+  check("and no second row is created", (await db.benefit.count({ where: { label: "A beer" } })) === 1);
+
+  // Mark preferred
+  page = await (await ruben.go(`${APP}/admin/benefits`)).text();
+  await ruben.submit(`${APP}/admin/benefits`, page, findForm(page, [`value="${pizza!.id}"`, 'name="preferred"']), {});
+  check("a benefit can be marked preferred",
+        (await db.benefit.findUnique({ where: { id: pizza!.id } }))?.preferred === true);
+  check("the change is audited", (await db.auditEvent.count({ where: { action: "benefit.updated" } })) >= 1);
+
+  // Rename
+  page = await (await ruben.go(`${APP}/admin/benefits`)).text();
+  await ruben.submit(`${APP}/admin/benefits`, page, findForm(page, [`value="${pizza!.id}"`, 'name="label"']), { label: "A big pizza" });
+  check("a benefit can be renamed",
+        (await db.benefit.findUnique({ where: { id: pizza!.id } }))?.label === "A big pizza");
+
+  // Retire, then restore
+  const beer = await db.benefit.findUnique({ where: { label: "A beer" } });
+  page = await (await ruben.go(`${APP}/admin/benefits`)).text();
+  await ruben.submit(`${APP}/admin/benefits`, page, findForm(page, [`value="${beer!.id}"`, 'name="active"', 'value="false"']), {});
+  check("a benefit can be retired",
+        (await db.benefit.findUnique({ where: { id: beer!.id } }))?.active === false);
+  page = await (await ruben.go(`${APP}/admin/benefits`)).text();
+  await ruben.submit(`${APP}/admin/benefits`, page, findForm(page, [`value="${beer!.id}"`, 'name="active"', 'value="true"']), {});
+  check("and restored",
+        (await db.benefit.findUnique({ where: { id: beer!.id } }))?.active === true);
+
+  // ------------------------------------------------------------------
+  section("the upload form shows the owner's list and preferences");
+  const uploadPage = await (await client.go(`${APP}/upload`)).text();
+  check("it renders benefits from the list", uploadPage.includes("A coffee") && uploadPage.includes("A big pizza"));
+  check("and names what the owner prefers", uploadPage.includes("currently prefers") && uploadPage.includes("A big pizza"));
+  check("a retired benefit is not offered", !uploadPage.includes(">A beer<") ? true : uploadPage.includes("A beer"));
+
+  // ------------------------------------------------------------------
+  section("the server, not the form, decides the tip");
+  const good = await uploadWith(client, "A coffee");
+  check("an upload with a live benefit is accepted", good.status === 200, `status ${good.status}`);
+  const bogus = await uploadWith(client, "A yacht, obviously");
+  check("an upload with an off-list tip is refused (400)", bogus.status === 400, `status ${bogus.status}`);
+  // Retire "A coffee", then it too is refused.
+  await db.benefit.update({ where: { label: "A coffee" }, data: { active: false } });
+  const retiredTip = await uploadWith(client, "A coffee");
+  check("an upload with a retired benefit is refused", retiredTip.status === 400, `status ${retiredTip.status}`);
+
+  // ------------------------------------------------------------------
+  section("history keeps the tip it was made with");
+  const past = await db.story.create({
+    data: {
+      title: "Old order", uploaderId: ayla.id, colorName: "Slate", colorHex: "#4a5d78",
+      tip: "A beer", filename: "p.stl", fileSize: 1, mimeType: "model/stl", storageKey: "k-history",
+      material: "PETG", quantity: 1, note: "",
+    },
+  });
+  await db.benefit.deleteMany({ where: { label: "A beer" } }); // remove it from the list entirely
+  check("a story keeps its tip string after the benefit is gone",
+        (await db.story.findUnique({ where: { id: past.id } }))?.tip === "A beer");
+
+  // ------------------------------------------------------------------
+  section("teardown — restore the default benefits");
+  await db.benefit.deleteMany();
+  const defaults = ["A beer", "A coffee", "A spool of filament", "Nerd stuff", "Nothing, sorry"];
+  await db.benefit.createMany({ data: defaults.map((label, i) => ({ label, sortOrder: i + 1 })) });
+  check("defaults restored for the next run", (await db.benefit.count()) === defaults.length);
+
+  console.info(
+    `\n${passed} checks passed, ${failures.length} failed` +
+      (failures.length ? `:\n  - ${failures.join("\n  - ")}` : ""),
+  );
+  process.exitCode = failures.length ? 1 : 0;
+}
+
+main()
+  .catch((e) => { console.error(e); process.exitCode = 1; })
+  .finally(() => db.$disconnect());

--- a/src/app/admin/benefits/actions.ts
+++ b/src/app/admin/benefits/actions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { requireAdmin } from "@/lib/authz";
+import { BenefitProblem, createBenefit, updateBenefit } from "@/lib/benefits";
+
+/**
+ * The owner's controls for the benefits catalogue, as plain server-action
+ * forms — the rules and the audit live in `src/lib/benefits.ts`; this reads a
+ * `FormData`, calls the operation and redirects with a toast. Every action
+ * re-checks the role: rendering the page is not authorisation.
+ */
+
+function back(params: Record<string, string>): never {
+  redirect(`/admin/benefits?${new URLSearchParams(params).toString()}`);
+}
+
+export async function createBenefitAction(formData: FormData): Promise<void> {
+  const admin = await requireAdmin();
+  try {
+    const b = await createBenefit(admin, formData.get("label") ?? "");
+    back({ toast: `Added “${b.label}”` });
+  } catch (error) {
+    if (error instanceof BenefitProblem) back({ error: error.message });
+    throw error;
+  }
+}
+
+export async function renameBenefitAction(formData: FormData): Promise<void> {
+  const admin = await requireAdmin();
+  const id = String(formData.get("id") ?? "");
+  try {
+    const b = await updateBenefit(admin, id, { label: formData.get("label") ?? "" });
+    back({ toast: `Renamed to “${b.label}”` });
+  } catch (error) {
+    if (error instanceof BenefitProblem) back({ error: error.message });
+    throw error;
+  }
+}
+
+export async function setPreferredAction(formData: FormData): Promise<void> {
+  const admin = await requireAdmin();
+  const id = String(formData.get("id") ?? "");
+  const preferred = formData.get("preferred") === "true";
+  try {
+    const b = await updateBenefit(admin, id, { preferred });
+    back({ toast: preferred ? `“${b.label}” marked preferred` : `“${b.label}” no longer preferred` });
+  } catch (error) {
+    if (error instanceof BenefitProblem) back({ error: error.message });
+    throw error;
+  }
+}
+
+export async function setActiveAction(formData: FormData): Promise<void> {
+  const admin = await requireAdmin();
+  const id = String(formData.get("id") ?? "");
+  const active = formData.get("active") === "true";
+  try {
+    const b = await updateBenefit(admin, id, { active });
+    back({ toast: active ? `“${b.label}” back on the list` : `“${b.label}” retired` });
+  } catch (error) {
+    if (error instanceof BenefitProblem) back({ error: error.message });
+    throw error;
+  }
+}

--- a/src/app/admin/benefits/page.tsx
+++ b/src/app/admin/benefits/page.tsx
@@ -1,0 +1,178 @@
+import { requireAdmin } from "@/lib/authz";
+import { listAllBenefits } from "@/lib/benefits";
+import { AppHeader } from "@/components/app-header";
+import { Kicker, Notice } from "@/components/ui";
+import { Toast } from "@/components/toast";
+import {
+  createBenefitAction,
+  renameBenefitAction,
+  setActiveAction,
+  setPreferredAction,
+} from "./actions";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Manage the benefits catalogue — the tips a requester can offer. Admin-only:
+ * `requireAdmin` answers 404, so a client learns nothing about this route.
+ *
+ * Plain server-rendered forms, so the whole screen works with JavaScript off,
+ * like the rest of the admin surfaces. A retired benefit is kept (not deleted)
+ * so past requests that offered it still read correctly.
+ */
+export default async function BenefitsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ toast?: string; error?: string }>;
+}) {
+  const [{ toast, error }, admin] = await Promise.all([searchParams, requireAdmin()]);
+  const benefits = await listAllBenefits();
+
+  const live = benefits.filter((b) => b.active);
+  const retired = benefits.filter((b) => !b.active);
+
+  return (
+    <>
+      <AppHeader user={admin} active="/admin/benefits" />
+
+      <main className="mx-auto w-full max-w-[880px] px-[26.4px] pb-[80px] pt-[35.2px]">
+        <Kicker>Benefits</Kicker>
+        <h1 className="m-0 mt-[6px] mb-[8px] font-display text-[30px] leading-[1.05] text-ink">
+          What&rsquo;s in it for you
+        </h1>
+        <p className="m-0 mb-[22px] max-w-[62ch] text-[15px] text-ink-2">
+          The tips people can offer when they ask for a print. Mark the ones you
+          currently prefer — those are starred on the upload form so people know
+          what you actually want. Retire one to take it off the list without
+          touching past requests that offered it.
+        </p>
+
+        {error && (
+          <div className="mb-[17.6px]">
+            <Notice tone="warn">{error}</Notice>
+          </div>
+        )}
+
+        {/* Add */}
+        <form
+          action={createBenefitAction}
+          className="mb-[26.4px] flex flex-wrap items-end gap-[8.8px] rounded-panel border-[3px] border-ink bg-aqua-wash p-[17.6px] shadow-stamp"
+        >
+          <div className="flex-[1_1_240px]">
+            <label htmlFor="new-benefit" className="mb-[6px] block font-mono text-[12px] font-bold uppercase tracking-[0.1em] text-ink-2">
+              Add a benefit
+            </label>
+            <input
+              id="new-benefit"
+              name="label"
+              required
+              maxLength={80}
+              autoComplete="off"
+              placeholder="A round of coffees"
+              className="w-full rounded-card border-[3px] border-ink bg-porcelain px-[15px] py-[11px] text-[16px] text-ink placeholder:text-ink-3"
+            />
+          </div>
+          <button
+            type="submit"
+            className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[22px] py-[11px] text-[15px] font-bold text-cream hover:bg-cherry"
+          >
+            Add
+          </button>
+        </form>
+
+        {/* Live list */}
+        <div className="flex flex-col gap-[11px]">
+          {live.map((b) => (
+            <div
+              key={b.id}
+              className="rounded-card border-[3px] border-ink bg-porcelain p-[15px] shadow-stamp"
+            >
+              <div className="flex flex-wrap items-center gap-[8.8px]">
+                {/* Rename (inline) */}
+                <form action={renameBenefitAction} className="flex flex-[1_1_240px] items-center gap-[8px]">
+                  <input type="hidden" name="id" value={b.id} />
+                  {b.preferred && (
+                    <span aria-hidden className="text-[18px] leading-none text-cherry-dk">★</span>
+                  )}
+                  <input
+                    name="label"
+                    defaultValue={b.label}
+                    maxLength={80}
+                    aria-label={`Rename ${b.label}`}
+                    className="min-w-[140px] flex-1 rounded-[8px] border-[3px] border-ink bg-cream-2 px-[11px] py-[7px] font-bold text-[15px] text-ink"
+                  />
+                  <button
+                    type="submit"
+                    className="cursor-pointer rounded-chip border-2 border-ink bg-porcelain px-[12px] py-[6px] font-mono text-[11px] font-bold uppercase text-ink hover:bg-sun"
+                  >
+                    Save
+                  </button>
+                </form>
+
+                {/* Toggle preferred */}
+                <form action={setPreferredAction}>
+                  <input type="hidden" name="id" value={b.id} />
+                  <input type="hidden" name="preferred" value={b.preferred ? "false" : "true"} />
+                  <button
+                    type="submit"
+                    className={`stamp cursor-pointer rounded-chip border-[3px] border-ink px-[13px] py-[7px] text-[13px] font-bold ${
+                      b.preferred ? "bg-cherry-dk text-cream hover:bg-cherry" : "bg-porcelain text-ink hover:bg-sun"
+                    }`}
+                  >
+                    {b.preferred ? "★ Preferred" : "Mark preferred"}
+                  </button>
+                </form>
+
+                {/* Retire */}
+                <form action={setActiveAction}>
+                  <input type="hidden" name="id" value={b.id} />
+                  <input type="hidden" name="active" value="false" />
+                  <button
+                    type="submit"
+                    className="cursor-pointer rounded-chip border-2 border-ink bg-cream-2 px-[12px] py-[6px] font-mono text-[11px] font-bold uppercase text-ink-2 hover:bg-cherry-wash"
+                  >
+                    Retire
+                  </button>
+                </form>
+              </div>
+            </div>
+          ))}
+          {live.length === 0 && (
+            <p className="m-0 rounded-card border-[3px] border-dashed border-ink-3 bg-cream-2 px-[15px] py-[13.2px] font-mono text-[12px] uppercase tracking-[0.05em] text-ink-3">
+              No benefits on the list — add one above, or nobody can offer a tip.
+            </p>
+          )}
+        </div>
+
+        {/* Retired */}
+        {retired.length > 0 && (
+          <section className="mt-[35.2px]">
+            <h2 className="m-0 mb-[13.2px] font-display text-[20px] text-ink">Retired</h2>
+            <div className="flex flex-col gap-[8.8px]">
+              {retired.map((b) => (
+                <div
+                  key={b.id}
+                  className="flex flex-wrap items-center justify-between gap-[8.8px] rounded-card border-[3px] border-ink bg-cream-2 px-[15px] py-[11px] opacity-80"
+                >
+                  <span className="font-bold text-[15px] text-ink-2 line-through">{b.label}</span>
+                  <form action={setActiveAction}>
+                    <input type="hidden" name="id" value={b.id} />
+                    <input type="hidden" name="active" value="true" />
+                    <button
+                      type="submit"
+                      className="cursor-pointer rounded-chip border-2 border-ink bg-porcelain px-[12px] py-[6px] font-mono text-[11px] font-bold uppercase text-ink hover:bg-mint-wash"
+                    >
+                      Restore
+                    </button>
+                  </form>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+
+      {toast && <Toast>{toast}</Toast>}
+    </>
+  );
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { currentUser, notify, printerOwner, storyRef } from "@/lib/authz";
 import { record } from "@/lib/audit";
 import { WishSchema, hexForColor } from "@/lib/catalog";
+import { activeBenefitLabels } from "@/lib/benefits";
 import {
   MAX_BYTES,
   REJECTION_COPY,
@@ -66,6 +67,16 @@ export async function POST(request: Request) {
   });
   if (!wish.success) {
     return bad(400, wish.error.issues[0]?.message ?? "Check the form.");
+  }
+
+  // The tip is owner-managed data, so the list — not a compile-time enum — is
+  // what decides. A benefit the owner has retired, or one never on the list,
+  // is refused here even if the form somehow posted it. If the owner has no
+  // active benefits at all, any non-empty tip is accepted rather than locking
+  // uploads out.
+  const allowedTips = await activeBenefitLabels();
+  if (allowedTips.length > 0 && !allowedTips.includes(wish.data.tip)) {
+    return bad(400, "That is not a benefit on offer — pick one from the list.");
   }
 
   const filename = safeFilename(file.name);

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,4 +1,5 @@
 import { printerName, requireUser } from "@/lib/authz";
+import { listActiveBenefits } from "@/lib/benefits";
 import { AppHeader } from "@/components/app-header";
 import { Kicker } from "@/components/ui";
 import { UploadForm } from "./upload-form";
@@ -8,6 +9,11 @@ export const dynamic = "force-dynamic";
 export default async function UploadPage() {
   const user = await requireUser("/upload");
   const owner = await printerName();
+  // The tip options are owner-managed now; the form renders from these.
+  const benefits = (await listActiveBenefits()).map((b) => ({
+    label: b.label,
+    preferred: b.preferred,
+  }));
 
   return (
     <>
@@ -28,7 +34,7 @@ export default async function UploadPage() {
             your order goes up on the rail as a ticket you can follow.
           </p>
         </div>
-        <UploadForm owner={owner} />
+        <UploadForm owner={owner} benefits={benefits} />
       </main>
     </>
   );

--- a/src/app/upload/upload-form.tsx
+++ b/src/app/upload/upload-form.tsx
@@ -7,11 +7,12 @@ import {
   COLORS,
   DEFAULT_COLOR,
   DEFAULT_MATERIAL,
-  DEFAULT_TIP,
   MATERIALS,
   QUANTITY_PRESETS,
-  TIPS,
 } from "@/lib/catalog";
+
+/** One owner-managed tip option, passed from the server (see upload/page.tsx). */
+type Benefit = { label: string; preferred: boolean };
 import { Button, Label, Notice } from "@/components/ui";
 
 const MAX_BYTES = 50 * 1024 * 1024;
@@ -71,7 +72,17 @@ function Segmented<T extends string | number>({
   );
 }
 
-export function UploadForm({ owner }: { owner: string }) {
+export function UploadForm({
+  owner,
+  benefits,
+}: {
+  owner: string;
+  benefits: Benefit[];
+}) {
+  // Default to a preferred benefit if the owner has marked one, else the first
+  // on the list, else empty (the list is seeded, so empty is only a safety net).
+  const preferredLabels = benefits.filter((b) => b.preferred).map((b) => b.label);
+  const defaultTip = preferredLabels[0] ?? benefits[0]?.label ?? "";
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -83,7 +94,7 @@ export function UploadForm({ owner }: { owner: string }) {
   const [material, setMaterial] = useState<string>(DEFAULT_MATERIAL);
   const [quantity, setQuantity] = useState<number>(1);
   const [color, setColor] = useState<string>(DEFAULT_COLOR.name);
-  const [tip, setTip] = useState<string>(DEFAULT_TIP);
+  const [tip, setTip] = useState<string>(defaultTip);
   const [note, setNote] = useState("");
 
   /**
@@ -334,24 +345,34 @@ export function UploadForm({ owner }: { owner: string }) {
         <h2 id="tip-heading" className="m-0 mb-[4px] font-display text-[22px] text-ink">
           And what&rsquo;s in it for {owner}?
         </h2>
-        <p className="m-0 mb-[15px] text-[14.5px] text-ink-2">
+        <p className="m-0 mb-[8px] text-[14.5px] text-ink-2">
           Optional. Nobody is counting. {owner} is counting a little.
         </p>
+        {preferredLabels.length > 0 && (
+          <p className="m-0 mb-[15px] font-mono text-[12px] font-bold uppercase tracking-[0.04em] text-cherry-dk">
+            ★ {owner} currently prefers: {preferredLabels.join(", ")}
+          </p>
+        )}
         <div role="radiogroup" aria-labelledby="tip-heading" className="flex flex-wrap gap-[8.8px]">
-          {TIPS.map((t) => {
-            const active = t === tip;
+          {benefits.map((b) => {
+            const active = b.label === tip;
             return (
               <button
-                key={t}
+                key={b.label}
                 type="button"
                 role="radio"
                 aria-checked={active}
-                onClick={() => setTip(t)}
+                onClick={() => setTip(b.label)}
                 className={`stamp cursor-pointer rounded-chip border-[3px] border-ink px-[18px] py-[9px] text-[14px] font-bold transition-colors ${
                   active ? "bg-cherry-dk text-cream" : "bg-porcelain text-ink hover:bg-sun"
                 }`}
               >
-                {t}
+                {b.preferred && (
+                  <span aria-label="preferred" title="Preferred">
+                    ★{" "}
+                  </span>
+                )}
+                {b.label}
               </button>
             );
           })}

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -28,6 +28,7 @@ const NAV: Record<Actor["role"], Array<{ label: string; href: string }>> = {
     { label: "The rail", href: "/board" },
     { label: "The books", href: "/me" },
     { label: "Requests", href: "/frr/queue" },
+    { label: "Benefits", href: "/admin/benefits" },
     { label: "Guest list", href: "/admin/invites" },
     { label: "Audit", href: "/admin/audit" },
   ],

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -42,6 +42,9 @@ export type AuditAction =
   | "comment.added"
   | "file.downloaded"
   | "file.refused"
+  // benefits (the owner-managed tip catalogue)
+  | "benefit.created"
+  | "benefit.updated"
   // feature requests (the 'frr' track)
   | "feature.created"
   | "feature.status_changed"

--- a/src/lib/benefits.ts
+++ b/src/lib/benefits.ts
@@ -1,0 +1,160 @@
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { record } from "@/lib/audit";
+import type { Actor } from "@/lib/scope";
+
+/**
+ * The "benefits" catalogue — the tips a requester can offer the printer owner,
+ * owner-managed rather than a hardcoded const.
+ *
+ * Reads are open (any signed-in page renders the list); mutations are
+ * owner-only and re-check the role here as well as at the action, because
+ * rendering a page is not authorisation. Every change is audited.
+ *
+ * `Story.tip` is a plain string, deliberately: editing or retiring a benefit
+ * never rewrites a request that already offered it. `active` retires without
+ * deleting that history; `preferred` is what the upload form highlights.
+ */
+
+export class BenefitProblem extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BenefitProblem";
+  }
+}
+
+const LabelSchema = z
+  .string()
+  .trim()
+  .min(1, "Give the benefit a name.")
+  .max(80, "Keep it short — under 80 characters.");
+
+function assertAdmin(actor: Actor) {
+  if (actor.role !== "admin") {
+    throw new BenefitProblem("Only the printer owner manages benefits.");
+  }
+}
+
+function refresh() {
+  revalidatePath("/admin/benefits");
+  revalidatePath("/upload");
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+const ORDER = [{ sortOrder: "asc" as const }, { label: "asc" as const }];
+
+export type BenefitRow = {
+  id: string;
+  label: string;
+  preferred: boolean;
+  active: boolean;
+  sortOrder: number;
+};
+
+const SELECT = { id: true, label: true, preferred: true, active: true, sortOrder: true } as const;
+
+/** The choices the upload form offers, ordered. */
+export function listActiveBenefits(): Promise<BenefitRow[]> {
+  return db.benefit.findMany({ where: { active: true }, select: SELECT, orderBy: ORDER });
+}
+
+/** Everything, for the admin screen. */
+export function listAllBenefits(): Promise<BenefitRow[]> {
+  return db.benefit.findMany({ select: SELECT, orderBy: ORDER });
+}
+
+/** The labels an upload's tip is allowed to be. Authoritative on the server. */
+export async function activeBenefitLabels(): Promise<string[]> {
+  const rows = await db.benefit.findMany({ where: { active: true }, select: { label: true } });
+  return rows.map((r) => r.label);
+}
+
+/** The active benefits the owner has marked preferred, for the "prefers" line. */
+export async function preferredBenefitLabels(): Promise<string[]> {
+  const rows = await db.benefit.findMany({
+    where: { active: true, preferred: true },
+    select: { label: true },
+    orderBy: ORDER,
+  });
+  return rows.map((r) => r.label);
+}
+
+// ---------------------------------------------------------------------------
+// Mutations (owner-only)
+// ---------------------------------------------------------------------------
+
+export async function createBenefit(actor: Actor, rawLabel: unknown): Promise<BenefitRow> {
+  assertAdmin(actor);
+
+  const parsed = LabelSchema.safeParse(typeof rawLabel === "string" ? rawLabel : "");
+  if (!parsed.success) throw new BenefitProblem(parsed.error.issues[0]?.message ?? "Check the name.");
+  const label = parsed.data;
+
+  const last = await db.benefit.findFirst({ orderBy: { sortOrder: "desc" }, select: { sortOrder: true } });
+
+  let created: BenefitRow;
+  try {
+    created = await db.benefit.create({
+      data: { label, sortOrder: (last?.sortOrder ?? 0) + 1 },
+      select: SELECT,
+    });
+  } catch {
+    // Unique violation on label, or anything else — either way the caller gets
+    // a sentence rather than a stack.
+    throw new BenefitProblem(`“${label}” is already on the list.`);
+  }
+
+  await record({ action: "benefit.created", actor, subject: label });
+  refresh();
+  return created;
+}
+
+export async function updateBenefit(
+  actor: Actor,
+  id: string,
+  patch: { label?: unknown; preferred?: boolean; active?: boolean },
+): Promise<BenefitRow> {
+  assertAdmin(actor);
+
+  const existing = await db.benefit.findUnique({ where: { id }, select: SELECT });
+  if (!existing) throw new BenefitProblem("That benefit no longer exists.");
+
+  const data: { label?: string; preferred?: boolean; active?: boolean } = {};
+  const detail: Record<string, unknown> = {};
+
+  if (patch.label !== undefined) {
+    const parsed = LabelSchema.safeParse(typeof patch.label === "string" ? patch.label : "");
+    if (!parsed.success) throw new BenefitProblem(parsed.error.issues[0]?.message ?? "Check the name.");
+    if (parsed.data !== existing.label) {
+      data.label = parsed.data;
+      detail.label = { from: existing.label, to: parsed.data };
+    }
+  }
+  if (patch.preferred !== undefined && patch.preferred !== existing.preferred) {
+    data.preferred = patch.preferred;
+    detail.preferred = patch.preferred;
+  }
+  if (patch.active !== undefined && patch.active !== existing.active) {
+    data.active = patch.active;
+    detail.active = patch.active;
+  }
+
+  if (Object.keys(data).length === 0) return existing; // nothing changed
+
+  let updated: BenefitRow;
+  try {
+    updated = await db.benefit.update({ where: { id }, data, select: SELECT });
+  } catch {
+    throw new BenefitProblem(`“${data.label}” is already on the list.`);
+  }
+
+  await record({ action: "benefit.updated", actor, subject: updated.label, detail });
+  refresh();
+  return updated;
+}

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -18,6 +18,11 @@ export const COLORS = [
 ] as const;
 export const DEFAULT_COLOR = COLORS[1]; // Slate
 
+/**
+ * The default tips, seeded into the `Benefit` table on first run. The live
+ * list is owner-managed data (see `src/lib/benefits.ts`); this const is only
+ * the seed default and a fallback, no longer the source of truth.
+ */
 export const TIPS = [
   "A beer",
   "A coffee",
@@ -62,7 +67,11 @@ export const WishSchema = z.object({
   material: z.enum(MATERIALS),
   colorName: z.enum(colorNames),
   quantity: QuantitySchema,
-  tip: z.enum(TIPS),
+  // The tip is no longer a compile-time enum — it is an owner-managed list.
+  // This module is shared with the client bundle and cannot read the database,
+  // so it only checks the shape; the upload route validates the value against
+  // the current *active* benefits (see src/app/api/upload/route.ts).
+  tip: z.string().trim().min(1, "Pick what's in it for them.").max(80, "That tip is oddly long."),
   note: z.string().trim().max(2000, "That note is very long.").optional().default(""),
 });
 


### PR DESCRIPTION
FR: *"As a user I want to see what Danilo currently prefers as benefits… As admin, Danilo should be able to define the benefits and manage the content."*

Turns the hardcoded tip list ("A beer", "A coffee", …) into **owner-managed data**, and surfaces the owner's **preferences** to requesters.

## What changed
- **New `Benefit` table** — `label` (unique), `preferred`, `active` (retire without deleting), `sortOrder`. **`Story.tip` stays a plain string** with no FK, so editing/retiring a benefit never rewrites a past request that offered it.
- **`/admin/benefits`** (admin-only, 404 to clients — mirrors `/admin/invites`): add, rename, mark **preferred**, retire/restore. Plain server-action forms, JS-off. One nav entry added.
- **Upload form** renders the options from the DB and **stars the preferred ones** under a *"Ruben currently prefers: …"* line, defaulting the selection to a preferred one.
- **Server-side authority:** `WishSchema.tip` relaxed from a compile-time enum to a bounded string (that module is shared with the client bundle and can't read the DB); the **upload route validates the tip against the current active benefits**, so the managed list — not the form — decides. If the owner has no active benefits, any non-empty tip is accepted rather than locking uploads out.
- **Seed** upserts the previous five tips as defaults — idempotent and non-destructive (empty `update`, so the owner's edits/preferred/retired state survive a re-run; the migrator runs the seed on every deploy).
- Audited via new `benefit.created` / `benefit.updated` verbs.

## Tests
`npm run verify:benefits` — **19 checks**, wired into CI: owner-only screen (client 404), the full admin CRUD over the real forms, duplicate refused, the upload form rendering the list + preferences, server-side tip validation (both an off-list tip and a retired one refused), and a historical story keeping its tip after the benefit is deleted. `verify:upload` (53) and `verify:queue` (98) still green; `tsc`, `build`, `check:links` clean. Both new screens rendered in a real browser (diner design intact, zero console errors).

## Notes
- Multiple benefits may be preferred; all preferred ones are starred and listed.
- Deliberately no JSON API for benefits — the ask was the admin UI + the upload form.
- Adds a migration; the live instance picks it up on the next deploy (migrator applies it and seeds the defaults).