### PR TITLE
Put the slicer credential in the link, and add a plain download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Added
+
+- **Download the model.** Every ticket now has a plain **Download** button
+  beside *Open in PrusaSlicer* — the same bytes with no helper and no setup,
+  for the printer owner who is not sitting at the machine with the slicer on
+  it, or who uses a different slicer. There is no new server surface behind it:
+  `/api/models/[id]` already streamed the file with
+  `Content-Disposition: attachment`, already scoped it with `storyScope`, and
+  already recorded `file.downloaded` whenever bytes go to somebody other than
+  the uploader. Shown to anyone who can see the ticket, and kept *above* the
+  slicer disclosure so the simple answer is the visible one.
+
+### Fixed
+
+- **"Open in PrusaSlicer" stopped working, and the fix removes a credential
+  from disk.** The helper authenticated with `PPP_TOKEN` — a bearer token
+  pasted once into `~/.config/ppp/slicer.conf`. A bearer token *is* the session
+  token, so shortening sessions to twenty idle minutes killed it and every
+  click began answering `HTTP 401`. That file had been holding a thirty-day,
+  full-authority credential at rest; the feature was depending on the weakness
+  the session change removed. The link now carries its own credential instead —
+  `ppp://slice/<id>?t=…`, minted when the ticket renders, for that person and
+  that model, expiring in half an hour — and `slicer.conf` holds nothing but
+  the address of the instance. The token asserts an identity and a subject and
+  never an authorisation: the route still loads the account, refuses a
+  suspended one, and re-applies `storyScope`, so a link cannot reach a model
+  its holder has lost access to or be edited to fetch a different one. Old
+  installs keep working (`PPP_TOKEN` is still honoured when a link carries no
+  `t`) but the line can now be deleted. Six new probes; the suite is 103.
+
 ### Changed
 
 - **A session is now worth twenty idle minutes, not a renewing month.**

--- a/docs/prusaslicer.md
+++ b/docs/prusaslicer.md
@@ -34,8 +34,8 @@ only new moving part, and it talks to nothing but this app's own API.
 ```
  Browser                 Helper on your machine            This app
  ───────                 ──────────────────────            ────────
- click  ──ppp://slice/104──▶ prusa-open.sh
-                            GET /api/models/104  ───────────▶  (bearer token)
+ click ─ppp://slice/104?t=…─▶ prusa-open.sh
+                            GET /api/models/104?t=…  ───────▶  (link credential)
                             ◀───────────────────── the .stl bytes
                             writes /tmp/…/PPP-104-clip.stl
                             prusa-slicer --single-instance <that file>
@@ -56,10 +56,12 @@ That registers `ppp://` links to open with
 
 ```sh
 PPP_BASE="https://print.example"      # your instance, no trailing slash
-PPP_TOKEN="…"                          # a bearer token — see below
 # PPP_SLICER=…                         # only if auto-detect misses — see below
 # PPP_DOWNLOAD_DIR="$HOME/.cache/ppp/models"
 ```
+
+That is the whole config: **there is no token to paste.** The clicked link
+carries its own credential.
 
 ### Finding the slicer
 
@@ -87,21 +89,47 @@ default `PPP_DOWNLOAD_DIR` is under `~/.cache`, which a Flatpak with home access
 can see; if yours is sandboxed tighter, grant it with
 `flatpak override --user --filesystem=xdg-cache/ppp com.prusa3d.PrusaSlicer`.
 
-Get a token by signing in — and keep it out of your shell history:
+### The credential is in the link
+
+Click **Open in PrusaSlicer** on any ticket and it works. The link is
+`ppp://slice/<id>?t=<token>`, and that token is minted by the app when the
+ticket is rendered — for **you**, for **that model**, for **half an hour**.
+
+It is deliberately not much of a secret, because it cannot do much: it names
+who you are, and the server decides the rest. Your account is loaded and
+refused if it has been suspended, and the same `storyScope` rule the pages use
+is re-applied — so a link cannot reach a model you have lost access to, and
+cannot be edited to fetch a different one. If it expires, open the ticket again
+and click; there is nothing to rotate.
+
+Two consequences worth stating plainly:
+
+- **Nothing secret is on your disk.** `slicer.conf` holds an address. It is
+  still created `600`, but there is nothing in it to steal.
+- **Signing out does not kill an outstanding link.** Nothing is stored, so
+  there is nothing to revoke — the half hour has to elapse. Suspending the
+  account *does* stop it. For read access to one model you could already open,
+  that is the right side of the trade.
+
+#### If you set this up before
+
+Earlier versions put a `PPP_TOKEN` in that file — a bearer token, which is the
+session token. When sessions came down from thirty days to twenty idle minutes
+it stopped working, and every click began answering `HTTP 401`. That is the bug
+this replaced.
+
+The helper still honours `PPP_TOKEN` when a link carries no `t`, so an old
+bookmark keeps working, but there is no reason to keep one:
 
 ```bash
-curl -si https://print.example/api/auth/sign-in/username \
-  -H 'content-type: application/json' \
-  -d '{"username":"you","password":"…"}' | grep -i '^set-auth-token:'
+sed -i '/^PPP_TOKEN=/d' ~/.config/ppp/slicer.conf
 ```
 
-The token **is** your session token: it carries your account's access and no
-more, and signing out of the app revokes it. That is also why the config file
-is `600` — it holds a credential. See [the API](api.md#authentication) for the
-full picture on bearer tokens.
+### Just want the file?
 
-Now click **Open in PrusaSlicer** on any ticket. Nothing to paste — the link
-carries only the ticket number; the address and the token live in the config.
+Every ticket also has a plain **Download** button next to this one. Same bytes,
+same permissions, no helper and no setup — for a machine without PrusaSlicer,
+or a slicer that is not PrusaSlicer.
 
 ## When it does not work
 
@@ -120,12 +148,15 @@ indistinguishable from one that was never wired up. Common lines:
 | It says | Means |
 | --- | --- |
 | `no config at …` | The installer has not run, or `$PPP_SLICER_CONF` points elsewhere. |
-| `not authorised (HTTP 401)` | The token is wrong, expired, or was revoked by signing out. Mint a new one. |
+| `that link has expired (HTTP 401)` | Links last half an hour. Open the ticket again and click the button. |
+| `the PPP_TOKEN in … is expired` | You are on the old config-token path. Delete the line and click the button in the app — see *If you set this up before*. |
+| `that link carries no credential and … sets no PPP_TOKEN` | An old bookmark, on a config with no token. Open the ticket in the app and click there. |
+| `the credential in that link is malformed` | The URL was edited or truncated in transit. Re-click from the ticket. |
 | `story N … not one this account may see (HTTP 404)` | That ticket is not yours, or does not exist. |
 | `could not find PrusaSlicer` | Auto-detect missed it. Set `PPP_SLICER` — see *Finding the slicer* above. |
 | `slicer '…' is not runnable` | `PPP_SLICER` points at something that is not a command or an executable file. |
 | loads then says *empty file* / *loading failed* | The bytes did arrive; the slicer could not read them (a truncated or non-model file). Check the ticket's file. |
-| `WARNING: … is group/world-readable` | `chmod 600 ~/.config/ppp/slicer.conf`. |
+| `WARNING: … is group/world-readable` | Only raised while the file still holds a `PPP_TOKEN`. Delete the line, or `chmod 600 ~/.config/ppp/slicer.conf`. |
 
 ## macOS and Windows
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -22,7 +22,7 @@ docker run --rm -v "$PWD:/src:ro" semgrep/semgrep semgrep scan \
   --config=p/owasp-top-ten --config=p/security-audit --config=p/nextjs /src/src
 docker run --rm --network host ghcr.io/zaproxy/zaproxy:stable \
   zap-baseline.py -t http://localhost:3000        # DAST
-npm run probe:security                     # DAST, app-specific (97 probes)
+npm run probe:security                     # DAST, app-specific (103 probes)
 ```
 
 ## Result
@@ -34,7 +34,7 @@ npm run probe:security                     # DAST, app-specific (97 probes)
 | Syft + Grype | SBOM, binary contents | **92 (2 crit, 46 high)** | 0 |
 | Semgrep | 153 rules, 37 files | 1 (false positive) | 0 |
 | OWASP ZAP baseline | passive DAST | **1 medium, 3 low** | 0 fail / 63 pass |
-| `probe:security` | 97 app-specific probes | **2 real, 4 artifacts** | 97 pass |
+| `probe:security` | 103 app-specific probes | **2 real, 4 artifacts** | 103 pass |
 | `verify:models` | 29 upload-validator checks | — | 29 pass |
 | `verify:passkey` | WebAuthn in a real browser | *unverified* | 13 pass |
 
@@ -335,6 +335,47 @@ invitation), `A07-reauth-redirect` (it is sent to `/reauth` instead) and
 `A07-reauth-fresh` (a sign-in from moments ago still can). The first and third
 drive the *same* form submission and differ only in the age of the session, so
 the pair fails if the gate stops discriminating in either direction.
+
+#### The slicer link credential, and the token it replaced
+
+Shortening the session broke "Open in PrusaSlicer", and the way it broke is
+worth recording because the feature had been quietly depending on the weakness.
+
+The helper runs on somebody's own machine and holds no cookie, so it
+authenticated with `PPP_TOKEN` — a bearer token pasted once into
+`~/.config/ppp/slicer.conf`. A bearer token is the session token, so that file
+held a **thirty-day, full-authority credential at rest**, revocable only by
+signing out. At twenty idle minutes it simply stopped working: every click
+answered `HTTP 401`.
+
+The fix is not a longer-lived credential in the same place. The link carries
+its own instead — `ppp://slice/<id>?t=…`, minted when the ticket renders, for
+that person and that model, expiring in half an hour
+(`src/lib/slicer-token.ts`). `PPP_TOKEN` is gone from the installer's template
+and the config now holds nothing but an address.
+
+What the token is, precisely: an HMAC over `version.storyId.userId.expiry`,
+keyed on `BETTER_AUTH_SECRET`. It asserts an **identity and a subject, never an
+authorisation** — the route loads the account, refuses a suspended one, and
+re-applies `storyScope` against the database exactly as it does for a session.
+So a link cannot outlive the access it was minted under, and cannot be edited
+to fetch a different model.
+
+Stateless on purpose, and the cost is stated rather than hidden: an outstanding
+link is **not** revoked by signing out, because nothing is stored to revoke. It
+is revoked by suspending the account, by the scope check, and by half an hour
+passing. The alternative writes a `verification` row on every render of every
+ticket to be read at most once. For read access to one model the holder could
+already open, this is the right side of the trade — it would not be for
+anything that writes.
+
+Net against what it replaced: a thirty-day credential for the whole account, in
+a file, became a thirty-minute credential for one model, in a URL. Six probes
+hold it — that a ticket carries one at all, that an anonymous fetch is still
+401, that a minted one works, that it cannot be pointed at another model, and
+that a tampered or malformed one is refused. The binding probe aims the token at
+a story the printer owner *can* read by session, so it fails if the binding ever
+stops being enforced independently of scope.
 
 ### Residual risk accepted
 

--- a/scripts/install-slicer-handler.sh
+++ b/scripts/install-slicer-handler.sh
@@ -71,8 +71,8 @@ fi
 command -v update-desktop-database >/dev/null 2>&1 &&
   update-desktop-database "$apps_dir" 2>/dev/null || true
 
-# Config skeleton — never overwrite an existing one, and lock it down, because
-# it is about to hold a bearer token.
+# Config skeleton — never overwrite an existing one. Still created 600: it holds
+# no credential any more, but an existing file might, and tightening is free.
 conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ppp"
 conf="$conf_dir/slicer.conf"
 mkdir -p "$conf_dir"
@@ -82,17 +82,14 @@ else
   umask 077
   cat >"$conf" <<'CONF'
 # Pretty Please Print → PrusaSlicer bridge config. Read by prusa-open.sh.
-# This file holds a credential: keep it mode 600 (this file was created so).
+#
+# There is nothing secret in here. The clicked link carries its own credential
+# — minted by the app for whoever was looking at that ticket, good for half an
+# hour and for that one model — so the only thing this file has to say is which
+# instance to talk to.
 
-# The instance, no trailing slash.
+# The instance, no trailing slash. This is the only required setting.
 PPP_BASE="https://print.example"
-
-# A bearer token. It is your session token, so signing out of the app revokes
-# it. Mint one — and keep it out of your shell history:
-#   curl -si "$PPP_BASE/api/auth/sign-in/username" \
-#     -H 'content-type: application/json' \
-#     -d '{"username":"you","password":"..."}' | grep -i '^set-auth-token:'
-PPP_TOKEN="paste-the-set-auth-token-value-here"
 
 # Optional. Left unset, the helper finds PrusaSlicer on its own — a binary on
 # PATH (prusa-slicer / prusaslicer / PrusaSlicer), a Flatpak install, or an
@@ -108,9 +105,16 @@ PPP_TOKEN="paste-the-set-auth-token-value-here"
 # PPP_DOWNLOAD_DIR="$HOME/.cache/ppp/models"
 CONF
   chmod 600 "$conf"
-  echo "created $conf (mode 600) — edit PPP_BASE and PPP_TOKEN"
+  echo "created $conf — set PPP_BASE to your instance"
 fi
 
 echo
-echo "Done. Set PPP_BASE and PPP_TOKEN in $conf, then click 'Open in PrusaSlicer'"
-echo "on any ticket. Trouble? tail -f \"\${XDG_STATE_HOME:-\$HOME/.local/state}/ppp/slicer.log\""
+echo "Done. Set PPP_BASE in $conf, then click 'Open in PrusaSlicer' on any"
+echo "ticket. No token to paste — the link carries its own."
+if [ -f "$conf" ] && grep -q '^[[:space:]]*PPP_TOKEN=' "$conf" 2>/dev/null; then
+  echo
+  echo "NOTE: $conf still sets PPP_TOKEN. That was the old way in and it is a"
+  echo "      long-lived credential on disk; links carry their own now. You can"
+  echo "      delete the line."
+fi
+echo "Trouble? tail -f \"\${XDG_STATE_HOME:-\$HOME/.local/state}/ppp/slicer.log\""

--- a/scripts/prusa-open.sh
+++ b/scripts/prusa-open.sh
@@ -16,15 +16,20 @@
 #
 # Config lives at $PPP_SLICER_CONF (default ~/.config/ppp/slicer.conf) and sets:
 #   PPP_BASE          the instance, e.g. https://print.example         (required)
-#   PPP_TOKEN         a bearer token from a sign-in response            (required)
 #   PPP_SLICER        the slicer binary            (default: prusa-slicer)
 #   PPP_DOWNLOAD_DIR  where fetched models land    (default: ~/.cache/ppp/models)
+#   PPP_TOKEN         DEPRECATED — see below                          (optional)
 #
-# The token IS the session token — signing out of the app revokes it. Get one
-# with, and keep it out of your shell history:
-#   curl -si $PPP_BASE/api/auth/sign-in/username \
-#     -H 'content-type: application/json' \
-#     -d '{"username":"you","password":"..."}' | grep -i '^set-auth-token:'
+# THE CONFIG NO LONGER HOLDS A CREDENTIAL. The clicked link carries its own:
+# `ppp://slice/<id>?t=<token>`, minted by the app for the person who was looking
+# at that ticket, good for half an hour and for that one model. Nothing secret
+# is written to disk, so there is nothing here to leak or to rotate.
+#
+# It used to be PPP_TOKEN, a bearer token pasted in once — which was the session
+# token, so when sessions came down from thirty days to twenty idle minutes it
+# stopped working and every click answered HTTP 401. PPP_TOKEN is still honoured
+# when a link carries no `t` (an old bookmark, say), but it is on the way out:
+# delete it from the config and click the button again.
 #
 # Failures are made loud rather than swallowed: a protocol handler has no
 # terminal, so every error goes to a log AND a desktop notification (when
@@ -56,10 +61,11 @@ fail() {
 # --- config -----------------------------------------------------------------
 [ -f "$CONF" ] || fail "no config at $CONF — run install-slicer-handler.sh first"
 
-# A token in a world-readable file is a credential anyone on the box can read.
-# Warn rather than refuse: on a single-user workstation it is a papercut, not a
+# Only worth saying when the file still holds the deprecated credential — with
+# `t` in the link there is nothing in here anybody could misuse. Warn rather
+# than refuse either way: on a single-user workstation it is a papercut, not a
 # breach, and refusing outright would strand somebody mid-print.
-if command -v stat >/dev/null 2>&1; then
+if grep -q '^[[:space:]]*PPP_TOKEN=' "$CONF" 2>/dev/null && command -v stat >/dev/null 2>&1; then
   # GNU stat, then BSD/macOS stat. The last two octal digits are the group and
   # other bits; any non-zero there means someone besides the owner can read it.
   perms="$(stat -c '%a' "$CONF" 2>/dev/null || stat -f '%Lp' "$CONF" 2>/dev/null || echo '')"
@@ -72,7 +78,6 @@ fi
 . "$CONF"
 
 : "${PPP_BASE:?PPP_BASE is not set in $CONF}"
-: "${PPP_TOKEN:?PPP_TOKEN is not set in $CONF}"
 DOWNLOAD_DIR="${PPP_DOWNLOAD_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/ppp/models}"
 
 # --- locate the slicer ------------------------------------------------------
@@ -122,10 +127,30 @@ fi
 url="${1:-}"
 [ -n "$url" ] || fail "no URL given — this is invoked by clicking a ppp:// link"
 
-id="${url#ppp://slice/}"
+# Split `<id>` from an optional `?t=<token>`. The id is still validated to
+# digits before it goes anywhere near a request path, and the token to the
+# base64url alphabet plus the dot that separates its two halves — so neither
+# can smuggle anything into the fetch below.
+rest="${url#ppp://slice/}"
+id="${rest%%\?*}"
 id="${id%/}"
 case "$id" in
   "" | *[!0-9]*) fail "not a model link: $url (expected ppp://slice/<number>)" ;;
+esac
+
+link_token=""
+if [ "$rest" != "${rest#*\?}" ]; then
+  query="${rest#*\?}"
+  case "$query" in
+    *t=*)
+      link_token="${query##*t=}"
+      link_token="${link_token%%&*}"
+      ;;
+  esac
+fi
+case "$link_token" in
+  "") : ;;
+  *[!A-Za-z0-9._-]*) fail "the credential in that link is malformed — open the ticket again and re-click" ;;
 esac
 
 command -v curl >/dev/null 2>&1 || fail "curl is not installed"
@@ -141,21 +166,38 @@ trap 'rm -rf "$tmp"' EXIT
 hdr="$tmp/headers"
 body="$tmp/body"
 
+# Prefer the link's own credential; fall back to the deprecated config token so
+# an old bookmark still works. One or the other has to be present.
+fetch_args=(-sS -o "$body" -D "$hdr" -w '%{http_code}')
+if [ -n "$link_token" ]; then
+  # --get --data-urlencode rather than pasting into the URL: curl does the
+  # escaping, so the shell never has to be trusted with it.
+  fetch_args+=(--get --data-urlencode "t=$link_token")
+elif [ -n "${PPP_TOKEN:-}" ]; then
+  note "no credential in the link — falling back to the deprecated PPP_TOKEN"
+  fetch_args+=(-H "Authorization: Bearer $PPP_TOKEN")
+else
+  fail "that link carries no credential and $CONF sets no PPP_TOKEN — open the ticket in the app and click the button there"
+fi
+
 note "fetching story $id from $PPP_BASE"
 # No --fail: let curl succeed on any HTTP status and read the code from -w, so
 # the `case` below can answer 401 and 404 in words rather than "curl (22)". A
 # non-zero exit here is a real transport failure — DNS, connection refused —
 # and that is what the `|| fail` catches.
 code="$(
-  curl -sS \
-    -o "$body" -D "$hdr" -w '%{http_code}' \
-    -H "Authorization: Bearer $PPP_TOKEN" \
-    "$PPP_BASE/api/models/$id" 2>"$tmp/err"
+  curl "${fetch_args[@]}" "$PPP_BASE/api/models/$id" 2>"$tmp/err"
 )" || fail "could not reach $PPP_BASE: $(tr -d '\r' <"$tmp/err" | tail -n1)"
 
 case "$code" in
   200) : ;;
-  401) fail "not authorised (HTTP 401) — the token in $CONF is missing, expired, or was revoked by signing out" ;;
+  401)
+    if [ -n "$link_token" ]; then
+      fail "that link has expired (HTTP 401). They last half an hour — open the ticket again and click the button."
+    else
+      fail "not authorised (HTTP 401) — the PPP_TOKEN in $CONF is expired or was revoked. Delete it and click the button in the app instead; links now carry their own credential."
+    fi
+    ;;
   404) fail "story $id is not there, or not one this account may see (HTTP 404)" ;;
   *)   fail "server returned HTTP $code for story $id" ;;
 esac

--- a/scripts/security-probe.ts
+++ b/scripts/security-probe.ts
@@ -365,6 +365,60 @@ async function main() {
           r.status === 404, `expected 404, got ${r.status}`);
   }
 
+  // ---------------------------------------------------------------------
+  // The "Open in PrusaSlicer" link credential.
+  //
+  // A second way to be somebody at /api/models/[id], for a desktop helper that
+  // holds no cookie. It replaced a bearer token pasted into a file on the
+  // owner's machine — which was the session token, so it was a thirty-day,
+  // full-authority secret at rest, and it broke outright when sessions came
+  // down to twenty minutes.
+  //
+  // The token answers *who* and nothing else, so what matters is that it is
+  // unforgeable and that it cannot be pointed somewhere it was not minted for.
+  // ---------------------------------------------------------------------
+  // Minted off a story with real bytes behind it. `mallorysStory` is a bare row
+  // with an invented storage key, so a fetch of it 502s at the object store
+  // long after the credential has done its job — which would test nothing.
+  const realStory = spoofed!;
+  const ticket = await (await apiAdmin.raw(APP + `/story/${realStory.id}`)).text();
+  const minted = /ppp:\/\/slice\/\d+\?t=([A-Za-z0-9._-]+)/.exec(ticket)?.[1] ?? "";
+  probe("A05-slicer-minted", "a ticket carries a slicer link with its own credential",
+        minted.length > 0,
+        "no ppp:// link with a ?t= credential on the rendered ticket — the " +
+        "helper would fall back to a long-lived token on disk");
+
+  // Anonymous: no cookie, no bearer, exactly the helper's position.
+  const bare = (url: string) => fetch(url, { redirect: "manual" });
+
+  probe("A01-slicer-anon", "the model route still refuses a caller with nothing",
+        (await bare(APP + `/api/models/${realStory.id}`)).status === 401,
+        "an unauthenticated fetch of model bytes was not 401");
+
+  if (minted) {
+    probe("A01-slicer-ok", "a minted link fetches the model it names",
+          (await bare(APP + `/api/models/${realStory.id}?t=${minted}`)).status === 200,
+          "the credential the app just minted did not work — the button is broken");
+
+    // The binding that matters: one link, one model. Without it, a link to your
+    // own ticket would be a key to every ticket its holder can see — and the
+    // holder here is the printer owner, who can see all of them. Mallory's is
+    // the right target precisely because the admin *may* read it by session.
+    const crossed = await bare(APP + `/api/models/${mallorysStory.id}?t=${minted}`);
+    probe("A01-slicer-bound", "and cannot be pointed at a different model",
+          crossed.status !== 200,
+          `a token minted for ${realStory.id} fetched ${mallorysStory.id} (status ${crossed.status})`);
+
+    const tampered = minted.slice(0, -4) + "AAAA";
+    probe("A02-slicer-signature", "a tampered link credential is refused",
+          (await bare(APP + `/api/models/${realStory.id}?t=${tampered}`)).status !== 200,
+          "the HMAC over the claim is not being checked — anyone could mint one");
+
+    probe("A02-slicer-garbage", "and so is something that is not a token at all",
+          (await bare(APP + `/api/models/${realStory.id}?t=not-a-token`)).status !== 200,
+          "a malformed credential was accepted");
+  }
+
   const said = await client.raw(APP + `/api/stories/${mallorysStory.id}/comments`, {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/src/app/api/models/[id]/route.ts
+++ b/src/app/api/models/[id]/route.ts
@@ -3,8 +3,9 @@ import { GetObjectCommand } from "@aws-sdk/client-s3";
 
 import { db } from "@/lib/db";
 import { currentUser, storyRef } from "@/lib/authz";
-import { storyScope } from "@/lib/scope";
+import { storyScope, type Actor } from "@/lib/scope";
 import { record } from "@/lib/audit";
+import { readSlicerToken } from "@/lib/slicer-token";
 import { s3, bucket } from "@/lib/storage";
 
 /**
@@ -25,20 +26,59 @@ import { s3, bucket } from "@/lib/storage";
  * Scoped with `storyScope`, the same fragment the story page composes, so a
  * client asking for someone else's model gets 404 — not 403, which would
  * confirm it exists.
+ *
+ * Two ways to be somebody here. The ordinary one is a session, cookie or
+ * bearer. The other is `?t=`, the link credential minted into an
+ * "Open in PrusaSlicer" link — see `src/lib/slicer-token.ts` for why a desktop
+ * helper needs one and why it is not simply a long-lived token in a file.
+ *
+ * The token only ever answers *who*. Everything that decides *whether* runs
+ * afterwards and identically for both doors: the account is loaded and refused
+ * if suspended, and `storyScope` is re-applied against the database. A link
+ * therefore cannot reach a model its holder has lost access to, and cannot
+ * reach a different model than the one it names.
  */
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const user = await currentUser();
-  if (!user) return new NextResponse(null, { status: 401 });
-
   const { id } = await params;
   const storyId = Number(id);
   if (!Number.isInteger(storyId)) return new NextResponse(null, { status: 404 });
+
+  // A session first — a browser opening the viewer is the common case and
+  // costs nothing extra. The link credential is only consulted when there is
+  // no session to prefer, which is exactly the helper's situation.
+  let user = await currentUser();
+  let viaLink = false;
+
+  if (!user) {
+    const token = new URL(request.url).searchParams.get("t");
+    const subject = token ? readSlicerToken(token, storyId) : null;
+    if (subject) {
+      const row = await db.user.findUnique({
+        where: { id: subject },
+        select: { id: true, name: true, email: true, initials: true, role: true, banned: true },
+      });
+      // Suspension is checked here for the same reason `currentUser()` checks
+      // it: a credential minted before access was revoked must not outlive it.
+      if (row && !row.banned) {
+        user = {
+          id: row.id,
+          name: row.name,
+          email: row.email,
+          initials: row.initials ?? "??",
+          role: row.role === "admin" ? "admin" : "client",
+        } satisfies Actor;
+        viaLink = true;
+      }
+    }
+  }
+
+  if (!user) return new NextResponse(null, { status: 401 });
 
   const story = await db.story.findFirst({
     where: { AND: [{ id: storyId }, storyScope(user)] },
@@ -78,7 +118,7 @@ export async function GET(
       action: "file.downloaded",
       actor: user,
       subject: storyRef(story.id),
-      detail: { filename: story.filename },
+      detail: { filename: story.filename, ...(viaLink ? { via: "slicer-link" } : {}) },
     });
   }
 

--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -10,6 +10,7 @@ import { AdminActions } from "@/components/admin-actions";
 import { Conversation } from "@/components/conversation";
 import { ModelViewer } from "@/components/model-viewer";
 import { OpenInSlicer } from "@/components/open-in-slicer";
+import { DownloadModel } from "@/components/download-model";
 import { Toast } from "@/components/toast";
 import { WithdrawStory } from "@/components/withdraw-story";
 import { RequeueStory } from "@/components/requeue-story";
@@ -79,7 +80,12 @@ export default async function StoryPage({
             {/* Send the model to a PrusaSlicer on the viewer's own machine.
                 The bytes are fetched by a local helper, not by the slicer —
                 see the component and docs/prusaslicer.md for why. */}
-            <OpenInSlicer storyId={story.id} />
+            {/* The plain way to get the bytes — no helper, any machine. Kept
+                above the slicer control so the simple answer is the visible
+                one. */}
+            <DownloadModel storyId={story.id} filename={story.filename} />
+
+            <OpenInSlicer storyId={story.id} userId={user.id} />
 
             <Conversation
               storyId={story.id}

--- a/src/components/download-model.tsx
+++ b/src/components/download-model.tsx
@@ -1,0 +1,44 @@
+import { storyRef } from "@/lib/scope";
+
+/**
+ * Take a copy of the model, as uploaded.
+ *
+ * The printer owner needs the file, and "Open in PrusaSlicer" only helps on a
+ * machine with the helper installed — their own laptop, someone else's desk, a
+ * phone, or a slicer that is not PrusaSlicer, all had no answer at all. This is
+ * that answer, and it is deliberately the plainest thing on the page: a link.
+ *
+ * There is no new server surface behind it. `/api/models/[id]` already streams
+ * the bytes with `Content-Disposition: attachment` and the real filename, and
+ * is already scoped by `storyScope` — so this link grants nothing that opening
+ * the ticket did not already grant, and it is already audited: the route
+ * records `file.downloaded` whenever bytes go to somebody other than the person
+ * who uploaded them, which is exactly the printer owner taking a copy.
+ *
+ * Rendered for anyone who can see the ticket, which is the uploader and the
+ * printer owner. Not gated on role: an uploader fetching back the file they
+ * themselves put there reveals nothing, and a rule that said otherwise would be
+ * strange to explain.
+ */
+export function DownloadModel({
+  storyId,
+  filename,
+}: {
+  storyId: number;
+  filename: string;
+}) {
+  return (
+    <div className="mt-[13.2px]">
+      <a
+        href={`/api/models/${storyId}`}
+        className="stamp inline-flex cursor-pointer items-center gap-[8px] rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-sun"
+      >
+        <span aria-hidden className="font-mono text-[15px] leading-none">↓</span>
+        Download {storyRef(storyId)}
+      </a>
+      <p className="m-0 mt-[6px] font-mono text-[11px] leading-[1.5] text-ink-3">
+        {filename} — the file exactly as it was uploaded.
+      </p>
+    </div>
+  );
+}

--- a/src/components/open-in-slicer.tsx
+++ b/src/components/open-in-slicer.tsx
@@ -1,4 +1,5 @@
 import { storyRef } from "@/lib/scope";
+import { mintSlicerToken } from "@/lib/slicer-token";
 
 /**
  * "Open in PrusaSlicer" — a link to the `ppp://` scheme a helper on the
@@ -22,10 +23,33 @@ import { storyRef } from "@/lib/scope";
  * helper installed the click simply does nothing — the copy says as much, and
  * links to the one-time setup.
  *
- * The link carries only the numeric id. The base URL and the credential live
- * in the helper's own config on the owner's machine, never in the page.
+ * The link carries the ticket id **and a short-lived credential minted for the
+ * person reading this page**. It used to carry only the id, with a bearer token
+ * pasted once into the helper's config — but that token was the session token,
+ * so shortening sessions to twenty idle minutes stopped it working and the
+ * helper started answering `HTTP 401`. Putting the credential in the link
+ * rather than on disk fixes that and retires a thirty-day, full-authority
+ * secret in a file at the same time. See `src/lib/slicer-token.ts`.
+ *
+ * Minted per render, so it is as fresh as the page. It is good for half an
+ * hour, for this model only, and it authorises nothing on its own — the route
+ * re-checks the account and re-applies `storyScope`.
+ *
+ * `DownloadModel` sits beside this rather than inside it: the same bytes with
+ * no helper at all, for the printer owner who is not at the machine with the
+ * slicer on it. Putting it behind this disclosure would have hidden the plain
+ * answer behind the clever one.
  */
-export function OpenInSlicer({ storyId }: { storyId: number }) {
+export function OpenInSlicer({
+  storyId,
+  userId,
+}: {
+  storyId: number;
+  /** Who the link credential is minted for. */
+  userId: string;
+}) {
+  const token = mintSlicerToken(userId, storyId);
+
   return (
     <details className="group mt-[13.2px]">
       <summary className="stamp inline-flex cursor-pointer list-none items-center gap-[8px] rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-sun">
@@ -36,7 +60,7 @@ export function OpenInSlicer({ storyId }: { storyId: number }) {
 
       <div className="mt-[8.8px] rounded-card border-[3px] border-ink bg-cream-2 p-[13.2px]">
         <a
-          href={`ppp://slice/${storyId}`}
+          href={`ppp://slice/${storyId}?t=${token}`}
           className="stamp inline-block cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[18px] py-[8px] text-[14px] font-bold text-cream hover:bg-cherry"
         >
           Send {storyRef(storyId)} to the slicer
@@ -52,7 +76,8 @@ export function OpenInSlicer({ storyId }: { storyId: number }) {
           >
             the setup
           </a>
-          . Nothing happens if it is not installed.
+          . Nothing happens if it is not installed — the download beside this
+          works anywhere.
         </p>
       </div>
     </details>

--- a/src/lib/slicer-token.ts
+++ b/src/lib/slicer-token.ts
@@ -1,0 +1,114 @@
+import "server-only";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * The credential the "Open in PrusaSlicer" link carries.
+ *
+ * The helper on somebody's own machine has to fetch model bytes from the app,
+ * and it is not a browser: it holds no cookie. It used to hold a **bearer
+ * token pasted into `~/.config/ppp/slicer.conf`** — which was the session
+ * token, and therefore a thirty-day, full-authority credential sitting in a
+ * file. Shortening sessions to twenty idle minutes broke that outright (the
+ * helper started answering `HTTP 401`), and the fix is not a longer-lived
+ * credential in the same place. It is not needing one.
+ *
+ * So the link carries its own authority instead. `ppp://slice/<id>?t=…` is
+ * minted when the ticket is rendered, for the person looking at it and for
+ * that model alone, and it expires in half an hour. Nothing secret is written
+ * to disk at all: the config keeps only the address of the instance.
+ *
+ * **What this token is, precisely.** It asserts an *identity* and a *subject*,
+ * and nothing else. It is not an authorisation: the route still loads the user,
+ * refuses a suspended one, and re-applies `storyScope` against the database, so
+ * a token cannot outlive the access it was minted under except within its own
+ * half hour. Compared with what it replaces — the whole account, for thirty
+ * days, revocable only by signing out — the exchange is a good one in every
+ * direction.
+ *
+ * **Stateless on purpose.** An HMAC over the claim rather than a stored row:
+ * the alternative writes a `verification` row on every render of every ticket,
+ * to be read at most once and otherwise left to accumulate. The cost of that
+ * choice is honest and worth stating: an outstanding link is **not** revoked by
+ * signing out, because nothing is consulted to revoke. It IS revoked by
+ * suspending the account, and by the scope check, and by half an hour passing.
+ * For read access to one model the holder could already open, that is the right
+ * side of the trade; it would not be for anything that writes.
+ */
+
+/** Half an hour: long enough to read a ticket and click, short enough to matter. */
+export const SLICER_TOKEN_TTL_SECONDS = 60 * 30;
+
+/** Bumped if the payload shape ever changes, so old links fail closed. */
+const VERSION = "v1";
+
+function signingKey(): string {
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    // Loud rather than a guessable fallback. A constant default here would
+    // mean anybody who read the source could mint links against a deployment.
+    throw new Error(
+      "BETTER_AUTH_SECRET is required to sign slicer links. " +
+        "It is the same secret Better Auth uses; set it in the environment.",
+    );
+  }
+  return secret;
+}
+
+/** The signature covers the encoded payload verbatim, so there is nothing to canonicalise. */
+function sign(encodedPayload: string): string {
+  return createHmac("sha256", signingKey()).update(encodedPayload).digest("base64url");
+}
+
+/**
+ * Mint a link credential for one person and one model.
+ *
+ * base64url throughout: the result goes in a `ppp://` URL that a desktop
+ * environment hands to a shell script as an argument, and anything needing
+ * escaping there is a bug waiting to happen.
+ */
+export function mintSlicerToken(userId: string, storyId: number): string {
+  const expiresAt = Date.now() + SLICER_TOKEN_TTL_SECONDS * 1000;
+  const payload = `${VERSION}.${storyId}.${userId}.${expiresAt}`;
+  const encoded = Buffer.from(payload, "utf8").toString("base64url");
+  return `${encoded}.${sign(encoded)}`;
+}
+
+/**
+ * Read a link credential back, returning the user it was minted for.
+ *
+ * `storyId` is passed in and checked rather than trusted from the token: the
+ * caller already knows which model was asked for, and a token minted for one
+ * model must not fetch another. Returns null for anything at all wrong —
+ * there is no partial success worth reporting to a caller holding a bad token.
+ */
+export function readSlicerToken(token: string, storyId: number): string | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [encoded, signature] = parts as [string, string];
+
+  const expected = sign(encoded);
+  const a = Buffer.from(signature, "base64url");
+  const b = Buffer.from(expected, "base64url");
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+
+  let payload: string;
+  try {
+    payload = Buffer.from(encoded, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+
+  // The user id is a cuid and carries no dots, so a fixed split is safe.
+  const fields = payload.split(".");
+  if (fields.length !== 4) return null;
+  const [version, subject, userId, expiresAt] = fields as [string, string, string, string];
+
+  if (version !== VERSION) return null;
+  if (subject !== String(storyId)) return null;
+  if (!userId) return null;
+
+  const expiry = Number(expiresAt);
+  if (!Number.isFinite(expiry) || Date.now() > expiry) return null;
+
+  return userId;
+}


### PR DESCRIPTION
Fixes **Open in PrusaSlicer answering `HTTP 401` on every click**, and adds the Download button.

## What broke, and why it was my doing

The helper runs on somebody's own machine and holds no cookie, so it authenticated with `PPP_TOKEN` — a bearer token pasted once into `~/.config/ppp/slicer.conf`. **A bearer token is the session token.** So that file had been holding a thirty-day, full-authority credential at rest, and shortening sessions to twenty idle minutes in #38 killed it outright.

From the production log:

```
2026-08-30 17:41:56  fetching story 8 from https://ppp.danileau.com
2026-08-30 17:41:57  ERROR: not authorised (HTTP 401) — the token in
                     /home/danileau/.config/ppp/slicer.conf is … expired
```

The feature had been depending on the weakness #38 removed. Re-pasting would not have helped: a new token would die twenty minutes after its last use.

## The fix — the credential moves into the link

`ppp://slice/<id>?t=…`, minted when the ticket renders, for **that person**, **that model**, expiring in **half an hour**. `slicer.conf` now holds nothing but the address of the instance.

The token asserts an **identity and a subject, never an authorisation**. The route still loads the account, refuses a suspended one, and re-applies `storyScope` — so a link cannot reach a model its holder has lost access to, and cannot be edited to fetch a different one.

| | before | after |
|---|---|---|
| what | the whole account | one model |
| how long | 30 days, renewing | 30 minutes |
| where | a file on disk | the URL that was just clicked |
| revoked by | signing out | suspension, scope, expiry |

### The cost, stated rather than hidden

It is a stateless HMAC, so **an outstanding link is not revoked by signing out** — nothing is stored to revoke. Suspending the account stops it, the scope check stops it, half an hour stops it. The alternative writes a `verification` row on every render of every ticket, to be read at most once. For read access to one model the holder could already open, this is the right side of the trade; it would not be for anything that writes. Recorded in the audit, not glossed.

Old installs keep working (`PPP_TOKEN` is honoured when a link carries no `t`), but the installer no longer writes one and the docs say to delete it.

## Download

Requested alongside: the printer owner needs the file, and the slicer route only helps on a machine with the helper installed — a different laptop, a phone, or a slicer that is not PrusaSlicer had no answer at all.

No new server surface. `/api/models/[id]` already streamed with `Content-Disposition: attachment`, already scoped with `storyScope`, and already recorded `file.downloaded` when bytes go to somebody other than the uploader — "that is the printer owner taking a copy", as the route has always said. Only a link was missing.

It sits **above** the slicer disclosure rather than inside it. I built it inside first and moved it: burying the plain answer behind the clever one is exactly how the withdraw control became invisible (#39).

## Verification

Ran the **real handler** against a **real minted link** — fetched, saved `PPP-896-plain.stl` (684 bytes), handed off to the slicer, with no `PPP_TOKEN` anywhere.

Six new probes, suite is **103**:

| probe | asserts |
|---|---|
| `A05-slicer-minted` | a ticket carries a link credential at all |
| `A01-slicer-anon` | an anonymous fetch of model bytes is still 401 |
| `A01-slicer-ok` | a minted link fetches the model it names |
| `A01-slicer-bound` | and cannot be pointed at a different model |
| `A02-slicer-signature` | a tampered credential is refused |
| `A02-slicer-garbage` | so is something that is not a token |

`A01-slicer-bound` aims the token at a story the printer owner **may** read by session, so it fails if the binding ever stops being enforced independently of scope.

All seven `verify:` suites green, plus typecheck, `check:secrets`, `check:links`.

Worth noting: the first `A01-slicer-ok` failed and it was the probe's fault — it minted off a synthetic row with an invented storage key, so the fetch 502'd at the object store long after auth had succeeded. It was testing the wrong layer. Repointed at a story with real bytes.

## After merging

Deploying is still a manual wizard run on the NAS — merging does not deploy. And on the machine with the helper:

```bash
sed -i '/^PPP_TOKEN=/d' ~/.config/ppp/slicer.conf
```

Not required (the fallback keeps it working), but there is no reason to leave a dead credential on disk.
