### PR TITLE
Make the last three text-shaped controls look like buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Fixed
+
+- **The last three controls that looked like text.** After the withdraw button
+  on a ticket was made visible, three siblings were left drawn the old way —
+  a transparent border and muted grey, or a plain underline — so they read as
+  captions rather than controls. All three are now buttons in the shapes the
+  app already uses, and each carries the weight of what it does: the
+  feature-request **Withdraw** is now identical to the print one it shares a
+  label with (an underlined link before, which made the two backlogs look
+  different for no reason); **Forgotten password?** on the guest list is
+  neutral, because it mints a recovery link and takes nothing away, and the
+  list draws one per member; **Revoke access?** carries the same cherry as the
+  other destructive controls, while its **Suspended** state takes the amber the
+  tokens reserve for warnings — it reports a state *and* is the way back, and
+  red would read as a threat rather than a flag. Confirmation steps and wording
+  are unchanged throughout: these actions should be hard to fire by accident,
+  not hard to find.
+
 ### Added
 
 - **Download the model.** Every ticket now has a plain **Download** button

--- a/src/app/frr/[id]/page.tsx
+++ b/src/app/frr/[id]/page.tsx
@@ -176,7 +176,11 @@ export default async function FeaturePage({
           <form action={withdrawFeature} className="mt-[13.2px]">
             <input type="hidden" name="id" value={feature.id} />
             <details className="group">
-              <summary className="inline-block cursor-pointer list-none font-mono text-[12px] font-bold uppercase tracking-[0.06em] text-ink-3 underline underline-offset-4 hover:text-cherry-dk">
+              {/* The same button as the print track's withdraw, deliberately:
+                  identical label, identical shape. The 'frr' backlog mirrors
+                  the print one, and a control that reads as a link on one and
+                  a button on the other would be the seam showing. */}
+              <summary className="stamp inline-block cursor-pointer list-none rounded-chip border-[3px] border-ink bg-cherry-wash px-[15px] py-[8px] text-[14px] font-bold text-cherry-dk hover:bg-cherry-dk hover:text-cream">
                 Withdraw this request
               </summary>
               <div className="mt-[8.8px] rounded-card border-[3px] border-ink bg-cream-2 p-[13.2px]">
@@ -185,7 +189,7 @@ export default async function FeaturePage({
                 </p>
                 <button
                   type="submit"
-                  className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-cherry-wash"
+                  className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[15px] py-[8px] text-[14px] font-bold text-cream hover:bg-cherry"
                 >
                   Yes, withdraw it
                 </button>

--- a/src/components/member-access.tsx
+++ b/src/components/member-access.tsx
@@ -47,7 +47,19 @@ export function MemberAccess({
 
   return (
     <details>
-      <summary className="inline-block cursor-pointer list-none rounded-chip border-[3px] border-transparent px-[13.2px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink-2 hover:border-ink hover:bg-cream-2">
+      {/* Two states, and they want opposite colours. "Revoke access?" locks a
+          colleague out, so it carries the same cherry as the other destructive
+          controls. "Suspended" is doing double duty — it reports a state and it
+          is the way back — and red would read as a threat rather than a flag,
+          so it takes the amber the tokens reserve for warnings. Both are
+          buttons either way; neither used to look like one. */}
+      <summary
+        className={
+          suspended
+            ? "stamp inline-block cursor-pointer list-none rounded-chip border-[3px] border-ink bg-sun-wash px-[15px] py-[8px] text-[14px] font-bold text-sun-dk hover:bg-sun hover:text-ink"
+            : "stamp inline-block cursor-pointer list-none rounded-chip border-[3px] border-ink bg-cherry-wash px-[15px] py-[8px] text-[14px] font-bold text-cherry-dk hover:bg-cherry-dk hover:text-cream"
+        }
+      >
         {suspended ? "Suspended" : "Revoke access?"}
       </summary>
       <form action={formAction} className="mt-[8px] max-w-[560px]">

--- a/src/components/reset-password.tsx
+++ b/src/components/reset-password.tsx
@@ -46,7 +46,11 @@ export function ResetPassword({
 
   return (
     <details>
-      <summary className="inline-block cursor-pointer list-none rounded-chip border-[3px] border-transparent px-[13.2px] py-[6px] font-mono text-[11.5px] font-bold uppercase text-ink-2 hover:border-ink hover:bg-cream-2">
+      {/* Neutral rather than red. This mints a recovery link — it takes
+          nothing away — and the guest list draws one of these per member, so a
+          row of red buttons would shout about the wrong thing. The weight sits
+          on the confirm inside, where it belongs. */}
+      <summary className="stamp inline-block cursor-pointer list-none rounded-chip border-[3px] border-ink bg-porcelain px-[15px] py-[8px] text-[14px] font-bold text-ink hover:bg-sun">
         Forgotten password?
       </summary>
       <form action={formAction} className="mt-[8px] max-w-[560px]">


### PR DESCRIPTION
Finishes what #39 started. Three siblings were still drawn the old way — a transparent border and muted grey, or a plain underline — so they read as captions rather than controls.

| control | was | now | why that colour |
|---|---|---|---|
| `/frr/[id]` **Withdraw this request** | underlined text link | cherry, **identical to the print withdraw** | it shares a label with the control fixed in #39 |
| **Forgotten password?** | invisible | neutral porcelain | mints a recovery link, takes nothing away — and the list draws one per member |
| **Revoke access?** | invisible | cherry | it locks a colleague out |
| ⤷ its **Suspended** state | invisible | sun-wash (amber) | reports a state *and* is the way back; red would read as a threat, not a flag |

## The one that mattered most

After #39, the app had **two identically-named "Withdraw this request" controls in two different styles** — a button on the print track, an underlined link on the feature track. The two backlogs are deliberately built to look the same (`docs/feature-requests.md`: *"The shape is identical, which is what makes the owner handle a request exactly as they handle a print"*), so that difference was the seam showing. Its confirm also moved to the filled cherry the print one uses, so the escalation now reads the same on both tracks.

## Contrast

Checked against the tokens rather than assumed:

- cherry-dark on cherry-wash — **5.1:1**
- sun-dark on sun-wash — **4.9:1**

Both clear AA at these sizes. No new tokens were added; everything here already existed in the palette.

## Unchanged on purpose

Every confirmation step and all of its wording. These actions should be hard to **fire** by accident, not hard to **find** — only the second was ever broken, and the disclosures still ask.

## Verification

`verify:frr` (70), `verify:auth` and the 103 probes all pass. None of them matches on styling, so they exercise exactly the paths they did before.

Each state was looked at in a real browser rather than assumed — including the suspended one, which needed a suspended member to render at all.
