### PR TITLE
Feature requests: priority editable in any status, and priority/status/category filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Notable changes. Every entry names a released version; deployments pin
 
 ### Added
 
+- **Feature requests are filterable.** A filter bar on the `/frr` board and the
+  `/frr/queue` triage view narrows by priority, status and category. The choices
+  live in the URL and are applied server-side, ANDed onto `featureScope`, so a
+  filter can only ever narrow what a caller may already see — never widen it —
+  and a filtered view is link- and bookmark-able. An unrecognised value degrades
+  to "any" rather than erroring.
+
 - **The benefits (tip options) are owner-managed.** What used to be a hardcoded
   list of tips ("A beer", "A coffee", …) is now data the printer owner edits at
   `/admin/benefits`: add, rename, retire/restore, and mark which they currently
@@ -38,6 +45,12 @@ Notable changes. Every entry names a released version; deployments pin
   `story.requeued`; the owner is notified as for any new request.
 
 ### Changed
+
+- **A feature request's priority is editable in every status.** The requester
+  could only re-rank their own request while it was still live; now a closed
+  one — `Done` or `Declined` — can be re-prioritised too, because hindsight
+  keeps changing after the fact. The owner could always change any. Every
+  change is still audited (`feature.priority_changed`) and tells the other side.
 
 - **Withdraw now reaches Accepted (FRR-101).** A requester could only withdraw
   a `Requested` or `Declined` ticket; the window now also includes `Accepted`,

--- a/docs/feature-requests.md
+++ b/docs/feature-requests.md
@@ -10,19 +10,23 @@ notifications and audit trail a print goes through. It lives at **`/frr`**.
 
 - **`/frr`** — the rail. Your own requests (the owner sees everyone's), one
   column per stage, with anything closed gathered under *Closed* so you keep
-  your history without a second page.
+  your history without a second page. A **filter bar** narrows by priority,
+  status and category (the choices ride in the URL, applied server-side, so a
+  filter can only ever shrink what you were already allowed to see).
 - **`/frr/new`** — file one: a title, what-and-why, a **priority**
   (low / medium / high) and a **category** (UI / API / bug / other).
 - **`/frr/[id]`** — the request in full: where it sits in the flow, the
-  conversation, a **priority** control (the requester may change it while the
-  request is still live; the owner may change any, any time), and — while
-  nobody has started on it — a **Withdraw** control for the person who filed it.
+  conversation, a **priority** control (the requester may change it in **any**
+  status — a closed request can still be re-ranked; the owner may change any),
+  and — while nobody has started on it — a **Withdraw** control for the person
+  who filed it.
 
 ## For the owner
 
 - **`/frr/queue`** — triage. *Waiting on you* (still `Requested`) comes first,
   ordered high-priority first; everything in flight is a list with one control
-  each. Owner-only — a client gets a 404, exactly like the print queue.
+  each. The same **filter bar** (priority / status / category) narrows the
+  view. Owner-only — a client gets a 404, exactly like the print queue.
 - Move a request one step at a time: **Requested → Accepted → In progress →
   Shipped → Done**, or **Decline** it (terminal, and only from `Requested`).
   Every move notifies the requester and writes an audit row.

--- a/scripts/verify-frr.ts
+++ b/scripts/verify-frr.ts
@@ -356,11 +356,59 @@ async function main() {
   check("the owner can change any request's priority",
         (await db.featureRequest.findUnique({ where: { id: mine.id } }))?.priority === "medium");
 
-  // A closed request offers the requester no priority control.
+  // Priority is editable in EVERY status now — a closed request included.
   const closedPr = await makeFeature(ayla.id, "Long since closed", "Done");
   const closedPage = await (await client.go(`${APP}/frr/${closedPr.id}`)).text();
-  check("a Done request offers the requester no priority control",
-        !closedPage.includes("Change priority"));
+  const closedIdx = formIndexContaining(closedPage, 'name="priority"');
+  check("a Done request still offers the requester the priority control", closedIdx >= 0);
+  await client.submit(`${APP}/frr/${closedPr.id}`, closedPage, closedIdx, {
+    id: String(closedPr.id), priority: "high",
+  });
+  check("the requester reprioritises a Done request",
+        (await db.featureRequest.findUnique({ where: { id: closedPr.id } }))?.priority === "high");
+  check("and it is audited",
+        (await db.auditEvent.count({ where: { action: "feature.priority_changed", subject: refOf(closedPr.id) } })) === 1);
+
+  const declinedPr = await makeFeature(ayla.id, "Turned down but still ranked", "Declined");
+  const declinedPage = await (await client.go(`${APP}/frr/${declinedPr.id}`)).text();
+  await client.submit(`${APP}/frr/${declinedPr.id}`, declinedPage,
+    formIndexContaining(declinedPage, 'name="priority"'), { id: String(declinedPr.id), priority: "low" });
+  check("a Declined request's priority is editable too",
+        (await db.featureRequest.findUnique({ where: { id: declinedPr.id } }))?.priority === "low");
+
+  // ------------------------------------------------------------------
+  section("filtering by priority, status and category");
+  // A known spread the owner can filter over. Ayla owns them all here.
+  const fHigh = await makeFeature(ayla.id, "High UI thing", "Requested");
+  await db.featureRequest.update({ where: { id: fHigh.id }, data: { priority: "high", category: "ui" } });
+  const fLowApi = await makeFeature(ayla.id, "Low API thing", "Accepted");
+  await db.featureRequest.update({ where: { id: fLowApi.id }, data: { priority: "low", category: "api" } });
+
+  const q = async (query: string) =>
+    rendered(await (await ruben.go(`${APP}/frr/queue?${query}`)).text());
+
+  const byHigh = await q("priority=high");
+  check("filter priority=high shows the high one", byHigh.includes("High UI thing"));
+  check("and hides the low one", !byHigh.includes("Low API thing"));
+
+  const byApi = await q("category=api");
+  check("filter category=api shows the API one", byApi.includes("Low API thing"));
+  check("and hides the UI one", !byApi.includes("High UI thing"));
+
+  const byCombo = await q("priority=high&category=api");
+  check("a combined filter that matches nothing shows neither",
+        !byCombo.includes("High UI thing") && !byCombo.includes("Low API thing"));
+
+  // Scope holds under a filter: a client's filter never surfaces another's.
+  const malloryHigh = await makeFeature(mallory.id, "Mallory high UI", "Requested");
+  await db.featureRequest.update({ where: { id: malloryHigh.id }, data: { priority: "high", category: "ui" } });
+  const aylaFiltered = rendered(await (await client.go(`${APP}/frr?priority=high`)).text());
+  check("a client's priority filter still hides another client's matching request",
+        aylaFiltered.includes("High UI thing") && !aylaFiltered.includes("Mallory high UI"));
+
+  // A garbage filter value degrades to "any" rather than erroring.
+  const garbage = await ruben.go(`${APP}/frr/queue?priority=urgent`);
+  check("an unknown filter value is ignored (no error)", garbage.status === 200);
 
   // ------------------------------------------------------------------
   section("the board draws the four live rails, closed items leave");

--- a/src/app/frr/[id]/page.tsx
+++ b/src/app/frr/[id]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { requireUser, printerName } from "@/lib/authz";
-import { FEATURE_FLOW, featureLabel, featureRef, isFeatureTerminal } from "@/lib/scope";
+import { FEATURE_FLOW, featureLabel, featureRef } from "@/lib/scope";
 import { findFeature, listFeatureComments } from "@/lib/features";
 import { changeFeaturePriority, withdrawFeature } from "@/app/actions/features";
 import { relativeTime, PRIORITY_CHIP, CATEGORY_LABEL, FEATURE_PRIORITIES } from "@/lib/catalog";
@@ -44,11 +44,10 @@ export default async function FeaturePage({
   const canWithdraw =
     feature.requester.id === user.id &&
     (feature.status === "Requested" || feature.status === "Declined");
-  // Reprioritise: the owner any time, the requester on their own while it is
-  // still live. Matches `changeFeaturePriority` in the service.
+  // Reprioritise: the owner on any request, the requester on their own — in
+  // any status, a closed request included. Matches `changeFeaturePriority`.
   const canReprioritise =
-    user.role === "admin" ||
-    (feature.requester.id === user.id && !isFeatureTerminal(feature.status));
+    user.role === "admin" || feature.requester.id === user.id;
 
   return (
     <>

--- a/src/app/frr/page.tsx
+++ b/src/app/frr/page.tsx
@@ -2,9 +2,10 @@ import Link from "next/link";
 
 import { requireUser, printerName } from "@/lib/authz";
 import { FEATURE_BOARD, featureLabel } from "@/lib/scope";
-import { listFeatures } from "@/lib/features";
+import { coerceFeatureFilter, hasFeatureFilter, listFeatures } from "@/lib/features";
 import { AppHeader } from "@/components/app-header";
 import { FeatureCard } from "@/components/feature-card";
+import { FeatureFilterBar } from "@/components/feature-filter";
 import { Kicker } from "@/components/ui";
 import { Toast } from "@/components/toast";
 import type { FeatureStatus } from "@prisma/client";
@@ -30,12 +31,15 @@ const RAIL: Record<string, { bar: string; note: string }> = {
 export default async function FeatureBoardPage({
   searchParams,
 }: {
-  searchParams: Promise<{ toast?: string }>;
+  searchParams: Promise<{ toast?: string; priority?: string; status?: string; category?: string }>;
 }) {
-  const [{ toast }, user] = await Promise.all([searchParams, requireUser("/frr")]);
+  const [params, user] = await Promise.all([searchParams, requireUser("/frr")]);
+  const { toast } = params;
   const owner = await printerName();
 
-  const features = await listFeatures(user);
+  const filter = coerceFeatureFilter(params);
+  const features = await listFeatures(user, filter);
+  const filtered = hasFeatureFilter(filter);
   const isAdmin = user.role === "admin";
 
   const closed = features.filter((f) => f.status === "Done" || f.status === "Declined");
@@ -65,12 +69,28 @@ export default async function FeatureBoardPage({
           </Link>
         </div>
 
+        <FeatureFilterBar action="/frr" filter={filter} />
+
         {features.length === 0 ? (
           <div className="rounded-panel border-[3px] border-dashed border-ink-3 bg-cream-2 px-[26.4px] py-[35.2px] text-center">
-            <p className="m-0 font-display text-[19px] text-ink">Nothing here yet</p>
-            <p className="m-0 mt-[6px] text-[15px] text-ink-2">
-              The first idea goes on the board the moment you file it.
-            </p>
+            {filtered ? (
+              <>
+                <p className="m-0 font-display text-[19px] text-ink">Nothing matches those filters</p>
+                <p className="m-0 mt-[6px] text-[15px] text-ink-2">
+                  <Link href="/frr" className="underline underline-offset-2 hover:text-cherry-dk">
+                    Clear the filters
+                  </Link>{" "}
+                  to see everything.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="m-0 font-display text-[19px] text-ink">Nothing here yet</p>
+                <p className="m-0 mt-[6px] text-[15px] text-ink-2">
+                  The first idea goes on the board the moment you file it.
+                </p>
+              </>
+            )}
           </div>
         ) : (
           <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-[17.6px]">

--- a/src/app/frr/queue/page.tsx
+++ b/src/app/frr/queue/page.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
 
-import { db } from "@/lib/db";
 import { requireAdmin } from "@/lib/authz";
 import { featureLabel, featureRef } from "@/lib/scope";
-import { FEATURE_FIELDS } from "@/lib/features";
+import { coerceFeatureFilter, listFeatures } from "@/lib/features";
 import { relativeTime, PRIORITY_CHIP, CATEGORY_LABEL } from "@/lib/catalog";
 import { AppHeader } from "@/components/app-header";
 import { FeatureActions } from "@/components/feature-actions";
+import { FeatureFilterBar } from "@/components/feature-filter";
 import { Kicker, Notice, StatusChip } from "@/components/ui";
 import { Toast } from "@/components/toast";
 
@@ -21,14 +21,21 @@ export const dynamic = "force-dynamic";
 export default async function FeatureQueuePage({
   searchParams,
 }: {
-  searchParams: Promise<{ toast?: string; error?: string }>;
+  searchParams: Promise<{
+    toast?: string;
+    error?: string;
+    priority?: string;
+    status?: string;
+    category?: string;
+  }>;
 }) {
-  const [{ toast, error }, admin] = await Promise.all([searchParams, requireAdmin()]);
+  const [params, admin] = await Promise.all([searchParams, requireAdmin()]);
+  const { toast, error } = params;
 
-  const features = await db.featureRequest.findMany({
-    select: FEATURE_FIELDS,
-    orderBy: { createdAt: "asc" },
-  });
+  // The owner sees everyone's, so scope is `{}` — the filter is all the query
+  // narrows by here. Oldest-first, the order a triage queue wants.
+  const filter = coerceFeatureFilter(params);
+  const features = await listFeatures(admin, filter, "asc");
 
   // Priority order for the eye: high first. Within a priority, oldest first.
   const rank = { high: 0, medium: 1, low: 2 } as Record<string, number>;
@@ -48,6 +55,8 @@ export default async function FeatureQueuePage({
         <h1 className="m-0 mt-[6px] mb-[22px] font-display text-[30px] leading-[1.05] text-ink">
           Requests to triage
         </h1>
+
+        <FeatureFilterBar action="/frr/queue" filter={filter} />
 
         {error && (
           <div className="mb-[17.6px]">

--- a/src/components/feature-filter.tsx
+++ b/src/components/feature-filter.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+
+import {
+  FEATURE_PRIORITIES,
+  FEATURE_CATEGORIES,
+  PRIORITY_CHIP,
+  CATEGORY_LABEL,
+} from "@/lib/catalog";
+import { FEATURE_FLOW, featureLabel } from "@/lib/scope";
+import type { FeatureFilter } from "@/lib/features";
+import type { FeatureStatus } from "@prisma/client";
+
+const STATUSES = [...FEATURE_FLOW, "Declined"] as readonly FeatureStatus[];
+
+/**
+ * The filter bar over the feature-request views — priority, status, category.
+ *
+ * A native `method="get"` form, not a server action: submitting puts the
+ * choices in the URL (`?priority=high&status=Accepted`), which the page reads
+ * and applies server-side. So it works with JavaScript off, the result is
+ * link-and-bookmark-able, and the narrowing happens in the query — a filter
+ * can only ever shrink what `featureScope` already allows, never widen it.
+ */
+export function FeatureFilterBar({
+  action,
+  filter,
+}: {
+  /** The page path the form submits back to (also the "Clear" target). */
+  action: string;
+  filter: FeatureFilter;
+}) {
+  const active = Boolean(filter.priority || filter.status || filter.category);
+  const selectCls =
+    "rounded-card border-[3px] border-ink bg-porcelain px-[11px] py-[7px] font-mono text-[13px] text-ink";
+  const labelCls =
+    "font-mono text-[10.5px] font-bold uppercase tracking-[0.1em] text-ink-3";
+
+  return (
+    <form
+      method="get"
+      action={action}
+      className="mb-[22px] flex flex-wrap items-end gap-[10px] rounded-panel border-[3px] border-ink bg-cream-2 p-[13.2px]"
+    >
+      <div className="flex flex-col gap-[3px]">
+        <label htmlFor="f-priority" className={labelCls}>Priority</label>
+        <select id="f-priority" name="priority" defaultValue={filter.priority ?? ""} className={selectCls}>
+          <option value="">Any</option>
+          {FEATURE_PRIORITIES.map((p) => (
+            <option key={p} value={p}>{PRIORITY_CHIP[p]?.label ?? p}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-[3px]">
+        <label htmlFor="f-status" className={labelCls}>Status</label>
+        <select id="f-status" name="status" defaultValue={filter.status ?? ""} className={selectCls}>
+          <option value="">Any</option>
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>{featureLabel(s)}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-[3px]">
+        <label htmlFor="f-category" className={labelCls}>Category</label>
+        <select id="f-category" name="category" defaultValue={filter.category ?? ""} className={selectCls}>
+          <option value="">Any</option>
+          {FEATURE_CATEGORIES.map((c) => (
+            <option key={c} value={c}>{CATEGORY_LABEL[c] ?? c}</option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[16px] py-[8px] text-[13.5px] font-bold text-cream hover:bg-cherry"
+      >
+        Apply
+      </button>
+
+      {active && (
+        <Link
+          href={action}
+          className="font-mono text-[12px] font-bold uppercase tracking-[0.06em] text-ink-3 underline underline-offset-4 hover:text-cherry-dk"
+        >
+          Clear
+        </Link>
+      )}
+    </form>
+  );
+}

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -8,15 +8,15 @@ import { record } from "@/lib/audit";
 import { notify, printerName, printerOwner } from "@/lib/authz";
 import {
   AuthzError,
+  FEATURE_FLOW,
   assertFeatureTransition,
   featureLabel,
   featureRef,
   featureScope,
-  isFeatureTerminal,
   nextFeatureStatus,
   type Actor,
 } from "@/lib/scope";
-import { FEATURE_PRIORITIES, FeatureWishSchema } from "@/lib/catalog";
+import { FEATURE_CATEGORIES, FEATURE_PRIORITIES, FeatureWishSchema } from "@/lib/catalog";
 import { BodySchema } from "@/lib/stories";
 
 /**
@@ -87,12 +87,64 @@ export const FEATURE_FIELDS = {
 
 export type FeatureRow = Prisma.FeatureRequestGetPayload<{ select: typeof FEATURE_FIELDS }>;
 
-/** The requests this actor may see — their own, or all of them for the owner. */
-export function listFeatures(actor: Actor): Promise<FeatureRow[]> {
+/**
+ * The set of values a request may be filtered by. Empty/absent means "any".
+ * Priority, status and category are the three enum columns; a filter can only
+ * ever narrow a caller's scope, never widen it — `featureScope` stays the
+ * first term of every query below.
+ */
+export type FeatureFilter = { priority?: string; status?: string; category?: string };
+
+/** Every status a request can be in — the flow plus the terminal `Declined`. */
+const FEATURE_STATUSES = [...FEATURE_FLOW, "Declined"] as readonly string[];
+
+/**
+ * Keep only recognised filter values; anything unknown (a stray query string,
+ * a removed enum member) is dropped to "any" rather than erroring, so a
+ * hand-edited URL degrades to a wider result instead of a 500.
+ */
+export function coerceFeatureFilter(raw: {
+  priority?: string;
+  status?: string;
+  category?: string;
+}): FeatureFilter {
+  const pick = (v: string | undefined, allowed: readonly string[]) =>
+    v && allowed.includes(v) ? v : undefined;
+  return {
+    priority: pick(raw.priority, FEATURE_PRIORITIES),
+    status: pick(raw.status, FEATURE_STATUSES),
+    category: pick(raw.category, FEATURE_CATEGORIES),
+  };
+}
+
+/** True when at least one filter is set — for the "clear" affordance / count. */
+export const hasFeatureFilter = (f: FeatureFilter): boolean =>
+  Boolean(f.priority || f.status || f.category);
+
+function featureWhere(actor: Actor, filter: FeatureFilter): Prisma.FeatureRequestWhereInput {
+  const and: Prisma.FeatureRequestWhereInput[] = [featureScope(actor)];
+  if (filter.priority) and.push({ priority: filter.priority as Prisma.EnumFeaturePriorityFilter });
+  if (filter.status) and.push({ status: filter.status as Prisma.EnumFeatureStatusFilter });
+  if (filter.category) and.push({ category: filter.category as Prisma.EnumFeatureCategoryFilter });
+  return { AND: and };
+}
+
+/**
+ * The requests this actor may see — their own, or all of them for the owner —
+ * optionally narrowed by a filter. The scope predicate is always the first
+ * term of the AND, so no combination of filters can surface a request the
+ * caller is not entitled to. `order` is newest-first for the board and
+ * oldest-first for the owner's triage queue.
+ */
+export function listFeatures(
+  actor: Actor,
+  filter: FeatureFilter = {},
+  order: "asc" | "desc" = "desc",
+): Promise<FeatureRow[]> {
   return db.featureRequest.findMany({
-    where: featureScope(actor),
+    where: featureWhere(actor, filter),
     select: FEATURE_FIELDS,
-    orderBy: { createdAt: "desc" },
+    orderBy: { createdAt: order },
   });
 }
 
@@ -220,11 +272,11 @@ export async function withdrawFeature(actor: Actor, id: number) {
  * so a "low" from last month may be "high" today, and re-filing to fix a
  * dropdown would be silly.
  *
- * Who may: the **requester** on their own request while it is still live (not
- * `Done`/`Declined` — a closed request's priority is history, not a knob), and
- * the **owner** on any request, at any time, because triaging by priority is
- * their job. Anyone else — a client naming somebody else's id — is refused,
- * and indistinguishably from "does not exist" via `featureScope`.
+ * Who may: the **requester** on their own request in **any** status — a
+ * closed request can still be re-ranked, because hindsight and plans keep
+ * changing after the fact — and the **owner** on any request, since triaging
+ * by priority is their job. Anyone else — a client naming somebody else's id
+ * — is refused, indistinguishably from "does not exist" via `featureScope`.
  */
 export async function changeFeaturePriority(actor: Actor, id: number, rawPriority: unknown) {
   const priority = typeof rawPriority === "string" ? rawPriority : "";
@@ -242,12 +294,6 @@ export async function changeFeaturePriority(actor: Actor, id: number, rawPriorit
 
   if (actor.role !== "admin" && feature.requesterId !== actor.id) {
     throw problem(403, "Only the person who asked for it, or the printer owner, can reprioritise it.");
-  }
-  if (actor.role !== "admin" && isFeatureTerminal(feature.status)) {
-    throw problem(
-      409,
-      `${featureRef(feature.id)} is ${featureLabel(feature.status).toLowerCase()} — its priority is settled.`,
-    );
   }
 
   if (priority === feature.priority) {


### PR DESCRIPTION
Two refinements to the 'frr' track, requested by the owner.

## Priority editable in every status
`changeFeaturePriority` dropped the rule that blocked a requester from
re-ranking a closed (`Done`/`Declined`) request — a settled request can still be
re-prioritised, since hindsight and plans change after the fact. The owner could
always change any. Audit (`feature.priority_changed`) and the notify-the-other-
side behaviour are unchanged; the `/frr/[id]` priority control now shows in
every status.

## Filtering on both views
A filter bar on **`/frr`** (board) and **`/frr/queue`** (triage) narrows by
**priority**, **status** and **category**. It's a native `GET` form:
- choices ride in the URL (`?priority=high&status=Accepted&category=ui`),
  applied server-side, so it works with JS off and is link/bookmark-able;
- `listFeatures` ANDs the filter onto `featureScope`, so it can only ever
  **narrow** what a caller may already see, never widen it;
- an unrecognised value degrades to "any" rather than erroring.

The queue now reuses `listFeatures` (admin scope is `{}`) with an oldest-first
order instead of its own query. New shared `FeatureFilterBar` component.

## Tests
`verify:frr` **60 → 70**: a `Done` and a `Declined` request are each
re-prioritised and audited; each filter returns exactly the right subset; a
client's filter never surfaces another client's matching request; a garbage
filter value is ignored (200, not 500). `verify:queue` **102** unchanged — the
print side and shared header are untouched. `tsc`, `build`, `check:links` clean.

Files: `src/lib/features.ts`, `src/app/frr/{page,queue/page,[id]/page}.tsx`,
new `src/components/feature-filter.tsx`, `scripts/verify-frr.ts`,
`docs/feature-requests.md`, `CHANGELOG.md`.