### PR TITLE
Install the slicer helper where a branch cannot move it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Fixed
+
+- **"Open in PrusaSlicer" no longer depends on which branch is checked out.**
+  The `.desktop` entry named `scripts/prusa-open.sh` where it sits in the git
+  working tree, so the button quietly broke whenever that path stopped
+  resolving to the current handler — check out anything cut before the handler
+  landed and the file is gone, the click does nothing, and nothing says why.
+  It bit twice. The installer now copies the helper to `~/.local/bin/ppp-open`
+  and points the entry at that, which severs the dependency for one `cp`. The
+  trade is that the copy does not update itself: re-run the installer after a
+  `git pull`, which is safe at any time and leaves an existing config alone.
+  Existing setups are fixed by re-running it.
+
 ### Added
 
 - **Download the model.** Every ticket now has a plain **Download** button

--- a/docs/prusaslicer.md
+++ b/docs/prusaslicer.md
@@ -50,9 +50,9 @@ of this repo:
 ./scripts/install-slicer-handler.sh
 ```
 
-That registers `ppp://` links to open with
-[`scripts/prusa-open.sh`](../scripts/prusa-open.sh), and creates
-`~/.config/ppp/slicer.conf` (mode `600`) for you to fill in:
+That copies [`scripts/prusa-open.sh`](../scripts/prusa-open.sh) to
+`~/.local/bin/ppp-open`, registers `ppp://` links to open with **that copy**,
+and creates `~/.config/ppp/slicer.conf` for you to fill in:
 
 ```sh
 PPP_BASE="https://print.example"      # your instance, no trailing slash
@@ -62,6 +62,27 @@ PPP_BASE="https://print.example"      # your instance, no trailing slash
 
 That is the whole config: **there is no token to paste.** The clicked link
 carries its own credential.
+
+### Why a copy, and what to do after a `git pull`
+
+The handler is installed as a **copy** at `~/.local/bin/ppp-open`, and the
+`.desktop` entry points there rather than into this checkout.
+
+It used to point at `scripts/prusa-open.sh` where it sits in the working tree,
+which quietly made the button depend on which branch was checked out. Check out
+anything cut before the handler landed and the file is simply gone: the click
+does nothing, and nothing anywhere says why. That is the worst failure mode this
+whole helper is written to avoid, and it bit twice before the copy went in.
+
+The trade is that the copy does not update itself. **After pulling changes,
+re-run the installer** — it overwrites the copy, and that is the only step:
+
+```bash
+git pull && ./scripts/install-slicer-handler.sh
+```
+
+Running it again is safe at any time. It leaves an existing `slicer.conf`
+alone.
 
 ### Finding the slicer
 
@@ -148,6 +169,7 @@ indistinguishable from one that was never wired up. Common lines:
 | It says | Means |
 | --- | --- |
 | `no config at …` | The installer has not run, or `$PPP_SLICER_CONF` points elsewhere. |
+| nothing at all happens, no log line | The handler is not where the `.desktop` says. If you set this up before the copy landed, it still points into the checkout — re-run the installer. |
 | `that link has expired (HTTP 401)` | Links last half an hour. Open the ticket again and click the button. |
 | `the PPP_TOKEN in … is expired` | You are on the old config-token path. Delete the line and click the button in the app — see *If you set this up before*. |
 | `that link carries no credential and … sets no PPP_TOKEN` | An old bookmark, on a config with no token. Open the ticket in the app and click there. |

--- a/scripts/install-slicer-handler.sh
+++ b/scripts/install-slicer-handler.sh
@@ -8,8 +8,8 @@
 #
 # What it does, all under your own home directory — nothing system-wide, no
 # sudo:
-#   1. writes a .desktop entry into ~/.local/share/applications that points at
-#      this checkout's prusa-open.sh by absolute path;
+#   1. copies prusa-open.sh to ~/.local/bin/ppp-open, and writes a .desktop
+#      entry into ~/.local/share/applications pointing at *that copy*;
 #   2. makes it the default handler for the x-scheme-handler/ppp MIME type;
 #   3. creates ~/.config/ppp/slicer.conf (mode 600) for you to fill in, if it
 #      is not already there.
@@ -27,9 +27,27 @@ case "$(uname -s)" in
 esac
 
 here="$(cd "$(dirname "$0")" && pwd)"
-handler="$here/prusa-open.sh"
-[ -f "$handler" ] || { echo "prusa-open.sh is not beside this installer ($handler)" >&2; exit 1; }
+source_handler="$here/prusa-open.sh"
+[ -f "$source_handler" ] || { echo "prusa-open.sh is not beside this installer ($source_handler)" >&2; exit 1; }
+
+# Install a COPY, and point the .desktop at that rather than at the checkout.
+#
+# The entry used to name this script where it sits in the working tree, which
+# quietly made the button depend on which branch happened to be checked out:
+# switch to anything cut before the handler landed and the file is gone, the
+# click does nothing, and nothing anywhere says why. That is not hypothetical —
+# it has bitten twice, most recently when the file was there but was a different
+# version than the deployed app expected.
+#
+# A copy costs one `cp` and severs the dependency entirely. It is overwritten on
+# every run, so re-running after a `git pull` is how you update the helper — and
+# the closing message says so.
+bin_dir="$HOME/.local/bin"
+handler="$bin_dir/ppp-open"
+mkdir -p "$bin_dir"
+cp "$source_handler" "$handler"
 chmod +x "$handler"
+echo "installed $handler"
 
 apps_dir="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
 desktop="$apps_dir/ppp-slicer.desktop"
@@ -111,6 +129,10 @@ fi
 echo
 echo "Done. Set PPP_BASE in $conf, then click 'Open in PrusaSlicer' on any"
 echo "ticket. No token to paste — the link carries its own."
+echo
+echo "The helper is a copy at $handler, so the button does not care which"
+echo "branch this checkout is on. After a git pull, re-run this installer to"
+echo "update it."
 if [ -f "$conf" ] && grep -q '^[[:space:]]*PPP_TOKEN=' "$conf" 2>/dev/null; then
   echo
   echo "NOTE: $conf still sets PPP_TOKEN. That was the old way in and it is a"


### PR DESCRIPTION
## The failure

The `.desktop` entry named `scripts/prusa-open.sh` **where it sits in the git working tree**:

```
Exec=/home/danileau/work/ppp/scripts/prusa-open.sh %u
```

So "Open in PrusaSlicer" quietly depended on which branch happened to be checked out. Check out anything cut before the handler landed and the file is gone — the click does nothing, no log line is written, and nothing anywhere says why. That is indistinguishable from *"never installed"*, which is the one failure mode this helper is written to avoid; it goes to some length to make every other refusal loud.

**It has bitten twice.** Once when switching off a feature branch removed the file outright. Again, more subtly, during #40: the file was present but was a *newer* version than the deployed app was serving links for.

## The fix

The installer copies the helper to `~/.local/bin/ppp-open` and points the entry at the copy. One `cp`, and the dependency is severed.

```
Exec=$HOME/.local/bin/ppp-open %u
```

## The trade, and how it is handled

A copy does not update itself. So it is overwritten on **every** run, and re-running after a pull is how you update it:

```bash
git pull && ./scripts/install-slicer-handler.sh
```

Running it again is safe at any time and leaves an existing `slicer.conf` alone. The closing message says this, `docs/prusaslicer.md` has a section on it, and there is a new troubleshooting row for the symptom — *nothing at all happens, no log line* — pointing at exactly this.

**Existing setups are fixed by re-running the installer.** Anyone who set this up before the copy landed still has an entry pointing into a checkout.

## Verification

Exercised against a **throwaway `HOME`** rather than the real desktop, so nothing on the developer machine was modified — confirmed afterwards that the real `.desktop` and `~/.local/bin` were untouched.

| checked | result |
|---|---|
| helper installed | `~/.local/bin/ppp-open`, executable |
| is it a real copy | `diff -q` against the source — identical |
| what `Exec=` names | the copy, not the checkout |
| config skeleton | still carries no credential (#40) |
| re-runnable | yes; overwrites the copy, leaves the config |
