### PR TITLE
Point the Feature requests nav at the board, not the triage queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Changed
+
+- **"Feature requests" in the nav, and it goes to the board.** The owner's nav
+  item was labelled *Requests* and pointed at `/frr/queue`, the triage view —
+  so the owner's way in was the work list while everyone else's was the board.
+  It now reads **Feature requests** for both roles and points at `/frr`, which
+  is the print track's shape (the board is the shared view; triage is a step
+  off it). Triage did not become unreachable: `/frr` grows a **Triage** button
+  for the owner, since nothing else in the app linked to it, and the nav item
+  stays lit while you are there.
+
 ### Added
 
 - **Download the model.** Every ticket now has a plain **Download** button

--- a/src/app/frr/page.tsx
+++ b/src/app/frr/page.tsx
@@ -61,12 +61,25 @@ export default async function FeatureBoardPage({
               stages a print goes through. {owner} sees each one and moves it along.
             </p>
           </div>
-          <Link
-            href="/frr/new"
-            className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[22px] py-[11px] text-[15px] font-bold text-cream hover:bg-cherry"
-          >
-            + New request
-          </Link>
+          <div className="flex flex-wrap items-center gap-[8.8px]">
+            {/* The owner's triage view. The nav points at this board rather
+                than at the queue, so without this the queue would be reachable
+                only by typing the URL. */}
+            {isAdmin && (
+              <Link
+                href="/frr/queue"
+                className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-porcelain px-[18px] py-[11px] text-[15px] font-bold text-ink hover:bg-sun"
+              >
+                Triage
+              </Link>
+            )}
+            <Link
+              href="/frr/new"
+              className="stamp cursor-pointer rounded-chip border-[3px] border-ink bg-cherry-dk px-[22px] py-[11px] text-[15px] font-bold text-cream hover:bg-cherry"
+            >
+              + New request
+            </Link>
+          </div>
         </div>
 
         <FeatureFilterBar action="/frr" filter={filter} />

--- a/src/app/frr/queue/page.tsx
+++ b/src/app/frr/queue/page.tsx
@@ -48,7 +48,7 @@ export default async function FeatureQueuePage({
 
   return (
     <>
-      <AppHeader user={admin} active="/frr/queue" />
+      <AppHeader user={admin} active="/frr" />
 
       <main className="mx-auto w-full max-w-[1180px] px-[26.4px] pb-[80px] pt-[35.2px]">
         <Kicker>Feature requests</Kicker>

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -22,14 +22,16 @@ const NAV: Record<Actor["role"], Array<{ label: string; href: string }>> = {
     { label: "Order up", href: "/upload" },
     { label: "My orders", href: "/me" },
     { label: "History", href: "/history" },
-    { label: "Requests", href: "/frr" },
+    { label: "Feature requests", href: "/frr" },
   ],
   admin: [
     { label: "The pass", href: "/queue" },
     { label: "The rail", href: "/board" },
     { label: "The books", href: "/me" },
     { label: "History", href: "/history" },
-    { label: "Requests", href: "/frr/queue" },
+    // The board, not the triage queue: the owner wants to see everything that
+    // has been asked for, and triage is one button away on that page.
+    { label: "Feature requests", href: "/frr" },
     { label: "Benefits", href: "/admin/benefits" },
     { label: "Guest list", href: "/admin/invites" },
     { label: "Audit", href: "/admin/audit" },


### PR DESCRIPTION
## What changed

Both roles' nav item now reads **Feature requests** and points at `/frr`.

Before, the owner's item was labelled *Requests* and pointed at `/frr/queue` — so the owner's way into the feature track was the work list, while everyone else's was the board. That is not the shape the print track uses: *The rail* is the shared board and *The pass* is the owner's queue **beside** it, both present.

## Two things that would otherwise have broken quietly

**Triage would have been orphaned.** Nothing else in the app linked to `/frr/queue` — I grepped. Repointing the nav alone would have left it reachable only by typing the URL, so `/frr` now carries a **Triage** button for the owner.

**Nothing would have been lit.** `active` is an exact href match (`app-header.tsx:86`), so the queue page passing `active="/frr/queue"` would have matched no nav item at all once that href was gone. It passes `"/frr"` now, and the item stays lit while triaging.

## Verification

`verify:frr` passes unchanged (70).

Rendering checked against the **served HTML** rather than a hydrated DOM, on three pages:

| | `/frr` | `/frr/queue` | `/board` |
|---|---|---|---|
| label present | ✅ | ✅ | — |
| Triage button | ✅ | — *(already there)* | — |
| `aria-current` count | 1 → `/frr` | 1 → `/frr` | 1 → `/board` |

Worth noting for anyone reading the server log during the suite: `verify:frr` deliberately makes bare POSTs with no action id (`verify-frr.ts:225`, `:301`) to prove a raw POST cannot drive a state change. Next answering *"Failed to find Server Action"* is that check passing, not a fault.
