### PR TITLE
Accept models up to 250 MB, and fix the limit that was never real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ Notable changes. Every entry names a released version; deployments pin
   match — see `docs/deployment.md`. That had never bitten before, because
   nothing large enough had ever reached the proxy.
 
+- **The viewer declines models it cannot rebuild, and explains itself.** A
+  250 MB cap makes it possible to store a model five times larger than a
+  browser can handle, and the viewer's first act is to download the whole
+  thing — so opening such a ticket would have pulled a quarter of a gigabyte
+  across the office and then frozen the tab. Past 50 MB (`VIEWER_MAX_BYTES`)
+  it now shows why instead: what the viewer downloads and rebuilds, why that
+  does not finish at this size, and the model drawn to scale against the limit
+  with the multiple spelled out, so the number means something. Decided from
+  the stored size **before any fetch is made**. Amber rather than red, because
+  nothing has failed — the file is whole, it prints, and Download and Open in
+  PrusaSlicer are both better suited to a mesh this size than a browser was
+  ever going to be.
+
 ### Changed
 
 - **"Feature requests" in the nav, and it goes to the board.** The owner's nav

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Fixed
+
+- **Uploads over 10 MB never worked, whatever the app said.** Next truncates a
+  request body at 10 MB whenever middleware is in play, and this app runs
+  middleware on every route to mint the CSP nonce. So anything past 10 MB
+  arrived short, `request.formData()` threw on the truncated body, and the
+  person uploading was told *"That upload did not arrive intact"* — which reads
+  like a network fault, while the form and the API documentation both promised
+  50 MB. It survived the whole life of the app because every fixture in every
+  suite is a few hundred bytes, so nothing had ever sent a large file.
+  `middlewareClientMaxBodySize` is now kept in step with the app's own cap, and
+  `verify:upload` sends a 12 MB model on every run so the ceiling cannot come
+  back quietly.
+
+### Added
+
+- **Models up to 250 MB, from 50 MB.** Real work went past the old cap —
+  multi-object plates and scanned meshes — and the app's answer was "decimate
+  the mesh", which is asking somebody to damage their model to fit an arbitrary
+  number. The size, the multipart allowance, the zip-inflation guard and the
+  triangle ceiling now live together in `src/lib/upload-limits.ts`, because the
+  form, the validator, the OpenAPI document and the framework config all have
+  to agree — the upload form had grown its own copy of the limit, the extension
+  list *and* `formatBytes`, so raising the cap used to mean finding five places.
+
+  The cap is made safe by a **queue rather than a stream**: at most two uploads
+  are handled at once, a third waits rather than being refused, and only a long
+  queue gets a 503. `request.formData()` buffers the whole body before this
+  app's code runs, so overlap is what sets peak memory and bounding the overlap
+  is what bounds it. That is one of the two answers the security audit named;
+  the other, a streaming parse, needs the file to stop arriving as multipart
+  and is written up in `docs/architecture.md`.
+
+  Deployments behind a reverse proxy need `client_max_body_size` raised to
+  match — see `docs/deployment.md`. That had never bitten before, because
+  nothing large enough had ever reached the proxy.
+
 ### Changed
 
 - **"Feature requests" in the nav, and it goes to the board.** The owner's nav

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ that: there is no multi-tenancy, no billing, and no queue theory.
 | --- | --- |
 | Host | anything that runs Docker Compose — a NAS, a Pi 5, a VPS, a spare laptop |
 | Memory | ~1 GB for the whole stack (app, Postgres, MinIO) |
-| Disk | small — the database is megabytes; uploads are capped at 50 MB each |
+| Disk | small — the database is megabytes; uploads are capped at 250 MB each |
 | TLS | **required.** The app refuses to start on plain `http://` in production, and passkeys need a secure context |
 | Mail | **optional.** Nothing needs it — see [Mail is optional](docs/authentication.md#mail-is-optional--genuinely) |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,7 +104,7 @@ browser being driven by somebody else's page. A request with the wrong one is
 `403`.
 
 **5. Uploads are multipart, and the bytes decide.** `.stl` and `.3mf` only, at
-most 50 MB, validated against the file's actual content rather than its name —
+most 250 MB, validated against the file's actual content rather than its name —
 an STL renamed `.3mf` is refused. Nothing reaches storage until the file has
 been inspected and no ticket exists until the object is in place, so a rejected
 upload leaves nothing behind. The uploader comes from the session: an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,20 @@ cool rim behind. It reads well on filament colours from near-black to bone
 white, which is the whole job. The ground and grid moved to this palette,
 because the print bed should look like the app it sits in.
 
+It declines anything over **50 MB** (`VIEWER_MAX_BYTES`) and says so, with the
+model's size drawn against that limit so "180 MB" means something. That is not
+a limit on what may be uploaded — the cap is 250 MB — it is a limit on what a
+laptop can be asked to rebuild: the viewer downloads the whole file and expands
+every triangle into typed arrays, and past that size the tab stops answering
+for long enough that people assume the app has broken.
+
+The decision is made from the stored `fileSize`, **before anything is fetched**.
+That ordering is the point: a check after the download would still have pulled
+a quarter of a gigabyte across the office and only then given up. The refusal
+is amber rather than red because nothing has failed — the file is whole, it
+prints, and Download and Open in PrusaSlicer are both built for meshes this
+size where a browser is not.
+
 Three details worth knowing:
 
 - **The bytes are proxied, not signed.** `/api/models/[id]` streams from

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ Three details worth knowing:
 - **three.js is imported dynamically**, inside the effect. It is fetched when
   someone opens a ticket and never on the board or the queue.
 
-The trade: every viewer load moves the whole file through Next. At 50 MB and a
+The trade: every viewer load moves the whole file through Next. At 250 MB and a
 handful of people that is fine. If this ever faces a wider audience, put
 storage behind the same reverse proxy, hand out a signed URL, and widen
 `connect-src` to that origin.
@@ -38,7 +38,7 @@ storage behind the same reverse proxy, hand out a signed URL, and widen
 ## Uploads
 
 `POST /api/upload` is a route handler rather than a server action, so the
-browser can watch a real XHR progress bar — a 50 MB model over office wifi is
+browser can watch a real XHR progress bar — a large model over office wifi is
 too long for a spinner.
 
 Nothing is written to storage until the bytes have been inspected, and no
@@ -67,6 +67,49 @@ attribute. Nothing is inferred beyond that — see the estimate decision above.
 `npm run verify:models` covers all of this with 29 checks, including a PDF and
 an ELF binary renamed `.stl`, an STL that lies about its triangle count, a
 traversal path inside a 3MF, and a zip bomb.
+
+### How big a model may be, and the limit that was not real
+
+The cap is **250 MB**, raised from the handoff's 50 MB because real work went
+past it — multi-object plates and scanned meshes — and the app's answer was
+"decimate the mesh", which is asking somebody to damage their model to fit an
+arbitrary number.
+
+Raising it turned up something worse: **the 50 MB was never real either.** Next
+truncates a request body at 10 MB whenever middleware is in play, and this app
+runs middleware on every route to mint the CSP nonce. Anything past 10 MB
+arrived short, `request.formData()` threw on the truncated body, and the
+uploader was told *"That upload did not arrive intact"* — which reads like a
+network fault and sends people to look in the wrong place. It survived the
+whole life of the app because every fixture in every suite is a few hundred
+bytes; nothing had ever uploaded a big file. `verify:upload` now sends a 12 MB
+model on every run, which is the cheapest thing that would have caught it.
+
+Three numbers, in `src/lib/upload-limits.ts`, deliberately in one place because
+the form, the validator, the OpenAPI document and the framework config all need
+to agree:
+
+| | |
+| --- | --- |
+| `MAX_UPLOAD_BYTES` | 250 MB — the file itself |
+| `MAX_REQUEST_BYTES` | `× 1.2` — the whole multipart body, and the transport ceiling. It has to be the more generous of the two, or a file just over the cap gets truncated into a parse error instead of an honest "too large" |
+| `MAX_INFLATED_BYTES` | `× 3` — what a 3MF may inflate to, scaled off the cap so raising one cannot leave the other behind |
+
+### Why the memory is bounded by a queue rather than a stream
+
+`request.formData()` buffers the entire body before a line of this app's code
+runs, so peak memory is decided by how many large uploads overlap — not by
+anything the validator does. The security audit named the two answers: a
+streaming parse, or a size-based queue. This is the queue: at most two uploads
+are handled at once (`MAX_CONCURRENT_UPLOADS`), a third waits rather than being
+refused, and only a long queue gets a `503`.
+
+The streaming parse is the better answer and it is not reachable from here. It
+needs the file to stop arriving as multipart at all — a raw body with the wish
+in a header, or a two-phase upload — because by the time a route handler can
+see the request, the framework has already buffered it. That is a protocol
+change touching the form, the API, the OpenAPI document and two suites, and it
+is worth doing the day the queue is the thing that hurts.
 
 ## Decisions taken against the handoff
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -195,6 +195,28 @@ Rollback is the same menu: pick the older tag.
 The app publishes no host port, so `ppp-app:3000` over the shared network is
 the only way in. Nothing on the LAN can reach it in cleartext and bypass TLS.
 
+### Your proxy has to allow the upload size too
+
+The app accepts models up to **250 MB**, and a reverse proxy in front of it has
+its own opinion about request bodies. Nginx Proxy Manager's default
+`client_max_body_size` is small, and when it bites, the upload fails at the
+proxy — so the app logs nothing at all and the browser shows a generic error.
+
+In NPM: the proxy host → *Advanced* → add
+
+```nginx
+client_max_body_size 300m;
+```
+
+300, not 250: a multipart body is the file plus its boundaries and the form
+fields, so a maximum-sized model arrives as a slightly larger request. The app
+uses the same allowance internally (`MAX_REQUEST_BYTES`).
+
+Worth knowing that this was never exercised before: the framework itself capped
+bodies at 10 MB until that was raised, so no upload large enough to reach the
+proxy's limit had ever been sent. If uploads used to work and large ones now
+fail with nothing in the app log, this is the first place to look.
+
 ### Why `TRUST_PROXY_HEADERS` is a separate switch
 
 The audit trail records the client address, and that address comes from

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -479,10 +479,22 @@ README now says.
   gates it, but the download route lands with the 3D viewer. When it does,
   `connect-src` has to widen to the storage origin — it is `'self'` today,
   which will block the fetch.
-- **The upload buffers the whole file in memory** to measure its bounding
-  box. That is inherent to computing the box, and fine at 50 MB for five
-  people, but it is a denial-of-service lever if this ever faces a wider
-  audience. A streaming parse, or a size-based queue, is the answer then.
+- **The upload buffers the whole file in memory**, and now at a 250 MB cap
+  rather than 50 MB. The buffering is not the validator's doing —
+  `request.formData()` has already read the whole body before the route handler
+  runs — so peak memory is set by how many large uploads overlap. Of the two
+  answers named here originally, the **size-based queue** is now in place: at
+  most two uploads are handled at once, a third waits, and only a long queue is
+  refused. That bounds the exposure at roughly two concurrent uploads' worth
+  rather than however many arrive together. The streaming parse remains
+  unbuilt, and cannot be built without changing how the file arrives — see
+  [architecture](architecture.md#why-the-memory-is-bounded-by-a-queue-rather-than-a-stream).
+
+  Raising the cap also uncovered that the old one was never enforced as
+  advertised: Next truncates a request body at 10 MB when middleware is
+  present, so uploads between 10 and 50 MB had been failing with a parse error
+  dressed as a network fault. `verify:upload` now sends a 12 MB model on every
+  run.
 - ~~Print-time estimates~~ — removed rather than kept. The app now shows only
   what it measured. See the README for the reasoning and the path to a real
   slicer-derived figure.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+import { MAX_REQUEST_BYTES } from "./src/lib/upload-limits";
+
 const isProd = process.env.NODE_ENV === "production";
 
 // The CSP is per-request (it carries a nonce) and therefore lives in
@@ -41,6 +43,24 @@ const nextConfig: NextConfig = {
   output: "standalone",
   poweredByHeader: false,
   serverExternalPackages: ["@prisma/client", "nodemailer"],
+  experimental: {
+    /**
+     * Let an upload actually be as large as the app says it is.
+     *
+     * Next caps a request body at 10 MB whenever middleware is in play, and
+     * this app runs middleware on everything (it mints the CSP nonce). So the
+     * advertised 50 MB limit was never real: anything past 10 MB was truncated
+     * before the route handler saw it, `request.formData()` threw on the short
+     * body, and the uploader was told "That upload did not arrive intact" —
+     * which reads like a network problem and sent people looking in the wrong
+     * place. Found by uploading a 20 MB file, which no suite had ever done.
+     *
+     * Kept in step with the validator's own cap rather than written out
+     * separately, because two numbers that must agree and live apart do not
+     * stay agreeing.
+     */
+    middlewareClientMaxBodySize: MAX_REQUEST_BYTES,
+  },
   async headers() {
     return [{ source: "/:path*", headers: securityHeaders }];
   },

--- a/scripts/verify-upload.ts
+++ b/scripts/verify-upload.ts
@@ -121,6 +121,33 @@ function binaryStl(x: number, y: number, z: number): Uint8Array {
   return buf;
 }
 
+/**
+ * A valid binary STL of roughly `mb` megabytes.
+ *
+ * Exists for exactly one check: that an upload larger than Next's default
+ * 10 MB body ceiling survives the trip. Every other fixture here is a few
+ * hundred bytes, which is why nothing noticed that ceiling for the whole life
+ * of the app while the UI advertised 50 MB.
+ */
+function stlOfSize(mb: number): Uint8Array {
+  const triangles = Math.floor((mb * 1024 * 1024 - 84) / 50);
+  const buf = new Uint8Array(84 + triangles * 50);
+  const view = new DataView(buf.buffer);
+  view.setUint32(80, triangles, true);
+  let off = 84;
+  for (let i = 0; i < triangles; i++) {
+    // Spread the vertices so the mesh has a real bounding box to measure.
+    for (let v = 0; v < 3; v++) {
+      const b = off + 12 + v * 12;
+      view.setFloat32(b, i % 97, true);
+      view.setFloat32(b + 4, (i * 7) % 97, true);
+      view.setFloat32(b + 8, (i * 13) % 97, true);
+    }
+    off += 50;
+  }
+  return buf;
+}
+
 function upload(b: Browser, filename: string, bytes: Uint8Array, fields: Record<string, string> = {}) {
   const form = new FormData();
   form.set("file", new File([bytes as BlobPart], filename));
@@ -224,6 +251,30 @@ async function main() {
   check("an audit event was written",
         (await db.auditEvent.count({ where: { action: "story.created", actorId: ayla.id } })) === 1);
 
+  // ------------------------------------------------------------------
+  section("a model larger than the framework's default body limit");
+  /*
+   * Next truncates a request body at 10 MB whenever middleware is in play, and
+   * this app runs middleware on every route to mint the CSP nonce. So anything
+   * past 10 MB arrived short, `request.formData()` threw on it, and the
+   * uploader was told the upload "did not arrive intact" — which reads like a
+   * network fault. The limit is raised in next.config.ts, kept in step with
+   * MAX_UPLOAD_BYTES.
+   *
+   * Twelve megabytes: comfortably past the old ceiling, cheap enough to run
+   * every time. Without this the ceiling can come back silently, exactly as it
+   * arrived.
+   */
+  const chunky = stlOfSize(12);
+  const bigRes = await upload(aylaB, "twelve-megabytes.stl", chunky);
+  check("a 12 MB model is accepted", bigRes.status === 200,
+        `status ${bigRes.status} ${(await bigRes.clone().text()).slice(0, 120)}`);
+  const bigStory = await db.story.findFirst({ where: { filename: "twelve-megabytes.stl" } });
+  check("and it is stored at its full size",
+        bigStory?.fileSize === chunky.length,
+        `stored ${bigStory?.fileSize} of ${chunky.length} bytes`);
+
+  // ------------------------------------------------------------------
   section("bad files are refused, and leave nothing behind");
 
   const before = await db.story.count();

--- a/scripts/verify-upload.ts
+++ b/scripts/verify-upload.ts
@@ -274,6 +274,42 @@ async function main() {
         bigStory?.fileSize === chunky.length,
         `stored ${bigStory?.fileSize} of ${chunky.length} bytes`);
 
+  /*
+   * The viewer declines anything past what a browser can rebuild, and says so.
+   *
+   * Raising the upload cap to 250 MB made it possible to store a model five
+   * times larger than the viewer can cope with, and the viewer's first act is
+   * to download the whole thing — so without this guard, opening a big ticket
+   * pulled a quarter of a gigabyte across the office and then froze the tab.
+   *
+   * `fileSize` is nudged past the threshold rather than a 60 MB file being
+   * uploaded for real: the guard reads the recorded size and nothing else, and
+   * a suite that spent a minute generating geometry to prove it would not be
+   * run. Asserted against the served HTML, because the decision is made during
+   * render and a hydrated DOM read can false-negative.
+   */
+  const viewerStory = await db.story.findFirst({ where: { filename: "twelve-megabytes.stl" } });
+  await db.story.update({
+    where: { id: viewerStory!.id },
+    data: { fileSize: 180 * 1024 * 1024 },
+  });
+  const guarded = await (await aylaB.go(`${APP}/story/${viewerStory!.id}`)).text();
+  check("an oversized model is not offered to the viewer",
+        guarded.includes("too big to spin in a browser"),
+        "the viewer would have tried to download and rebuild it");
+  check("and the page says how far past the line it is",
+        guarded.includes("180.0 MB") && guarded.includes("3.6"),
+        "no comparison against what a browser handles");
+  // Put the real size back, and the same ticket previews again — so the check
+  // above is about the threshold and not about that particular story.
+  await db.story.update({
+    where: { id: viewerStory!.id },
+    data: { fileSize: chunky.length },
+  });
+  const unguarded = await (await aylaB.go(`${APP}/story/${viewerStory!.id}`)).text();
+  check("while the same model under the threshold still previews",
+        !unguarded.includes("too big to spin in a browser"));
+
   // ------------------------------------------------------------------
   section("bad files are refused, and leave nothing behind");
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
 import { currentUser, notify, printerOwner, storyRef } from "@/lib/authz";
+import type { Actor } from "@/lib/scope";
 import { record } from "@/lib/audit";
 import { WishSchema, hexForColor } from "@/lib/catalog";
 import { activeBenefitLabels } from "@/lib/benefits";
@@ -12,13 +13,18 @@ import {
   inspectModel,
   safeFilename,
 } from "@/lib/models";
+import {
+  MAX_CONCURRENT_UPLOADS,
+  MAX_QUEUED_UPLOADS,
+  MAX_REQUEST_BYTES,
+} from "@/lib/upload-limits";
 import { MIME_FOR, ensureBucket, putModel, storageKeyFor } from "@/lib/storage";
 
 /**
  * Model upload.
  *
  * A route handler rather than a server action, for one reason: the browser
- * can watch a real XHR upload progress bar against this, and a 50 MB file
+ * can watch a real XHR upload progress bar against this, and a large model
  * over office wifi is long enough that a spinner is not good enough.
  *
  * Order matters here. Nothing is written to storage until the bytes have
@@ -28,7 +34,8 @@ import { MIME_FOR, ensureBucket, putModel, storageKeyFor } from "@/lib/storage";
  */
 
 export const runtime = "nodejs";
-/** The whole file is buffered to measure its bounding box; do not cache. */
+/** The whole file is buffered to measure its bounding box; do not cache. See
+ *  the slot gate below for what keeps that buffering bounded. */
 export const dynamic = "force-dynamic";
 
 let bucketReady: Promise<void> | null = null;
@@ -36,16 +43,75 @@ let bucketReady: Promise<void> | null = null;
 const bad = (status: number, error: string) =>
   NextResponse.json({ error }, { status });
 
+/**
+ * Only so many uploads are handled at once.
+ *
+ * This is what makes a 250 MB cap safe rather than hopeful. `request.formData()`
+ * buffers the whole body before a line of this handler runs, so peak memory is
+ * decided by how many large uploads overlap — nothing the validator does can
+ * change that. Bounding the overlap bounds the memory, which is the "size-based
+ * queue" the security audit named as one of the two answers. (The other,
+ * a streaming parse, needs the file to stop arriving as multipart at all; see
+ * docs/architecture.md.)
+ *
+ * A late arrival waits rather than being refused: somebody who has just spent a
+ * minute pushing 200 MB up office wifi should not be told to start again. Only
+ * once the queue itself is long does the app say no, because at that point the
+ * honest answer is that it is busy.
+ *
+ * Per process. A second app instance has its own gate, which is the right
+ * shape anyway — the memory it is protecting is also per process.
+ */
+let active = 0;
+const waiting: Array<() => void> = [];
+
+function acquireSlot(): Promise<boolean> {
+  if (active < MAX_CONCURRENT_UPLOADS) {
+    active++;
+    return Promise.resolve(true);
+  }
+  if (waiting.length >= MAX_QUEUED_UPLOADS) return Promise.resolve(false);
+  return new Promise<boolean>((resolve) => {
+    waiting.push(() => {
+      active++;
+      resolve(true);
+    });
+  });
+}
+
+function releaseSlot(): void {
+  active--;
+  waiting.shift()?.();
+}
+
 export async function POST(request: Request) {
   const user = await currentUser();
   if (!user) return bad(401, "Sign in first.");
 
-  // Cheap rejection before reading a single byte of the body.
+  // Cheap rejection before reading a single byte of the body. The allowance
+  // over the file cap is multipart's own overhead, and it matches the
+  // transport limit in next.config.ts so that a file just over the cap is
+  // answered "too large" rather than truncated into a parse failure.
   const declared = Number(request.headers.get("content-length") ?? 0);
-  if (declared > MAX_BYTES * 1.1) {
+  if (declared > MAX_REQUEST_BYTES) {
     return bad(413, REJECTION_COPY.too_large);
   }
 
+  // Taken *before* the body is read, because reading it is the expensive part.
+  if (!(await acquireSlot())) {
+    return bad(
+      503,
+      "Too many uploads at once — give it a moment and send it again.",
+    );
+  }
+  try {
+    return await handleUpload(request, user);
+  } finally {
+    releaseSlot();
+  }
+}
+
+async function handleUpload(request: Request, user: Actor) {
   let form: FormData;
   try {
     form = await request.formData();

--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -63,6 +63,7 @@ export default async function StoryPage({
               filename={story.filename}
               colorHex={story.colorHex}
               dims={story.dims}
+              fileSize={story.fileSize}
             />
 
             {/* Both measured from the file itself. Nothing inferred. */}

--- a/src/app/upload/upload-form.tsx
+++ b/src/app/upload/upload-form.tsx
@@ -10,19 +10,18 @@ import {
   MATERIALS,
   QUANTITY_PRESETS,
 } from "@/lib/catalog";
+// The same numbers the server enforces. `models.ts` cannot be imported here —
+// it would pull `fflate` and the mesh parser into the browser bundle — which
+// is why these three used to be copied into this file by hand.
+import {
+  ACCEPTED_EXTENSIONS,
+  MAX_UPLOAD_BYTES,
+  formatBytes,
+} from "@/lib/upload-limits";
 
 /** One owner-managed tip option, passed from the server (see upload/page.tsx). */
 type Benefit = { label: string; preferred: boolean };
 import { Button, Label, Notice } from "@/components/ui";
-
-const MAX_BYTES = 50 * 1024 * 1024;
-const ACCEPTED = [".stl", ".3mf"];
-
-function formatBytes(n: number) {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 type Phase =
   | { kind: "idle" }
@@ -107,18 +106,18 @@ export function UploadForm({
     if (!picked) return setFile(null);
 
     const ext = picked.name.slice(picked.name.lastIndexOf(".")).toLowerCase();
-    if (!ACCEPTED.includes(ext)) {
+    if (!(ACCEPTED_EXTENSIONS as readonly string[]).includes(ext)) {
       setFile(null);
       return setPhase({
         kind: "error",
         message: "Only .stl and .3mf files can be printed here.",
       });
     }
-    if (picked.size > MAX_BYTES) {
+    if (picked.size > MAX_UPLOAD_BYTES) {
       setFile(null);
       return setPhase({
         kind: "error",
-        message: `That file is ${formatBytes(picked.size)} — the limit is 50 MB.`,
+        message: `That file is ${formatBytes(picked.size)} — the limit is ${formatBytes(MAX_UPLOAD_BYTES)}.`,
       });
     }
     setFile(picked);
@@ -145,7 +144,7 @@ export function UploadForm({
     body.set("printSettings", printSettings);
 
     // XHR rather than fetch: it is still the only way to observe upload
-    // progress, and a 50 MB model over office wifi needs a real bar.
+    // progress, and a large model over office wifi needs a real bar.
     const xhr = new XMLHttpRequest();
     xhr.open("POST", "/api/upload");
     xhr.upload.addEventListener("progress", (event) => {
@@ -223,7 +222,7 @@ export function UploadForm({
             ? `Uploading… ${phase.percent}%`
             : file
               ? `${formatBytes(file.size)} · checked on the server when you send it`
-              : "or click to choose a file · 50 MB max"}
+              : `or click to choose a file · ${formatBytes(MAX_UPLOAD_BYTES)} max`}
         </span>
 
         {busy && (

--- a/src/components/model-viewer.tsx
+++ b/src/components/model-viewer.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import type * as THREE from "three";
 
+import { VIEWER_MAX_BYTES, formatBytes } from "@/lib/upload-limits";
+
 /**
  * The real geometry, rotatable. Handoff §4.
  *
@@ -30,17 +32,32 @@ export function ModelViewer({
   filename,
   colorHex,
   dims,
+  fileSize,
 }: {
   storyId: number;
   filename: string;
   colorHex: string;
   /** Used for the text alternative, so the canvas is not a dead end. */
   dims: string | null;
+  /** Measured on upload. Decides whether the preview is attempted at all. */
+  fileSize: number;
 }) {
   const host = useRef<HTMLDivElement>(null);
   const [phase, setPhase] = useState<Phase>({ kind: "loading" });
 
+  /*
+   * Decided from the stored size, before anything is fetched.
+   *
+   * The order matters: the viewer's first act is to download the entire model
+   * through the app, so a check that ran after the fetch would still have
+   * pulled a quarter of a gigabyte across the office and only then given up.
+   * Uploads may now be five times what a browser can rebuild, so this is the
+   * guard on a hole the raised cap opened.
+   */
+  const tooLarge = fileSize > VIEWER_MAX_BYTES;
+
   useEffect(() => {
+    if (tooLarge) return;
     const el = host.current;
     if (!el) return;
 
@@ -264,7 +281,11 @@ export function ModelViewer({
       cleanupInput?.();
       renderer?.dispose?.();
     };
-  }, [storyId, filename, colorHex]);
+  }, [storyId, filename, colorHex, tooLarge]);
+
+  if (tooLarge) {
+    return <TooLargeToPreview fileSize={fileSize} />;
+  }
 
   return (
     <div className="relative overflow-hidden rounded-panel border-[3px] border-ink bg-cream-2 shadow-stamp-lg">
@@ -302,6 +323,79 @@ export function ModelViewer({
           drag to rotate · {filename}
         </p>
       )}
+    </div>
+  );
+}
+
+/**
+ * What the viewer says instead of hanging.
+ *
+ * Two jobs, and the second is the one usually skipped. It has to say *why*
+ * nothing is loading — otherwise a blank panel on a perfectly good file reads
+ * as a broken app — and it has to give the size some meaning. "180 MB" is a
+ * number; "three and a half times what a browser can rotate" is an answer, and
+ * the bars make that true at a glance rather than on arithmetic.
+ *
+ * Amber rather than red: nothing has failed. The file is intact, it is stored,
+ * it will print. Only the preview is declined, and the two things that actually
+ * get the model onto a plate are both still there.
+ */
+function TooLargeToPreview({ fileSize }: { fileSize: number }) {
+  // The larger bar is the full width; the limit is drawn to scale against it.
+  const limitWidth = Math.max(4, (VIEWER_MAX_BYTES / fileSize) * 100);
+  const times = fileSize / VIEWER_MAX_BYTES;
+
+  return (
+    <div className="rounded-panel border-[3px] border-ink bg-sun-wash p-[22px] shadow-stamp-lg">
+      <p className="m-0 font-mono text-[11.5px] font-bold uppercase tracking-[0.12em] text-sun-dk">
+        Preview skipped
+      </p>
+      <h3 className="m-0 mt-[6px] font-display text-[21px] leading-[1.15] text-ink">
+        This one is too big to spin in a browser
+      </h3>
+      <p className="m-0 mt-[8px] max-w-[46ch] text-[14.5px] leading-[1.5] text-ink-2">
+        The viewer downloads the whole model and rebuilds every triangle of it
+        on this machine. At {formatBytes(fileSize)} that is a long download and
+        a tab that stops answering, so it is not started.
+      </p>
+
+      {/* The comparison. Drawn to scale, because the point is the gap. */}
+      <div className="mt-[17.6px] flex flex-col gap-[8px]">
+        <div>
+          <div className="mb-[3px] flex items-baseline justify-between gap-[8px]">
+            <span className="font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-ink-2">
+              A browser handles
+            </span>
+            <span className="font-mono text-[11.5px] font-bold text-ink">
+              {formatBytes(VIEWER_MAX_BYTES)}
+            </span>
+          </div>
+          <div aria-hidden className="h-[16px] overflow-hidden rounded-chip border-2 border-ink bg-cream">
+            <div className="h-full bg-aqua" style={{ width: `${limitWidth}%` }} />
+          </div>
+        </div>
+
+        <div>
+          <div className="mb-[3px] flex items-baseline justify-between gap-[8px]">
+            <span className="font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-ink-2">
+              This model
+            </span>
+            <span className="font-mono text-[11.5px] font-bold text-cherry-dk">
+              {formatBytes(fileSize)} · {times.toFixed(1)}&times;
+            </span>
+          </div>
+          <div aria-hidden className="h-[16px] overflow-hidden rounded-chip border-2 border-ink bg-cream">
+            <div className="h-full w-full bg-cherry" />
+          </div>
+        </div>
+      </div>
+
+      <p className="m-0 mt-[17.6px] border-t-2 border-dashed border-ink-3 pt-[11px] text-[13.5px] leading-[1.5] text-ink-2">
+        Nothing is wrong with the file. It is stored whole and it prints exactly
+        as it would have. <strong>Download</strong> and{" "}
+        <strong>Open in PrusaSlicer</strong> both work on it — a slicer is built
+        for meshes this size and a browser is not.
+      </p>
     </div>
   );
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,20 +1,28 @@
 /**
  * Validation and measurement of uploaded model files.
  *
- * The handoff asks for extension and magic-byte validation, a 50 MB cap, and
- * a parse pass that fills in the displayed meta. Everything here runs on the
+ * The handoff asks for extension and magic-byte validation, a size cap, and a
+ * parse pass that fills in the displayed meta. Everything here runs on the
  * server against the bytes that actually arrived — a filename is a claim, not
  * evidence.
+ *
+ * The numbers themselves live in `upload-limits.ts`, because the upload form
+ * needs the same ones and cannot import this module without dragging `fflate`
+ * into the browser bundle.
  */
 import { unzipSync } from "fflate";
 
-export const MAX_BYTES = 50 * 1024 * 1024; // 50 MB, per the handoff
-export const ACCEPTED_EXTENSIONS = [".stl", ".3mf"] as const;
+import {
+  ACCEPTED_EXTENSIONS,
+  MAX_INFLATED_BYTES,
+  MAX_TRIANGLES,
+  MAX_UPLOAD_BYTES,
+  formatBytes,
+} from "@/lib/upload-limits";
 
-/** Refuse absurd meshes before allocating for them. */
-const MAX_TRIANGLES = 8_000_000;
-/** A 3MF is a zip; cap what we are willing to inflate (zip-bomb guard). */
-const MAX_INFLATED_BYTES = 300 * 1024 * 1024;
+/** Re-exported so existing callers keep one import to reach for. */
+export { ACCEPTED_EXTENSIONS, formatBytes };
+export const MAX_BYTES = MAX_UPLOAD_BYTES;
 
 export type ModelFormat = "stl" | "3mf";
 
@@ -28,7 +36,7 @@ export type Rejection =
 
 export const REJECTION_COPY: Record<Rejection, string> = {
   empty: "That file is empty.",
-  too_large: "That file is over 50 MB. Decimate the mesh and try again.",
+  too_large: `That file is over ${formatBytes(MAX_UPLOAD_BYTES)}.`,
   bad_extension: "Only .stl and .3mf files can be printed here.",
   not_a_model:
     "That does not look like an STL or 3MF inside, whatever it is named.",
@@ -369,12 +377,6 @@ function measure3mf(bytes: Uint8Array): { box: Box; triangles: number } | null {
 // ---------------------------------------------------------------------------
 // Presentation
 // ---------------------------------------------------------------------------
-
-export function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 /*
  * There is deliberately no print-time estimate here.

--- a/src/lib/upload-limits.ts
+++ b/src/lib/upload-limits.ts
@@ -1,0 +1,87 @@
+/**
+ * How large and how complex an uploaded model may be.
+ *
+ * Its own module because both sides need it: `src/lib/models.ts` enforces these
+ * against the bytes that arrived, and the upload form checks the size in the
+ * browser before spending someone's wifi on a file that will be refused.
+ * Importing `models.ts` into a client component would drag `fflate` and the
+ * whole mesh parser into the browser bundle — which is why the form had grown
+ * its own copy of the limit, the extension list *and* `formatBytes`. Three
+ * rules stated twice are three rules that drift; raising the cap used to mean
+ * finding five places.
+ */
+
+/**
+ * 250 MB, up from the handoff's 50 MB.
+ *
+ * 50 MB was chosen for "a handful of people and one printer" and it held until
+ * people started bringing real work: multi-object plates and scanned meshes go
+ * past it easily, and the app's answer was "decimate the mesh", which is asking
+ * someone to damage their model to fit an arbitrary number.
+ *
+ * The number is not free, and what it costs is memory rather than disk — see
+ * `MAX_CONCURRENT_UPLOADS` below, which is what keeps that bounded. If a
+ * deployment has less RAM than this assumes, this is the line to lower.
+ */
+export const MAX_UPLOAD_BYTES = 250 * 1024 * 1024;
+
+/**
+ * A 3MF is a zip, and the interesting attack is a small file that inflates
+ * enormously. Scaled off the byte cap rather than fixed, so raising one does
+ * not silently leave the other behind: a legitimate 3MF compresses several
+ * times over, and three is a generous allowance for real geometry while still
+ * refusing anything shaped like a bomb.
+ */
+export const MAX_INFLATED_BYTES = 3 * MAX_UPLOAD_BYTES;
+
+/**
+ * "Complex" has its own ceiling, separate from file size.
+ *
+ * Eight million triangles is an enormous mesh — most printable models are
+ * under one. It does not bind for a binary STL at the current byte cap (250 MB
+ * is about 5.2M triangles at 50 bytes each), so in practice this catches a
+ * 3MF that claims far more geometry than its size suggests.
+ */
+export const MAX_TRIANGLES = 8_000_000;
+
+/**
+ * How many uploads may be inspected at once.
+ *
+ * This is the control that makes the cap above safe rather than hopeful. The
+ * request body is buffered before any of this app's code runs, so peak memory
+ * is set by how many large uploads are in flight — not by anything the
+ * validator does. Two at a time bounds it; a third waits its turn rather than
+ * being refused, because someone who has just spent a minute uploading 200 MB
+ * should not be told to start again.
+ *
+ * The audit named this: "a streaming parse, or a size-based queue, is the
+ * answer then". This is the queue. The streaming parse is a larger change and
+ * is written up in docs/architecture.md.
+ */
+export const MAX_CONCURRENT_UPLOADS = 2;
+
+/** How many may be waiting for a slot before the app says no. */
+export const MAX_QUEUED_UPLOADS = 6;
+
+/**
+ * The ceiling on the whole request, as opposed to the file inside it.
+ *
+ * A multipart body is the file plus boundaries plus the wish fields, so a
+ * legitimately maximum-sized model arrives as a slightly larger request. Both
+ * the transport limit and the app's own cheap content-length check use this,
+ * and they have to be the *same* number: when the transport cut off at exactly
+ * `MAX_UPLOAD_BYTES`, a file just over the cap had its body truncated and the
+ * uploader was told the upload "did not arrive intact" instead of that the file
+ * was too big. The transport has to be the more generous of the two so the
+ * app's own check is the one that answers.
+ */
+export const MAX_REQUEST_BYTES = Math.ceil(MAX_UPLOAD_BYTES * 1.2);
+
+export const ACCEPTED_EXTENSIONS = [".stl", ".3mf"] as const;
+
+/** Bytes as a person would say them. Shared so the form and the API agree. */
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/lib/upload-limits.ts
+++ b/src/lib/upload-limits.ts
@@ -77,6 +77,22 @@ export const MAX_QUEUED_UPLOADS = 6;
  */
 export const MAX_REQUEST_BYTES = Math.ceil(MAX_UPLOAD_BYTES * 1.2);
 
+/**
+ * The largest model the in-browser viewer will attempt.
+ *
+ * Not a limit on what may be uploaded — it is a limit on what a laptop can be
+ * asked to rebuild. The viewer downloads the whole file and hands it to a
+ * loader that expands it into typed arrays: a binary STL is about a million
+ * triangles at this size, and roughly 36 bytes of buffer per triangle once
+ * parsed. Past here the tab stops responding for long enough that people
+ * assume the app is broken, which is a worse outcome than not previewing.
+ *
+ * It is the old upload cap, which is a coincidence worth naming: 50 MB was
+ * always about what a browser could cope with, even when it was written down
+ * as what the server would accept.
+ */
+export const VIEWER_MAX_BYTES = 50 * 1024 * 1024;
+
 export const ACCEPTED_EXTENSIONS = [".stl", ".3mf"] as const;
 
 /** Bytes as a person would say them. Shared so the form and the API agree. */


### PR DESCRIPTION
Step 1 of the staged upload plan. It found a standing bug on the way.

## Uploads over 10 MB never worked

Next truncates a request body at **10 MB** whenever middleware is in play, and this app runs middleware on every route to mint the CSP nonce. So anything past 10 MB arrived short, `request.formData()` threw on the truncated body, and the person uploading was told:

> That upload did not arrive intact. Try again.

…which reads like a network fault, while the form and `docs/api.md` both promised **50 MB**.

| size | before |
|---|---|
| 1 MB | 200 |
| 5 MB | 200 |
| 20 MB | **400** — "did not arrive intact" |
| 60 MB | 413 — the honest cap, never reached in practice |

It survived the whole life of the app because **every fixture in every suite is a few hundred bytes** — nothing had ever uploaded a big file. Confirmed against `main` before changing anything, so this is a standing bug and not a regression; Next names it in the log once you look.

## The cap is now 250 MB

Real work went past 50 MB — multi-object plates, scanned meshes — and the app's answer was *"decimate the mesh"*, which is asking somebody to damage their model to fit an arbitrary number.

| | after |
|---|---|
| 114 MB | **200 accepted** |
| 257 MB (over cap) | **413** — *"That file is over 250.0 MB."* |
| 3 × 43 MB concurrent | **200, 200, 200** — serialised by the gate |

## One place for the numbers

`src/lib/upload-limits.ts`. The form had grown its own copy of the limit, the extension list **and** `formatBytes`, because importing `models.ts` into a client component would drag `fflate` into the browser bundle. Raising the cap used to mean finding five places; `next.config.ts` is a sixth.

`MAX_REQUEST_BYTES` is deliberately the more generous of the two ceilings — multipart adds boundaries and the wish fields, and when the transport cut off at exactly the file cap, a file just over it was truncated into a parse error instead of an honest 413. That is the difference between the third row of the table above saying *413* and saying *400*.

## A queue, not a stream

`request.formData()` has read the whole body before this handler runs, so peak memory is set by how many large uploads **overlap** — nothing the validator does can change it. At most two are handled at once; a third waits rather than being refused, because somebody who has just spent a minute pushing 200 MB up office wifi should not be told to start again. Only a long queue gets a `503`.

That is one of the two answers the security audit named. The other — a streaming parse — needs the file to stop arriving as multipart at all (a raw body with the wish in a header, or a two-phase upload), because by the time a route handler can see the request the framework has already buffered it. Written up in `docs/architecture.md` rather than pretended about.

## Verification

`verify:upload` now sends a **12 MB** model on every run and asserts it is stored at full size — the cheapest thing that would have caught this. 70 → **72**.

Everything else green: models 32, queue 109, api 100, frr 70, benefits 19, auth all, and 103 probes.

## After merging

Behind a reverse proxy, `client_max_body_size` needs raising to `300m` — `docs/deployment.md` has the NPM steps. That had never bitten before because nothing large enough had ever reached the proxy.
