### PR TITLE
A session lasts twenty idle minutes, and giving out access asks again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Changed
+
+- **A session is now worth twenty idle minutes, not a renewing month.**
+  `session.expiresIn` was 30 days with `updateAge` at a day — and because
+  `expiresIn` is an *idle* window that Better Auth pushes back out on use, a
+  session touched once a month renewed itself indefinitely. "Thirty days" was
+  the number in the config; *forever* was the behaviour, on a cookie written to
+  the browser profile with `Max-Age=2592000`. On the shared office desktop this
+  app is built for, that is the wrong shape: the threat is somebody sitting
+  down after you, and the only thing that helps against a captured cookie is
+  how long it stays worth something. It is twenty minutes now, sliding every
+  minute so it never expires under somebody mid-task. Bearer tokens inherit it,
+  which closes the "long-lived credential in a shell history" item in the
+  security audit. Deliberately *not* done: a JWT session (it would put
+  revocation back on a delay — the same bug cookie caching was turned off for),
+  moving the token out of a cookie (a cookie is the only credential a browser
+  attaches to a top-level navigation, and this app is server-rendered), and
+  forcing a non-persistent cookie via `rememberMe: false` (Better Auth reads
+  that as a *fixed* 24-hour session with the sliding refresh off — worse than
+  what it buys).
+
+  **Everyone signs in once on upgrade.** The new window cannot reach the
+  sessions that already exist — Better Auth reads a stored `expiresAt` as
+  though it had been written under the current `expiresIn`, so a row minted
+  under the old config looks freshly updated and is never shortened (measured:
+  a planted thirty-day session was still thirty days out after use). A
+  migration retires them. It matches on the window rather than truncating the
+  table, so it touches nothing a session created under the new config owns, and
+  it is a no-op if re-run. No user, story, feature request, comment, invitation
+  or audit row is affected, and nothing cascades: no foreign key in the
+  database references `session`.
+
+### Added
+
+- **Re-authentication before handing out access.** Inviting somebody,
+  re-sending an invitation, minting a password-reset link and revoking or
+  restoring access now require a sign-in from the last five minutes; an older
+  session is sent to a new `/reauth` screen to confirm with a passkey or a
+  password. A shorter session limits how long a captured cookie is useful, but
+  these four actions outlive any session — an invitation mints an account, a
+  reset link is the ability to become somebody else — and asking for the
+  credential again is the one control a copied cookie cannot satisfy.
+  Withdrawing an unaccepted invitation is deliberately not gated, and neither
+  is `/admin/benefits`. `/reauth` offers the password as well as the passkey,
+  because requiring a passkey would leave an admin without one unable to revoke
+  access. Freshness is the age of the session itself: Better Auth has no
+  assert-without-signing-in primitive, so re-authenticating mints a new session
+  and the superseded row is left to expire — which is cheap now that a session
+  is twenty minutes rather than a month. Three probes cover it, and two of them
+  drive the same form submission differing only in session age.
+
+### Fixed
+
+- **The session cookie did not slide on a page render.** Better Auth extends a
+  live session in two places, and only one survives a React Server Component
+  render: the database row is pushed out, but Next forbids writing a cookie
+  during a render, so browsing pages kept the session row alive while the
+  browser's copy of the cookie counted down from whenever a route handler last
+  wrote it. Measured rather than assumed — `GET /board` returned no
+  `Set-Cookie` at all where `GET /api/stories` returned `Max-Age=1200`. At
+  thirty days nobody would have noticed; at twenty minutes it signs an active
+  person out with a perfectly live session behind them. `src/middleware.ts` now
+  re-stamps the cookie on page navigations, and only there — `/api/*` responses
+  set it themselves, and re-stamping there would resurrect the cookie that
+  `/api/auth/sign-out` had just deleted. Three new probes
+  (`A07-session-window`, `A07-session-cookie-maxage`, `A07-session-slides`)
+  hold the window, the cookie and the re-stamp in place; the suite is 97.
+
 ### Added
 
 - **Optional print settings on a request (FRR-103).** A free-text field where a

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,9 @@ before you paste one into a script:
   admin revoking access, and so does a password reset.
 - It carries exactly the authority of the account it came from — no more, and
   no less. There is no scope, no read-only variant and no long-lived key.
-- It lasts as long as a session does: 30 days.
+- It lasts as long as a session does: **twenty minutes of inactivity**. A
+  script that runs longer than that between calls has to sign in again — which
+  is the intended answer for anything unattended.
 - Unlike the cookie it is not `HttpOnly` and not `SameSite`-protected. It lands
   in shell history, in CI logs and in `ps` output. For anything that runs
   unattended, sign in fresh rather than reusing the token from the browser you

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -223,12 +223,53 @@ early instead of flashing a shell. It is deliberately not the boundary: a
 forged cookie gets past it and no further. The real checks run in every page
 and every server action.
 
+### Confirming it is still you
+
+Four things an admin can do outlive any session: inviting somebody (a whole new
+account), re-sending an invitation (a fresh working link), minting a
+password-reset link (the ability to become that person) and revoking or
+restoring access. All four ask for the passkey or the password again if the
+current sign-in is more than five minutes old, and send you to `/reauth` if it
+is.
+
+This is the sudo gate, and it exists because shortening the session window does
+not help against a cookie captured *now*. It is the one control a thief holding
+a copied cookie cannot satisfy.
+
+Withdrawing an unaccepted invitation is not gated — it only ever removes reach
+— and nor is `/admin/benefits`, which grants nobody anything.
+
+`/reauth` offers both the passkey and the password on purpose. Every account
+has a password by construction and only some have a passkey, so requiring a
+passkey would leave an admin without one unable to revoke access.
+
+One thing worth knowing, because it explains a spare row in `session`: Better
+Auth has no way to assert an identity without creating a session, so
+re-authenticating signs you in again and the gate reads the age of the session
+that comes back. The session it replaces is left to expire, which at twenty
+minutes is not long.
+
 ### Other decisions worth knowing
 
 - **Cookies** are `HttpOnly`, `SameSite=Lax`, `__Secure-` prefixed, and keyed
   on the *URL scheme* rather than `NODE_ENV` — a production boot over plain
   HTTP throws unless it is loopback, and an HTTPS deployment always gets the
   flag regardless of how the env is set.
+- **A session is worth twenty idle minutes**, sliding every minute
+  (`SESSION_IDLE_SECONDS`). It used to be thirty days with a daily slide, which
+  in practice meant *forever*: `expiresIn` is an idle window that renews, so a
+  session used once a month never expired at all. Twenty minutes is only
+  humane because passkeys are here — which does make the passkey nudge
+  load-bearing rather than decorative. The full reasoning, including why not a
+  JWT and why the token stays in a cookie, is in
+  [the security audit](security-audit.md#the-session-window).
+- **Middleware re-stamps the session cookie on page navigations.** Better Auth
+  slides the database row and the cookie together, but Next forbids writing a
+  cookie during a React Server Component render, so browsing pages would keep
+  the row alive while the browser's copy quietly expired. Harmless at thirty
+  days; at twenty minutes it signs people out mid-task. The cookie is never the
+  authority — the row is — so extending the browser's copy cannot extend a
+  session, it only stops the cookie dying first.
 - **Session cookie caching is off.** It would trust a signed snapshot without
   a database lookup, which makes sign-out lag by the cache lifetime. A DAST
   probe caught exactly that; see [the security audit](security-audit.md).

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -22,7 +22,7 @@ docker run --rm -v "$PWD:/src:ro" semgrep/semgrep semgrep scan \
   --config=p/owasp-top-ten --config=p/security-audit --config=p/nextjs /src/src
 docker run --rm --network host ghcr.io/zaproxy/zaproxy:stable \
   zap-baseline.py -t http://localhost:3000        # DAST
-npm run probe:security                     # DAST, app-specific (91 probes)
+npm run probe:security                     # DAST, app-specific (97 probes)
 ```
 
 ## Result
@@ -34,7 +34,7 @@ npm run probe:security                     # DAST, app-specific (91 probes)
 | Syft + Grype | SBOM, binary contents | **92 (2 crit, 46 high)** | 0 |
 | Semgrep | 153 rules, 37 files | 1 (false positive) | 0 |
 | OWASP ZAP baseline | passive DAST | **1 medium, 3 low** | 0 fail / 63 pass |
-| `probe:security` | 91 app-specific probes | **2 real, 4 artifacts** | 91 pass |
+| `probe:security` | 97 app-specific probes | **2 real, 4 artifacts** | 97 pass |
 | `verify:models` | 29 upload-validator checks | — | 29 pass |
 | `verify:passkey` | WebAuthn in a real browser | *unverified* | 13 pass |
 
@@ -236,6 +236,106 @@ spent when a password is actually set, which is what "single use" is for.
 `verify:auth` asserts both halves: a refused password leaves the link working,
 and a successful one kills it.
 
+### The session window
+
+The window used to be `expiresIn: 30 days` with `updateAge: 1 day`, and the
+second number is what made the first one wrong. `expiresIn` is an **idle**
+window, not an absolute one: Better Auth pushes `expiresAt` back out to
+`now + expiresIn` whenever a session is used and the last push was more than
+`updateAge` ago. So a session used once a month renewed itself forever. Thirty
+days was the number in the config; *indefinitely* was the behaviour, on a
+cookie written into the browser profile with `Max-Age=2592000`.
+
+On the shared office desktop this app is built for, that is the wrong shape:
+the threat is somebody sitting down after you, and against a captured cookie
+the only thing that helps is how long it stays worth something.
+
+It is now **twenty idle minutes**, sliding every minute
+(`SESSION_IDLE_SECONDS` in [`src/lib/auth-rules.ts`](../src/lib/auth-rules.ts)).
+Twenty minutes is only humane because passkeys are here — conditional UI signs
+a returning holder back in with no click — and it does make the passkey nudge
+load-bearing rather than decorative.
+
+Three things were considered and deliberately **not** done:
+
+- **A JWT session.** A JWT is a signed snapshot the server trusts without
+  touching the database, which is exactly finding 1 above with a longer fuse:
+  revocation — sign-out, access revoked, a password reset — would go back to
+  lagging by the token's lifetime. The session token stays an opaque row.
+- **Moving the token out of a cookie.** A cookie is the only credential a
+  browser attaches to a top-level navigation, and this app is server-rendered:
+  `requireUser` and `storyScope` run on the navigation itself. A token in
+  `localStorage` would also trade `HttpOnly` away for nothing.
+- **Forcing a non-persistent cookie** via `rememberMe: false`. At `Max-Age=1200`
+  the cookie no longer outlives the browser in any way that matters, and Better
+  Auth reads that flag as a *fixed* 24-hour session with the sliding refresh
+  switched off — strictly worse than what it would buy.
+
+#### One thing this broke, and how it was caught
+
+Better Auth slides a session in two places at once, and only one of them
+survives a React Server Component render. The database row is pushed out
+normally; the **cookie is not**, because Next forbids writing a cookie during a
+render. Measured rather than reasoned about: before the fix, `GET /board`
+returned no `Set-Cookie` at all where `GET /api/stories` returned
+`Max-Age=1200`.
+
+At thirty days nobody would ever have noticed. At twenty minutes it signs
+people out mid-task with a live session behind them — the kind of failure that
+gets "fixed" by asking for the window to be made long again.
+[`src/middleware.ts`](../src/middleware.ts) now re-stamps the cookie on page
+navigations (and only there — `/api/*` responses set it themselves, and
+re-stamping there would resurrect the cookie `/api/auth/sign-out` had just
+deleted). This is safe because the cookie is not the authority: it carries a
+token whose validity is the `session` row, so keeping the browser's copy longer
+cannot extend a session by a second. The invariant it buys is that the cookie
+never dies before the row it names.
+
+Three probes hold all of this: `A07-session-window` (the row spans twenty
+minutes), `A07-session-cookie-maxage` (the cookie expires with it) and
+`A07-session-slides` (a page render pushes the cookie out too).
+
+#### Re-authentication, for what outlives a session
+
+Shortening the window limits how long a captured cookie is worth something. It
+does not stop it being worth something *now*, and some of what an admin can do
+outlives any session: an invitation mints a whole new account, a reset link is
+the ability to become somebody else, and revoking access locks a colleague out.
+
+Those four actions — `sendInvite`, `resendInvite`, `resetPassword`,
+`setMemberAccess` — now require a sign-in from the last five minutes
+(`FRESH_AUTH_SECONDS`), and send the caller to `/reauth` when it is older. It
+is the one control on the list a copied cookie cannot satisfy: the thief has
+the session, not the passkey and not the password.
+
+`revokeInvite` is deliberately **not** gated — withdrawing an unaccepted invite
+only ever removes reach — and neither is `/admin/benefits`, which decides what
+tips the upload form offers and grants nobody anything.
+
+Two implementation notes, both of which look odd on purpose:
+
+- **Freshness is the age of the session itself**, not a separate marker. Better
+  Auth 1.7.1 has no "prove it is you" primitive: `/passkey/verify-authentication`
+  and `/sign-in/username` both mint a *new* session rather than annotating the
+  one you hold. So re-authenticating means signing in again, and a session
+  created moments ago is the evidence. A normal sign-in is therefore fresh for
+  its first five minutes, which is correct — somebody who just typed their
+  password should not be asked for it twice.
+- **The cost is one superseded session row per re-auth.** That would have been
+  a poor trade when a row lived thirty days; at twenty idle minutes the orphan
+  is gone before anyone would notice, which is what makes this cheaper than
+  hand-rolling WebAuthn verification against the `passkey` table in app code.
+
+`/reauth` offers the passkey *and* the password. Gating on a passkey alone
+would leave an admin who has not enrolled one unable to revoke access — a
+lockout on the most safety-critical control in the app.
+
+Three probes: `A07-reauth-stale` (a session backdated an hour cannot create an
+invitation), `A07-reauth-redirect` (it is sent to `/reauth` instead) and
+`A07-reauth-fresh` (a sign-in from moments ago still can). The first and third
+drive the *same* form submission and differ only in the age of the session, so
+the pair fails if the gate stops discriminating in either direction.
+
 ### Residual risk accepted
 
 - **A trusted-proxy misconfiguration is silent.** `TRUST_PROXY_HEADERS` now
@@ -256,8 +356,12 @@ and a successful one kills it.
   availability-for-integrity trade at this size; a cached local corpus would be
   the answer if it ever bit.
 - **No second factor.** A password plus an optional passkey is the whole set.
-  TOTP would be the next thing to add if this were ever exposed beyond an
-  office, and Better Auth's `twoFactor` plugin is the path.
+  Re-authentication on the access-moving actions (above) covers the case a
+  second factor would matter most for here — a captured session being used to
+  hand out access — but it is a sudo gate, not a second factor: it asks for the
+  same credential again rather than a different kind. TOTP would be the next
+  thing to add if this were ever exposed beyond an office, and Better Auth's
+  `twoFactor` plugin is the path.
 - **No password-change screen for a signed-in user.** Today changing a password
   means asking the admin for a reset link. That is a gap in convenience rather
   than in security, and `/api/auth/change-password` is already served by the
@@ -349,13 +453,15 @@ README now says.
   is allowed — that is `curl`, not a browser being driven by somebody else's
   page. A bearer token cannot be attached cross-origin at all, because the app
   serves no CORS headers and the preflight fails.
-- **A bearer token is a long-lived credential in a shell history.** It lasts
-  as long as the session (30 days), carries the full authority of the account,
-  and — unlike the cookie — is neither `HttpOnly` nor `SameSite`-protected. It
-  is revocable by signing out, by an admin revoking access and by a password
-  reset, which is what makes it acceptable at this size; there is no scoped or
-  read-only variant, and adding one would mean a credential store this app
-  does not otherwise need. [`docs/api.md`](api.md) says to sign in fresh for a
-  script rather than reusing the browser's token.
+- **A bearer token is a credential in a shell history.** It carries the full
+  authority of the account and — unlike the cookie — is neither `HttpOnly` nor
+  `SameSite`-protected. It is revocable by signing out, by an admin revoking
+  access and by a password reset, and since the session window came down to
+  twenty idle minutes it also simply stops working shortly after the job that
+  used it finishes. There is still no scoped or read-only variant, and adding
+  one would mean a credential store this app does not otherwise need.
+  [`docs/api.md`](api.md) says to sign in fresh for a script rather than
+  reusing the browser's token — which is now the only thing that works for
+  anything long-running.
 - **No second factor, and no self-service password change.** Both are in
   [Residual risk accepted](#residual-risk-accepted) above with the reasoning.

--- a/prisma/migrations/20260829083000_shorten_sessions/migration.sql
+++ b/prisma/migrations/20260829083000_shorten_sessions/migration.sql
@@ -1,0 +1,32 @@
+-- Retire the sessions that were minted under the old thirty-day window.
+--
+-- WHAT THIS TOUCHES: rows in "session" only, and only those whose window is
+-- longer than the current one allows. No user, story, feature request,
+-- comment, invitation or audit row is affected, and nothing cascades from
+-- here: no foreign key in this database references "session" (the only
+-- relation is user -> sessions, which cascades the other way). The cost to a
+-- person is that they sign in once more; for anyone with a passkey, a touch.
+--
+-- WHY IT IS NEEDED: the session window came down from a renewing thirty days
+-- to twenty idle minutes, and that change cannot reach the sessions that
+-- already exist. Better Auth decides whether to slide a session with
+--
+--     expiresAt - expiresIn + updateAge <= now()
+--
+-- which reads a stored expiresAt as though it had been written under the
+-- *current* expiresIn. Hand it a row minted under the old config and the
+-- arithmetic places the last update far in the future, so the row is never
+-- refreshed and therefore never shortened. Measured rather than assumed: a
+-- session planted with a thirty-day expiry was still thirty days out after
+-- being used against the new build.
+--
+-- Leaving them would mean the people already signed in -- the only people who
+-- have a session worth stealing today -- keep the exact credential this change
+-- exists to shorten.
+--
+-- WHY THE PREDICATE: a session created under the new config expires within
+-- twenty minutes, so anything reaching further out could only have come from
+-- the old one. The minute of slack absorbs clock skew between the migrator and
+-- the database. This also makes the statement safe to re-run: once the new
+-- config is live it matches nothing.
+DELETE FROM "session" WHERE "expiresAt" > now() + interval '21 minutes';

--- a/scripts/security-probe.ts
+++ b/scripts/security-probe.ts
@@ -16,6 +16,7 @@ import "./_env";
 import { db } from "../src/lib/db";
 import { issuePasswordSetupUrl } from "../src/lib/password-reset";
 import { TEST_PASSWORD, ensureCredentials, signInWithPassword, usernameFor } from "./_accounts";
+import { SESSION_IDLE_SECONDS } from "../src/lib/auth-rules";
 
 const APP = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
 const MAILPIT = process.env.MAILPIT_URL ?? "http://localhost:8025";
@@ -90,6 +91,29 @@ class Browser {
     this.store(res);
     return res;
   }
+  /**
+   * Post a server-action form the way a browser with no JavaScript does:
+   * carry every hidden input (Next's action id among them) and override the
+   * visible fields. Mirrors the helper in `verify-auth.ts`.
+   */
+  async submit(url: string, html: string, values: Record<string, string>) {
+    const form = /<form\b[\s\S]*?<\/form>/.exec(html)?.[0] ?? "";
+    const body = new FormData();
+    for (const tag of form.match(/<input\b[^>]*>/g) ?? []) {
+      if (!tag.includes('type="hidden"')) continue;
+      const name = /name="([^"]*)"/.exec(tag)?.[1];
+      const value = /value="([^"]*)"/.exec(tag)?.[1] ?? "";
+      if (name) {
+        body.append(
+          name.replace(/&amp;/g, "&").replace(/&quot;/g, '"'),
+          value.replace(/&amp;/g, "&").replace(/&quot;/g, '"'),
+        );
+      }
+    }
+    for (const [k, v] of Object.entries(values)) body.set(k, v);
+    return this.raw(url, { method: "POST", body });
+  }
+
   async go(url: string, init: RequestInit = {}) {
     let res = await this.raw(url, init);
     for (let i = 0; i < 8; i++) {
@@ -726,6 +750,133 @@ async function main() {
   probe("A07-protorel", "a protocol-relative ?next is not honoured",
         !(protoRel.headers.get("location") ?? "").includes("evil.example"),
         protoRel.headers.get("location") ?? "");
+
+  // ---------------------------------------------------------------------
+  // How long a session is worth something.
+  //
+  // The window used to be thirty days, and thirty days that *renewed* — any
+  // session used inside the window got the whole window back, so a session
+  // nobody revoked never actually expired. On the shared office desktop this
+  // app runs on, a captured cookie was therefore good more or less forever.
+  //
+  // Three probes rather than one, because the property has three moving parts
+  // and each fails differently: the database row is the authority, the cookie
+  // is what a thief actually carries away, and the re-stamp is what keeps the
+  // short window from logging honest people out.
+  // ---------------------------------------------------------------------
+  const fresh = new Browser();
+  await db.$executeRawUnsafe('DELETE FROM "rateLimit"');
+  const freshIn = await attemptSignIn(fresh, usernameFor(ayla.email), TEST_PASSWORD);
+  const freshCookie =
+    freshIn.headers.getSetCookie().find((c) => c.includes("ppp.session_token=")) ?? "";
+  const freshToken = decodeURIComponent(
+    (fresh.jar.get("ppp.session_token") ?? fresh.jar.get("__Secure-ppp.session_token") ?? ""),
+  ).split(".")[0];
+
+  const freshRow = await db.session.findFirst({
+    where: { token: freshToken },
+    select: { createdAt: true, expiresAt: true },
+  });
+  const windowSeconds = freshRow
+    ? Math.round((freshRow.expiresAt.getTime() - freshRow.createdAt.getTime()) / 1000)
+    : -1;
+  // A minute of slack: the row is written a moment after the clock is read.
+  probe("A07-session-window", "a new session is worth twenty minutes, not a month",
+        Math.abs(windowSeconds - SESSION_IDLE_SECONDS) <= 60,
+        `session row spans ${windowSeconds}s, expected ~${SESSION_IDLE_SECONDS}s — ` +
+        "session.expiresIn has moved, and it is an idle window that renews, " +
+        "so a large value means a captured cookie effectively never expires");
+
+  const maxAge = Number(/max-age=(\d+)/i.exec(freshCookie)?.[1] ?? -1);
+  probe("A07-session-cookie-maxage", "the session cookie expires with the session",
+        Math.abs(maxAge - SESSION_IDLE_SECONDS) <= 60,
+        `Set-Cookie carried Max-Age=${maxAge}, expected ~${SESSION_IDLE_SECONDS} — ` +
+        "a cookie outliving its row is a credential left on disk for no reason");
+
+  /*
+   * The regression guard for the cookie re-stamp in `src/middleware.ts`.
+   *
+   * Better Auth slides a session in two places, and only one of them survives
+   * a React Server Component render: the database row is pushed out, but Next
+   * forbids writing a cookie during a render, so the browser's copy keeps
+   * counting down from whenever a route handler last wrote it. Measured, not
+   * assumed — before the re-stamp, `GET /board` sent no `Set-Cookie` at all
+   * while `GET /api/stories` sent `Max-Age=1200`.
+   *
+   * At thirty days that was invisible. At twenty minutes it signs people out
+   * mid-task with a perfectly live session behind them, which is the kind of
+   * failure people work around by asking for the window to be made long again.
+   */
+  const nav = await fresh.raw(`${APP}/board`);
+  const navMaxAge = Number(
+    /max-age=(\d+)/i.exec(
+      nav.headers.getSetCookie().find((c) => c.includes("ppp.session_token=")) ?? "",
+    )?.[1] ?? -1,
+  );
+  probe("A07-session-slides", "a page render pushes the cookie out too",
+        Math.abs(navMaxAge - SESSION_IDLE_SECONDS) <= 60,
+        `GET /board returned Max-Age=${navMaxAge}, expected ~${SESSION_IDLE_SECONDS} — ` +
+        "restampSession() in src/middleware.ts is not firing, so the cookie " +
+        "will die under an active user while their session row is still alive");
+
+  // ---------------------------------------------------------------------
+  // Re-authentication for the actions that move access around.
+  //
+  // Shortening the session limits how long a captured cookie is worth
+  // something; it does not stop it being worth something right now. The
+  // actions whose effects outlive the session — an invitation mints an
+  // account, a reset link is the ability to become somebody else, revoking
+  // locks a colleague out — ask for the passkey or the password again, which
+  // is the one control on the list a copied cookie cannot satisfy.
+  //
+  // Freshness is the age of the session, so the stale case is exercised by
+  // backdating the row rather than by waiting five minutes.
+  // ---------------------------------------------------------------------
+  const staleAdmin = await signIn(admin);
+  const invitePage = await (await staleAdmin.go(`${APP}/admin/invites`)).text();
+
+  const staleToken = decodeURIComponent(
+    (staleAdmin.jar.get("ppp.session_token") ??
+      staleAdmin.jar.get("__Secure-ppp.session_token") ?? ""),
+  ).split(".")[0];
+  await db.session.updateMany({
+    where: { token: staleToken },
+    data: { createdAt: new Date(Date.now() - 60 * 60 * 1000) },
+  });
+
+  const staleEmail = "reauth-stale@office.example";
+  await db.invite.deleteMany({ where: { email: staleEmail } });
+  const staleTry = await staleAdmin.submit(`${APP}/admin/invites`, invitePage, {
+    email: staleEmail,
+    name: "Stale Session",
+  });
+  const staleLanded = staleTry.headers.get("location") ?? staleTry.url ?? "";
+  const staleMadeAnInvite =
+    (await db.invite.count({ where: { email: staleEmail } })) > 0;
+  probe("A07-reauth-stale", "an old session cannot hand out access",
+        !staleMadeAnInvite,
+        `an invitation for ${staleEmail} was created from a session an hour old — ` +
+        "requireFreshAuth() is not gating sendInviteAction, so a captured " +
+        `cookie can mint accounts (landed at ${staleLanded || "no redirect"})`);
+
+  probe("A07-reauth-redirect", "and is sent to confirm who it is",
+        staleLanded.includes("/reauth"),
+        `expected a redirect to /reauth, got "${staleLanded || "none"}"`);
+
+  // The other half: the gate must not simply break the feature.
+  const freshAdmin = await signIn(admin);
+  const freshPage = await (await freshAdmin.go(`${APP}/admin/invites`)).text();
+  const freshEmail = "reauth-fresh@office.example";
+  await db.invite.deleteMany({ where: { email: freshEmail } });
+  await freshAdmin.submit(`${APP}/admin/invites`, freshPage, {
+    email: freshEmail,
+    name: "Fresh Session",
+  });
+  probe("A07-reauth-fresh", "a sign-in from moments ago still can",
+        (await db.invite.count({ where: { email: freshEmail } })) > 0,
+        "a freshly signed-in admin was refused — the sudo window is too tight " +
+        "to invite anybody, which would make the control unusable");
+  await db.invite.deleteMany({ where: { email: { in: [staleEmail, freshEmail] } } });
 
   // Sign-out must kill the session server-side, not just drop the cookie.
   const leaver = client2;

--- a/src/app/admin/invites/actions.ts
+++ b/src/app/admin/invites/actions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { db } from "@/lib/db";
 import { requireAdmin } from "@/lib/authz";
+import { requireFreshAuth } from "@/lib/reauth";
 import { record } from "@/lib/audit";
 import { passwordResetEmail, sendMail } from "@/lib/email";
 import {
@@ -43,6 +44,9 @@ export async function sendInviteAction(
 ): Promise<InviteFormState> {
   // Every action re-checks the role. Rendering the page is not authorisation.
   const admin = await requireAdmin();
+  // An invitation mints a whole new account, which outlives any stolen
+  // session. Prove it is you.
+  await requireFreshAuth("/admin/invites");
 
   const parsed = InviteSchema.safeParse({
     email: formData.get("email"),
@@ -85,6 +89,9 @@ export async function sendInviteAction(
 
 export async function resendInviteAction(formData: FormData): Promise<void> {
   const admin = await requireAdmin();
+  // Re-sending rotates the token, so it hands out a working link exactly the
+  // way the first one did.
+  await requireFreshAuth("/admin/invites");
   const id = String(formData.get("id") ?? "");
   try {
     const { invite } = await resendInvite(id);
@@ -124,6 +131,9 @@ export async function resetPasswordAction(
   formData: FormData,
 ): Promise<InviteFormState> {
   const admin = await requireAdmin();
+  // A reset link is the ability to become somebody else. This is the single
+  // most valuable thing a captured admin session could be pointed at.
+  await requireFreshAuth("/admin/invites");
   const userId = String(formData.get("userId") ?? "");
 
   const target = await db.user.findUnique({
@@ -195,6 +205,9 @@ export async function setMemberAccessAction(
   formData: FormData,
 ): Promise<InviteFormState> {
   const admin = await requireAdmin();
+  // Both directions: revoking locks a colleague out, restoring lets somebody
+  // back in who was deliberately shut out.
+  await requireFreshAuth("/admin/invites");
   const userId = String(formData.get("userId") ?? "");
   const revoke = String(formData.get("revoke") ?? "") === "true";
 

--- a/src/app/reauth/page.tsx
+++ b/src/app/reauth/page.tsx
@@ -1,0 +1,60 @@
+import { redirect } from "next/navigation";
+
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/authz";
+import { isFreshAuth } from "@/lib/reauth";
+import { AuthShell, H1, Kicker, Lead } from "@/components/ui";
+import { ReauthForm } from "./reauth-form";
+
+/**
+ * Same rule as the sign-in page: only a same-origin absolute path survives, so
+ * this cannot be dressed up as a way to bounce somebody off-site.
+ */
+function safeNext(raw: string | undefined): string {
+  if (!raw) return "/";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  return raw;
+}
+
+/**
+ * "Confirm it's you" before the actions that move access around.
+ *
+ * Reached only by being sent here from one of those actions — see
+ * `requireFreshAuth` in `src/lib/reauth.ts`. Anyone whose sign-in is already
+ * recent enough is bounced straight back, so landing here by hand does not
+ * make you do anything twice.
+ */
+export default async function ReauthPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+  const target = safeNext(next);
+
+  // You have to be somebody before you can prove you are still them.
+  const user = await requireUser(`/reauth?next=${encodeURIComponent(target)}`);
+  if (await isFreshAuth()) redirect(target);
+
+  const row = await db.user.findUnique({
+    where: { id: user.id },
+    select: { username: true, displayUsername: true },
+  });
+
+  return (
+    <AuthShell>
+      <Kicker>One more time, please</Kicker>
+      <H1>Is that still you?</H1>
+      <Lead>
+        You are about to change who can get in. A password or a passkey confirms
+        it is you at the keyboard and not a browser somebody left open.
+      </Lead>
+
+      <ReauthForm
+        next={target}
+        username={row?.username ?? ""}
+        displayUsername={row?.displayUsername ?? row?.username ?? ""}
+      />
+    </AuthShell>
+  );
+}

--- a/src/app/reauth/reauth-form.tsx
+++ b/src/app/reauth/reauth-form.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { authClient } from "@/lib/auth-client";
+import { Button, Input, Label, Notice } from "@/components/ui";
+
+/**
+ * The re-authentication ceremony.
+ *
+ * Both paths sign in again — Better Auth has no way to assert an identity
+ * without minting a session — and the gate reads the age of the session that
+ * comes back. See `src/lib/reauth.ts`.
+ *
+ * The password is offered as well as the passkey, deliberately. Every account
+ * has a password by construction and only some have a passkey, so gating these
+ * actions on a passkey alone would leave an admin without one unable to revoke
+ * access — a lockout on the most safety-critical control in the app.
+ */
+export function ReauthForm({
+  next,
+  username,
+  displayUsername,
+}: {
+  next: string;
+  username: string;
+  displayUsername: string;
+}) {
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [passkeySupported, setPasskeySupported] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.PublicKeyCredential) {
+      setPasskeySupported(true);
+    }
+  }, []);
+
+  async function withPasskey() {
+    setError(null);
+    const res = await authClient.signIn.passkey();
+    if (res?.error) {
+      setError(
+        res.error.message ??
+          "That passkey was not accepted. Use your password instead.",
+      );
+      return;
+    }
+    window.location.assign(next);
+  }
+
+  async function withPassword(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+
+    const { error } = await authClient.signIn.username({ username, password });
+    if (error) {
+      setBusy(false);
+      setError(
+        error.status === 429
+          ? "Too many attempts. Wait a minute and try again."
+          : "That password does not match. Try again.",
+      );
+      return;
+    }
+    window.location.assign(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-[22px]">
+      {passkeySupported && (
+        <>
+          <Button type="button" onClick={withPasskey} className="w-full">
+            Confirm with a passkey
+          </Button>
+          <div className="flex items-center gap-[13.2px]">
+            <span className="h-[3px] flex-1 rounded-full bg-ink" />
+            <span className="font-mono text-[11.5px] font-bold uppercase tracking-[0.14em] text-ink-3">or</span>
+            <span className="h-[3px] flex-1 rounded-full bg-ink" />
+          </div>
+        </>
+      )}
+
+      <form onSubmit={withPassword} className="flex flex-col gap-[13.2px]">
+        {/* Named and readable, so a password manager fills the right entry —
+            and so it is obvious which account is being confirmed. */}
+        <input type="hidden" name="username" value={username} autoComplete="username" />
+        <div>
+          <Label htmlFor="password">Password for {displayUsername}</Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            required
+            autoFocus
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <Button type="submit" variant="secondary" disabled={busy} className="w-full">
+          {busy ? "Checking…" : "Confirm"}
+        </Button>
+      </form>
+
+      {error && <Notice tone="warn">{error}</Notice>}
+    </div>
+  );
+}

--- a/src/lib/auth-rules.ts
+++ b/src/lib/auth-rules.ts
@@ -1,11 +1,13 @@
 /**
- * What counts as a username and a password.
+ * The auth rules both sides need: what counts as a username and a password,
+ * and how long a session lives.
  *
- * Its own module because both sides need it: `src/lib/auth.ts` hands these to
- * Better Auth, and the registration and set-password forms render them as
- * hints and as `minLength` attributes. Importing `auth.ts` into a client
- * component would drag the database and `server-only` into the browser
- * bundle, and a rule stated twice is a rule that drifts.
+ * Its own module because `src/lib/auth.ts` hands these to Better Auth while
+ * the registration and set-password forms render them as hints and as
+ * `minLength` attributes, and `src/middleware.ts` needs the session window.
+ * Importing `auth.ts` into a client component or into middleware would drag
+ * the database and `server-only` where neither belongs, and a rule stated
+ * twice is a rule that drifts.
  */
 
 /**
@@ -36,3 +38,43 @@ export const USERNAME_RULE =
  */
 export const PASSWORD_MIN = 10;
 export const PASSWORD_MAX = 128;
+
+/**
+ * How long a session survives with nobody touching it: twenty minutes.
+ *
+ * Stated here rather than inline in `auth.ts` because `src/middleware.ts`
+ * needs the same number — see the cookie re-stamp there — and these two
+ * disagreeing would either log people out early or keep a cookie alive past
+ * the session it names.
+ *
+ * The reasoning for twenty minutes is in `auth.ts` beside `expiresIn`.
+ */
+export const SESSION_IDLE_SECONDS = 60 * 20;
+
+/**
+ * The session cookie, under both the names it can have.
+ *
+ * `advanced.cookiePrefix` makes it `ppp.session_token`, and Better Auth adds
+ * the `__Secure-` prefix wherever the deployment is served over HTTPS. Which
+ * one is live depends on the URL rather than on `NODE_ENV`, so anything
+ * looking for the cookie by name has to accept either.
+ */
+export const SESSION_COOKIE_NAMES = [
+  "__Secure-ppp.session_token",
+  "ppp.session_token",
+] as const;
+
+/**
+ * How long a sign-in counts as "just now" for the actions that hand out or
+ * take away access: five minutes.
+ *
+ * The sudo window. It is short because it is not a convenience — the whole
+ * point is that somebody holding a captured cookie cannot use it to invite an
+ * account, mint a password-reset link or revoke a colleague without producing
+ * the passkey or the password again.
+ *
+ * Five minutes rather than thirty seconds because the admin screens involve
+ * reading before acting, and rather than an hour because an hour is most of a
+ * working session and would gate almost nothing.
+ */
+export const FRESH_AUTH_SECONDS = 60 * 5;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,6 +16,7 @@ import { record } from "@/lib/audit";
 import {
   PASSWORD_MAX,
   PASSWORD_MIN,
+  SESSION_IDLE_SECONDS,
   USERNAME_MAX,
   USERNAME_MIN,
   USERNAME_PATTERN,
@@ -104,9 +105,59 @@ export const auth = betterAuth({
 
   session: {
     expiresAt: undefined,
-    expiresIn: 60 * 60 * 24 * 30, // 30 days
-    updateAge: 60 * 60 * 24, // slide the window at most once a day
-    freshAge: 60 * 60 * 24, // "recent login" window for sensitive actions
+
+    /**
+     * Twenty minutes of inactivity, not thirty days.
+     *
+     * `expiresIn` is an *idle* window rather than an absolute one: Better Auth
+     * pushes `expiresAt` back out to `now + expiresIn` whenever a session is
+     * used and the last push was more than `updateAge` ago. At the thirty days
+     * this used to be, that meant a session never really expired — anybody who
+     * opened the app monthly renewed it forever, on a cookie written into the
+     * browser profile with `Max-Age=2592000`. "Thirty days" was the number in
+     * the config; "indefinitely" was the behaviour.
+     *
+     * The machine this app runs on is a shared office desktop, so the threat
+     * that matters is somebody sitting down after you — and against a captured
+     * cookie the only thing that helps is how long it stays worth something.
+     * Twenty minutes is that window. It also settles the cookie question by
+     * itself: at `Max-Age=1200` the cookie is no longer something that outlives
+     * the browser or turns up in a profile backup, so there is nothing to gain
+     * from forcing a session cookie via `rememberMe: false` — which would in
+     * fact be worse, because Better Auth reads that as a *fixed* 24-hour
+     * session and skips the sliding refresh entirely.
+     *
+     * Twenty minutes is only humane because passkeys are here: conditional UI
+     * signs a returning holder back in with no click. It does make the passkey
+     * nudge load-bearing rather than decorative — anyone still on a password
+     * types it several times a day, and that pressure is the point.
+     */
+    expiresIn: SESSION_IDLE_SECONDS,
+
+    /**
+     * Slide the window every minute rather than every day.
+     *
+     * `updateAge` is how stale the window may get before a request pushes it
+     * out again, so it has to be far below `expiresIn` or the session expires
+     * under somebody mid-task: at the old one-day setting a twenty-minute
+     * window would be renewed long after it had already lapsed. A minute costs
+     * one indexed UPDATE per active session per minute, and means the clock
+     * only ever runs down when nobody is there.
+     */
+    updateAge: 60,
+
+    /**
+     * Left at a day, and deliberately not doing the job its name suggests.
+     *
+     * `freshAge` gates exactly two Better Auth endpoints — `/unlink-account`
+     * and `/list-sessions` — and this app exposes neither. It is NOT the
+     * re-authentication control for this app's own destructive actions; that
+     * is `requireFreshPasskey` in `src/lib/reauth.ts`, which asks for a passkey
+     * touch rather than trusting the age of a session that may have been
+     * captured. Kept at a day so the two library endpoints stay sane.
+     */
+    freshAge: 60 * 60 * 24,
+
     // Cookie caching is deliberately OFF.
     //
     // It stores a signed snapshot of the session in a second cookie and
@@ -115,6 +166,11 @@ export const auth = betterAuth({
     // cookie stays authenticated until the snapshot expires. On a shared
     // office machine that is precisely the case sign-out exists to cover —
     // and a DAST probe caught it doing exactly that (A07-logout).
+    //
+    // The same reasoning is why the session token stays an opaque row in
+    // `session` rather than a self-describing JWT: a JWT is that snapshot with
+    // a longer fuse, and it would put revocation — sign-out, access revoked, a
+    // password reset — back on a delay measured in minutes.
     //
     // The cost of turning it off is one indexed lookup per request. For a
     // handful of users against Postgres on the same box, that is not a

--- a/src/lib/reauth.ts
+++ b/src/lib/reauth.ts
@@ -1,0 +1,64 @@
+import "server-only";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+import { FRESH_AUTH_SECONDS } from "@/lib/auth-rules";
+
+/**
+ * Re-authentication for the actions that move access around.
+ *
+ * The session window is twenty idle minutes, which limits how long a captured
+ * cookie is worth anything but does not stop it being worth something *now*.
+ * The things worth protecting from a stolen twenty minutes are the ones that
+ * outlive it: an invitation mints a whole new account, a reset link is the
+ * ability to become somebody else, and revoking access locks a colleague out.
+ * So those ask for the passkey or the password again, which is the one control
+ * on the list a thief cannot satisfy with a copied cookie.
+ *
+ * **Freshness is the age of the session itself.** Better Auth 1.7.1 has no
+ * "prove it is you" primitive — `/passkey/verify-authentication` and
+ * `/sign-in/username` both mint a *new* session rather than annotating the one
+ * you hold — so re-authenticating means signing in again, and a session that
+ * was created moments ago is exactly the evidence we are looking for. It also
+ * means a normal sign-in is fresh for its first five minutes, which is right:
+ * somebody who just typed their password should not be asked for it twice.
+ *
+ * The cost of doing it this way is one superseded session row per re-auth.
+ * That was the deciding trade when the window was thirty days; at twenty idle
+ * minutes the orphan is gone before anyone would notice it, which is what
+ * makes this the cheap option rather than hand-rolling WebAuthn verification
+ * against the `passkey` table.
+ */
+
+/** Seconds since this session was created, or null if there is no session. */
+export async function authAgeSeconds(): Promise<number | null> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  const createdAt = session?.session?.createdAt;
+  if (!createdAt) return null;
+
+  const ms = Date.now() - new Date(createdAt).getTime();
+  // A clock that disagrees with the database should not mint freshness out of
+  // nowhere, so a negative age is treated as "no idea" rather than "brand new".
+  return ms < 0 ? null : Math.floor(ms / 1000);
+}
+
+/** Did this session begin recently enough to stand in for a re-auth? */
+export async function isFreshAuth(): Promise<boolean> {
+  const age = await authAgeSeconds();
+  // Fails closed: no session, or an age we cannot read, is not fresh.
+  return age !== null && age <= FRESH_AUTH_SECONDS;
+}
+
+/**
+ * Gate for an action that grants, transfers or withdraws access.
+ *
+ * Sends the caller to `/reauth` when their sign-in is too old, and returns
+ * only when it is recent enough. `returnTo` is where they land afterwards —
+ * the screen they were on, not the action they were attempting, because the
+ * form has to be filled in again anyway.
+ */
+export async function requireFreshAuth(returnTo: string): Promise<void> {
+  if (await isFreshAuth()) return;
+  redirect(`/reauth?next=${encodeURIComponent(returnTo)}`);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getSessionCookie } from "better-auth/cookies";
 import { buildCsp, newNonce } from "@/lib/csp";
+import { SESSION_COOKIE_NAMES, SESSION_IDLE_SECONDS } from "@/lib/auth-rules";
 
 /**
  * Two jobs, both cheap enough to run on every request.
@@ -78,12 +79,60 @@ export function middleware(request: NextRequest) {
   const hasCookie = getSessionCookie(request, { cookiePrefix: "ppp" });
 
   if (isApi || isPublic || hasCookie) {
-    return withCsp(NextResponse.next({ request: { headers: requestHeaders } }));
+    const res = withCsp(NextResponse.next({ request: { headers: requestHeaders } }));
+    // Route handlers set their own cookies; a page render cannot. See below.
+    if (!isApi) restampSession(request, res);
+    return res;
   }
 
   const signin = new URL("/signin", request.url);
   signin.searchParams.set("next", pathname + search);
   return withCsp(NextResponse.redirect(signin));
+}
+
+/**
+ * Re-stamp the session cookie's `Max-Age` on a page navigation.
+ *
+ * Better Auth slides a live session two ways at once: it pushes `expiresAt`
+ * out in the database, and it re-sets the cookie with a fresh `Max-Age`. Only
+ * the first of those survives a React Server Component render, because Next
+ * forbids writing a cookie during one. So browsing pages keeps the session row
+ * alive while the browser's copy of the cookie counts down from whenever a
+ * route handler last wrote it.
+ *
+ * At the thirty-day window this app used to run, nobody would ever have hit
+ * that. At twenty minutes it signs people out in the middle of working — row
+ * alive, cookie gone. Measured rather than assumed: `GET /board` sends no
+ * `Set-Cookie` at all, where `GET /api/stories` sends `Max-Age=1200`.
+ *
+ * Re-stamping is safe because the cookie is not the authority. It carries a
+ * token whose validity is the `session` row, and `getSession` refuses an
+ * expired row, so keeping the browser's copy for longer cannot extend a
+ * session by one second. What it buys is the invariant worth having: the
+ * cookie never dies before the row it names, and the two now slide on exactly
+ * the same requests.
+ *
+ * `/api/*` is deliberately excluded. Those responses can and do set the cookie
+ * themselves — and re-stamping there would resurrect the one that
+ * `/api/auth/sign-out` had just deleted.
+ */
+function restampSession(request: NextRequest, response: NextResponse): void {
+  for (const name of SESSION_COOKIE_NAMES) {
+    const cookie = request.cookies.get(name);
+    if (!cookie) continue;
+    response.cookies.set({
+      name,
+      value: cookie.value,
+      maxAge: SESSION_IDLE_SECONDS,
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      // `__Secure-` is a promise to the browser that the cookie only ever
+      // travels over HTTPS, and it refuses the cookie outright without it.
+      secure: name.startsWith("__Secure-"),
+    });
+    return;
+  }
 }
 
 export const config = {


### PR DESCRIPTION
## Why

`session.expiresIn` was thirty days with `updateAge` at a day. `expiresIn` is an **idle** window that Better Auth pushes back out on use, so a session touched once a month renewed itself indefinitely — thirty days was the number in the config, *forever* was the behaviour, on a cookie written into the browser profile with `Max-Age=2592000`.

On the shared office desktop this app is built for, the threat is somebody sitting down after you, and the only thing that helps against a captured cookie is how long it stays worth something.

## What changed

**Twenty idle minutes**, sliding every minute so it never expires under somebody mid-task. Bearer tokens inherit it, which closes the *"long-lived credential in a shell history"* item in the audit. It is only humane because passkeys are here — which does make the passkey nudge load-bearing rather than decorative.

**Re-authentication on the four actions that move access around** — invite, re-send, mint a reset link, revoke/restore. These outlive any session (an invitation mints an account; a reset link is the ability to become somebody else), so they require a sign-in from the last five minutes and send an older one to a new `/reauth`. Withdrawing an unaccepted invitation is not gated — it only removes reach — and nor is `/admin/benefits`.

## Two things found by measuring, not reasoning

**The cookie did not slide on a page render.** Better Auth extends a live session in two places and only one survives an RSC render: the row is pushed out, but Next forbids writing a cookie during a render. So browsing pages kept the session alive while the browser's copy counted down from whenever a route handler last wrote it.

| Request | DB row | Cookie `Max-Age` |
|---|---|---|
| `GET /board` *(before)* | slid | **no `Set-Cookie` at all** |
| `GET /api/stories` *(before)* | slid | 1200 |
| `GET /board` *(after)* | slid | 1200 |

Invisible at thirty days; at twenty minutes it signs an active person out with a live session behind them. Middleware re-stamps the cookie on page navigations and only there — `/api/*` sets it itself, and re-stamping there would resurrect the cookie sign-out just deleted. Safe because the cookie is not the authority: the row is, and `getSession` refuses an expired one.

**The new window could not reach sessions that already existed.** The refresh test reads a stored `expiresAt` as though written under the *current* `expiresIn`, so an old row looks freshly updated and is never shortened — a planted thirty-day session was still 30.00 days out after use. Without the migration this change would be cosmetic for exactly the people who have a session worth stealing.

## The migration

`DELETE FROM "session" WHERE "expiresAt" > now() + interval '21 minutes'` — matched on the window rather than truncating, so it can only hit rows the old config minted, and it is a no-op if re-run. Verified against a planted 30-day session:

| | before | after |
|---|---|---|
| users | 2 | 2 |
| stories | 2 | 2 |
| audit rows | 11 | 11 |
| sessions | 3 | 2 *(only the planted row)* |

No foreign key in the database references `session`, so nothing cascades. **Everyone signs in once on upgrade**, and the first admin action after deploy will bounce through `/reauth` — both mechanisms working, but worth expecting.

## Deliberately not done

- **A JWT session.** A signed snapshot trusted without a database lookup is finding 1 in the audit with a longer fuse — revocation would go back to lagging by the token's lifetime.
- **Moving the token out of a cookie.** A cookie is the only credential a browser attaches to a top-level navigation, and this app is server-rendered: `requireUser` and `storyScope` run on the navigation itself. `localStorage` would also trade `HttpOnly` away for nothing.
- **A non-persistent cookie via `rememberMe: false`.** At `Max-Age=1200` it buys nothing, and Better Auth reads that flag as a *fixed* 24-hour session with the sliding refresh off.

Each is recorded beside the config so nobody re-derives it.

## Honest limits

Re-auth is a **sudo gate, not a second factor** — it asks for the same credential again, so it stops a stolen cookie and not a stolen password. TOTP stays the answer if this ever leaves the office; the audit says so.

Freshness is the age of the session itself, because Better Auth 1.7.1 has no assert-without-signing-in primitive (`/passkey/verify-authentication` mints a session). So re-authenticating leaves one superseded row behind — cheap now that it expires in twenty minutes rather than a month.

`/reauth` takes the password as well as the passkey: requiring a passkey would leave an admin without one unable to revoke access.

## Verification

Six new probes, **97** in all. `A07-session-window`, `A07-session-cookie-maxage` and `A07-session-slides` hold the window, the cookie and the re-stamp; `A07-reauth-stale`, `A07-reauth-redirect` and `A07-reauth-fresh` hold the gate — the first and last drive the *same* form submission and differ only in the age of the session, so the pair fails if it stops discriminating either way.

All nine suites green: probes 97 · models 32 · auth all · upload 70 · queue 109 · frr 70 · api 100 · benefits 19 · passkey 13 · typecheck, `check:secrets`, `check:links`.
