### PR TITLE
Make withdrawing a request look like a button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Fixed
+
+- **Nobody could find how to withdraw a request.** The control on a ticket was
+  drawn with a transparent border and muted grey text, growing an outline only
+  on hover — so at rest it read as a caption rather than a button, and it sat
+  directly above *Print again*, which is a full enamel button. Next to its own
+  neighbour it looked like that button's label. It is now a button in the same
+  shape as *Decline* and *Flag*, tinted cherry-wash with cherry-dark text and
+  going solid red on hover, which keeps the two steps legible as an escalation:
+  an outlined red button opens the drawer, a filled red one commits. The
+  confirmation step and its wording are unchanged — a destructive action should
+  be hard to fire by accident, not hard to locate.
+
 ### Changed
 
 - **A session is now worth twenty idle minutes, not a renewing month.**

--- a/src/components/withdraw-story.tsx
+++ b/src/components/withdraw-story.tsx
@@ -13,6 +13,20 @@ import { withdrawStory } from "@/app/actions/stories";
  * this is the one action in the app that destroys something. Everything else
  * moves a ticket along or marks it; this removes it, the conversation with it,
  * and the uploaded geometry from storage.
+ *
+ * The trigger is a *button*, in the same enamel shape as Decline and Flag in
+ * `admin-actions.tsx`. It used to be drawn with a transparent border and muted
+ * text, growing an outline only on hover — which meant it read as a caption
+ * rather than a control, and read as one directly above "Print again", which
+ * is a full button. People could not find it. A destructive action being the
+ * quietest thing on the page is the wrong way round: hard to *fire* by
+ * accident is the goal, not hard to *locate*.
+ *
+ * So it carries colour as well as shape — cherry-wash with cherry-dark text
+ * (5.1:1), going solid on hover. That keeps the two steps legible as an
+ * escalation: an outlined red button opens the drawer, a filled red one
+ * commits. Tone is carried by the fill *and* by the word, never by colour
+ * alone, which is the rule the notices follow.
  */
 export function WithdrawStory({
   storyId,
@@ -27,7 +41,7 @@ export function WithdrawStory({
 }) {
   return (
     <details className="mt-[17.6px]">
-      <summary className="inline-block cursor-pointer list-none rounded-chip border-[3px] border-transparent px-[13.2px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink-2 hover:border-ink hover:bg-cream-2">
+      <summary className="stamp inline-block cursor-pointer list-none rounded-chip border-[3px] border-ink bg-cherry-wash px-[15px] py-[8px] text-[14px] font-bold text-cherry-dk hover:bg-cherry-dk hover:text-cream">
         Withdraw this request
       </summary>
       <form action={withdrawStory} className="mt-[8px]">


### PR DESCRIPTION
Reported: people could not find how to withdraw a request.

## Why it was invisible

The control was drawn with a **transparent border** and muted grey text, growing an outline only on hover. At rest it read as a caption rather than a control — and it sits directly above *Print again*, which is a full enamel button, so next to its own neighbour it looked like that button's label.

| | |
|---|---|
| before | small mono uppercase, `text-ink-2`, `border-transparent`, no fill, no shadow |
| after | `stamp` shadow, `border-ink`, `bg-cherry-wash`, bold `text-cherry-dk`, solid on hover |

## The fix

It now uses the enamel disclosure shape the app **already had** for *Decline* and *Flag* in `admin-actions.tsx`. This was never a missing pattern — just a control that wasn't using it. The only thing added on top is colour, which is what was asked for.

Contrast: cherry-dark on cherry-wash is 5.1:1 (AA); hover is cream on cherry-dark, the pairing the palette already documents at 6:1. Tone is carried by the fill *and* by the word, which is the rule the notices follow.

## What is deliberately unchanged

The confirmation step and its wording. A destructive action should be hard to **fire** by accident, not hard to **locate** — those are different problems, and only the second one was broken. The disclosure still says the file goes too, and still asks. The two steps now read as an escalation: an outlined red button opens the drawer, a filled red one commits.

## Verification

`verify:queue` (109) and `verify:upload` (70) both pass. They match on the strings `"Withdraw this request"` and `"Yes, withdraw it"` — neither changed, so the suites exercise the same path they always did. Typecheck and `check:links` clean.

Confirmed visually in a real browser at both states rather than assumed.

## Not included

Two siblings share the old styling and are left alone so this PR does one thing:

- `src/app/frr/[id]/page.tsx:179` — the feature-request withdraw, drawn as an **underlined text link**. Same label as this one, so after this merges the app has two identically-named controls in two styles. The stronger of the two follow-ups.
- `src/components/reset-password.tsx:49` — "Forgotten password?" on the guest list, byte-identical to what this replaces. Lower urgency: it is the admin's own tool on their own screen.

Both are one-line changes if wanted.
