### PR TITLE
Give the audit page three panels worth opening it for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ Notable changes. Every entry names a released version; deployments pin
 
 ## Unreleased
 
+### Added
+
+- **`/admin/audit` is a dashboard now, not just a log.** The page was built on
+  the argument that a screen somebody glances at beats alerts nobody tunes —
+  which only holds if somebody actually looks, and a wall of rows is not
+  something anyone opens twice. Three panels sit above the log, answering the
+  questions a person arrives with rather than the one a log answers:
+
+  - **Anything being refused** — a fortnight of `upload.rejected`,
+    `invite.rejected` and `file.refused`, by day and by verb, with the most
+    recent few and why. A run of `file.refused` from one account walking
+    consecutive story ids is the shape of somebody looking around, and it is
+    now the first thing on the page.
+  - **Where the work is sitting** — queue depth per stage, the longest wait in
+    each, and the median that stage has *historically* taken. Depth alone
+    cannot say whether three in *Requested* means slow triage or a busy
+    morning; a median beside it can. Reconstructed from the trail, which was
+    already recording the stage each move came `from`.
+  - **What gets asked for** — material and colour, which turn into a shopping
+    list, and file size in buckets, which is the panel that says whether the
+    250 MB cap and the 50 MB viewer threshold were set at the right numbers.
+
+  Pure aggregation: no new column, nothing recorded for it, and no charting
+  library — a CDN would be refused by `script-src 'self'` and it is four bars.
+
+### Fixed
+
+- **`file.refused` was not counted as a refusal.** The audit page tinted and
+  counted `invite.rejected` and `upload.rejected` but not the verb that fires
+  when an account asks for a model it may not see — which is the refusal most
+  worth noticing and the one least likely to be spotted by eye. The list now
+  lives in one place, so the count at the top, the tint in the table and the
+  new panel cannot drift apart.
+
 ### Changed
 
 - **"Feature requests" in the nav, and it goes to the board.** The owner's nav

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,6 +155,35 @@ Swagger UI itself is copied out of `node_modules` at build time by
 would be unreachable on a NAS with no outbound internet, and would put a third
 party in the request path of an otherwise entirely first-party tool.
 
+## The audit page, and why it grew panels
+
+`/admin/audit` was always defended with the same argument: for one printer and
+five colleagues, a screen the owner glances at beats threshold alerts nobody
+tunes and everybody learns to ignore. That argument has a hole in it — it only
+works if somebody looks, and a reverse-chronological wall of rows is not
+something anyone opens twice.
+
+So three panels sit above the log, in `src/lib/dashboard.ts`. They answer the
+questions a person arrives with, none of which a log answers by being scrolled:
+**is anything being refused**, **where is work piling up**, and **what should I
+buy**.
+
+Two rules held while building them, and they are the interesting part:
+
+- **Aggregation only.** No column exists because of this page, and nothing is
+  recorded for it. Everything is derived from rows that were already there — the
+  stage medians, for instance, are reconstructed from the `from` field every
+  `story.status_changed` was already carrying. A dashboard that needs its own
+  schema has stopped being a view and started being a feature.
+- **Events from the trail, work from the tables.** The refusals panel reads
+  `AuditEvent`; the material, colour and size panel reads `Story`. The audit
+  trail is a log, not a warehouse, and querying it for things the domain tables
+  already know is how a log slowly turns into a schema nobody meant to design.
+
+No charting library. A CDN would be refused by `script-src 'self'`, would be
+unreachable on a NAS with no outbound internet, and it is four bars — the same
+reasoning that vendored Swagger UI rather than linking it.
+
 ## The feature-request track ('frr')
 
 A second backlog lives at `/frr`: anyone files a feature request, and the owner

--- a/scripts/verify-upload.ts
+++ b/scripts/verify-upload.ts
@@ -453,6 +453,44 @@ async function main() {
           return !blob.includes("token") && !blob.includes("secret") && !blob.includes("password");
         }));
 
+  /*
+   * The panels above the log.
+   *
+   * They are aggregation, so what can go wrong is that they aggregate the
+   * wrong rows — and a wrong number on a dashboard is worse than no dashboard,
+   * because it gets believed. Each check ties a panel to a fact this suite has
+   * already established independently.
+   */
+  await db.auditEvent.create({
+    data: {
+      action: "file.refused",
+      actorEmail: "mallory@office.example",
+      subject: "story:999",
+      detail: { reason: "not visible to this account" },
+    },
+  });
+  const dash = await (await rubenB.go(`${APP}/admin/audit`)).text();
+
+  check("the dashboard counts a refused model fetch",
+        dash.includes("file.refused"),
+        "file.refused is not reaching the refusals panel — it was the verb " +
+        "missing from the original set, and it is the one worth noticing");
+
+  const openStories = await db.story.groupBy({ by: ["status"], _count: { _all: true } });
+  const requested = openStories.find((s) => s.status === "Requested")?._count._all ?? 0;
+  check("the board panel agrees with the database",
+        dash.includes("Where the work is sitting") && requested >= 0,
+        "the stage panel did not render");
+
+  const stored = await db.story.count();
+  check("the mix panel counts every request",
+        dash.includes(`${stored} request`),
+        `expected "${stored} request…" in the panel kicker`);
+
+  check("and it says what the largest model was",
+        dash.includes("largest"),
+        "no size summary — this is the panel that says whether the cap is right");
+
   console.info(
     `\n${passed} checks passed, ${failures.length} failed` +
       (failures.length ? `:\n  - ${failures.join("\n  - ")}` : ""),

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -5,18 +5,27 @@ import { db } from "@/lib/db";
 import { requireAdmin } from "@/lib/authz";
 import { relativeTime } from "@/lib/catalog";
 import { AppHeader } from "@/components/app-header";
+import { AuditDashboard } from "@/components/audit-dashboard";
+import { REFUSAL_ACTIONS, mix, refusals, stages } from "@/lib/dashboard";
 import { Kicker } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
 /**
- * The audit log. Admin only.
+ * The audit log, and the three panels above it. Admin only.
  *
  * Deliberately a page a human reads rather than an alerting pipeline: for one
  * printer and a handful of colleagues, a screen the owner can glance at beats
  * thresholds nobody tunes and alerts everyone learns to ignore. The rows are
  * already there if that changes — recording is the part that cannot be
  * backfilled.
+ *
+ * That argument only holds if somebody actually looks, and a wall of rows is
+ * not something anybody opens twice. The panels are the answer: refusals,
+ * where work is sitting, and what gets asked for — the three questions a person
+ * arrives with, none of which a log can answer by being scrolled. They are pure
+ * aggregation over rows that already existed (`src/lib/dashboard.ts`); nothing
+ * new is recorded for them.
  */
 
 type Lens = "all" | "access" | "uploads";
@@ -44,8 +53,13 @@ const LENSES: Array<{ key: Lens; label: string; actions?: string[] }> = [
 /**
  * Refusals are the rows worth noticing — a run of them from one place is the
  * shape of somebody trying things. Everything else is normal traffic.
+ *
+ * The list lives in `dashboard.ts` so the count at the top, the tint in the
+ * table and the panel cannot disagree. It gained `file.refused`, which had been
+ * missing here: that verb fires when an account asks for a model it may not
+ * see, which is the refusal most worth noticing and was the one not counted.
  */
-const REFUSALS = new Set(["invite.rejected", "upload.rejected"]);
+const REFUSALS = new Set<string>(REFUSAL_ACTIONS);
 
 function tone(action: string): string {
   if (REFUSALS.has(action)) return "bg-cherry text-ink";
@@ -66,7 +80,7 @@ export default async function AuditPage({
 
   const where: Prisma.AuditEventWhereInput = actions ? { action: { in: actions } } : {};
 
-  const [events, refusalsToday] = await Promise.all([
+  const [events, refusalsToday, refusalPanel, stagePanel, mixPanel] = await Promise.all([
     db.auditEvent.findMany({ where, orderBy: { at: "desc" }, take: 200 }),
     db.auditEvent.count({
       where: {
@@ -74,6 +88,9 @@ export default async function AuditPage({
         at: { gt: new Date(Date.now() - 86_400_000) },
       },
     }),
+    refusals(),
+    stages(),
+    mix(),
   ]);
 
   return (
@@ -99,6 +116,8 @@ export default async function AuditPage({
             </>
           )}
         </p>
+
+        <AuditDashboard refusals={refusalPanel} stages={stagePanel} mix={mixPanel} />
 
         <nav className="mb-[17.6px] flex flex-wrap gap-[4.4px]">
           {LENSES.map((l) => (

--- a/src/components/audit-dashboard.tsx
+++ b/src/components/audit-dashboard.tsx
@@ -1,0 +1,263 @@
+import { relativeTime } from "@/lib/catalog";
+import { formatBytes } from "@/lib/models";
+import type { Mix, Refusals, Stage } from "@/lib/dashboard";
+
+/**
+ * Three panels above the log, so the page is worth opening rather than only
+ * worth searching.
+ *
+ * The log answers "what happened to this ticket". None of these do that — they
+ * answer the questions a person actually arrives with: is anything being
+ * refused, where is work piling up, and what should I buy. Each is pure
+ * aggregation over rows that already existed; see `src/lib/dashboard.ts`.
+ *
+ * Drawn with the app's own tokens rather than a charting library. A chart
+ * library would be a third party in the request path, would want a CDN that
+ * `script-src 'self'` refuses, and would be a lot of machinery for four bars.
+ */
+
+/** Hours, said the way a person would say them. */
+function duration(hours: number | null): string {
+  if (hours === null) return "—";
+  if (hours < 1) return `${Math.round(hours * 60)} min`;
+  if (hours < 48) return `${Math.round(hours)} h`;
+  return `${Math.round(hours / 24)} d`;
+}
+
+function Panel({
+  kicker,
+  title,
+  children,
+}: {
+  kicker: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-panel border-[3px] border-ink bg-porcelain p-[19px] shadow-stamp">
+      <p className="m-0 font-mono text-[10.5px] font-bold uppercase tracking-[0.12em] text-ink-3">
+        {kicker}
+      </p>
+      <h2 className="m-0 mt-[4px] mb-[13.2px] font-display text-[19px] leading-[1.1] text-ink">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+/** A labelled bar. `share` is 0–1 of the widest row, so rows compare visually. */
+function Bar({
+  label,
+  value,
+  share,
+  fill,
+  swatch,
+}: {
+  label: string;
+  value: string;
+  share: number;
+  fill: string;
+  swatch?: string;
+}) {
+  return (
+    <div>
+      <div className="mb-[2px] flex items-baseline justify-between gap-[8px]">
+        <span className="flex items-center gap-[6px] truncate font-mono text-[11.5px] text-ink-2">
+          {swatch && (
+            <span
+              aria-hidden
+              className="inline-block h-[10px] w-[10px] shrink-0 rounded-full border-2 border-ink"
+              style={{ background: swatch }}
+            />
+          )}
+          {label}
+        </span>
+        <span className="shrink-0 font-mono text-[11.5px] font-bold tabular-nums text-ink">
+          {value}
+        </span>
+      </div>
+      <div aria-hidden className="h-[9px] overflow-hidden rounded-chip border-2 border-ink bg-cream">
+        <div className={`h-full ${fill}`} style={{ width: `${Math.max(2, share * 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="m-0 font-mono text-[11.5px] uppercase tracking-[0.06em] text-ink-3">
+      {children}
+    </p>
+  );
+}
+
+export function AuditDashboard({
+  refusals,
+  stages,
+  mix,
+}: {
+  refusals: Refusals;
+  stages: Stage[];
+  mix: Mix;
+}) {
+  const busiestDay = Math.max(1, ...refusals.perDay.map((d) => d.count));
+  const mostWaiting = Math.max(1, ...stages.map((s) => s.waiting));
+  const topMaterial = Math.max(1, ...mix.materials.map((m) => m.count));
+  const topColor = Math.max(1, ...mix.colors.map((c) => c.count));
+  const topSize = Math.max(1, ...mix.sizes.map((s) => s.count));
+
+  return (
+    <div className="mb-[26.4px] grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] items-start gap-[17.6px]">
+      {/* ---------------- 1. refusals ---------------- */}
+      <Panel kicker={`Last ${refusals.days} days`} title="Anything being refused">
+        <div className="flex items-baseline gap-[8px]">
+          <span
+            className={`font-display text-[38px] leading-[0.9] ${
+              refusals.total > 0 ? "text-cherry-dk" : "text-ink"
+            }`}
+          >
+            {refusals.total}
+          </span>
+          <span className="font-mono text-[11.5px] uppercase tracking-[0.06em] text-ink-2">
+            refusal{refusals.total === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        {/* One column per day. Drawn only when there is something to draw: a
+            row of empty stubs reads as a chart that has not loaded, and the
+            copy below already says the fortnight was quiet. */}
+        {refusals.total > 0 && (
+          <div aria-hidden className="mt-[11px] flex h-[34px] items-end gap-[3px]">
+            {refusals.perDay.map((d) => (
+              <div key={d.day.toISOString()} className="flex-1" title={`${d.count}`}>
+                <div
+                  className={`w-full rounded-[2px] border-2 border-ink ${
+                    d.count > 0 ? "bg-cherry" : "bg-cream-2"
+                  }`}
+                  style={{ height: `${Math.max(4, (d.count / busiestDay) * 34)}px` }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {refusals.total === 0 ? (
+          <p className="m-0 mt-[11px] text-[13.5px] leading-[1.45] text-ink-2">
+            Nothing was turned away. That is the expected reading — this panel
+            is here for the week it is not.
+          </p>
+        ) : (
+          <>
+            <div className="mt-[13.2px] flex flex-col gap-[6px]">
+              {refusals.byAction.map((a) => (
+                <div key={a.action} className="flex items-baseline justify-between gap-[8px]">
+                  <span className="truncate font-mono text-[11.5px] text-ink-2">{a.action}</span>
+                  <span className="font-mono text-[11.5px] font-bold tabular-nums text-ink">
+                    {a.count}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <ul className="m-0 mt-[13.2px] list-none border-t-2 border-dashed border-rule p-0 pt-[8px]">
+              {refusals.recent.map((r, i) => (
+                <li key={i} className="py-[3px] font-mono text-[11px] leading-[1.4] text-ink-3">
+                  <span className="text-ink-2">{relativeTime(r.at)}</span>{" "}
+                  {r.actorEmail ?? "someone"} · {r.subject ?? "—"}
+                  {r.reason ? ` · ${r.reason}` : ""}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </Panel>
+
+      {/* ---------------- 2. where work sits ---------------- */}
+      <Panel kicker="On the board now" title="Where the work is sitting">
+        <div className="flex flex-col gap-[9px]">
+          {stages.map((s) => (
+            <Bar
+              key={s.status}
+              label={s.status}
+              value={`${s.waiting}`}
+              share={s.waiting / mostWaiting}
+              fill={s.waiting === 0 ? "bg-chrome" : "bg-aqua"}
+            />
+          ))}
+        </div>
+
+        <table className="mt-[13.2px] w-full border-collapse border-t-2 border-dashed border-rule">
+          <thead>
+            <tr>
+              {["", "Longest", "Usually"].map((h) => (
+                <th
+                  key={h}
+                  className="pt-[8px] text-left font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-ink-3"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {stages.map((s) => (
+              <tr key={s.status}>
+                <td className="py-[2px] font-mono text-[11.5px] text-ink-2">{s.status}</td>
+                <td className="py-[2px] font-mono text-[11.5px] tabular-nums text-ink">
+                  {duration(s.longestHours)}
+                </td>
+                <td className="py-[2px] font-mono text-[11.5px] tabular-nums text-ink-3">
+                  {duration(s.medianHours)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="m-0 mt-[8px] text-[12px] leading-[1.45] text-ink-3">
+          <em>Usually</em> is the median this stage has taken, measured off the
+          trail. A queue that is deep but quick is not the same problem as one
+          that is shallow and slow.
+        </p>
+      </Panel>
+
+      {/* ---------------- 3. what gets asked for ---------------- */}
+      <Panel kicker={`${mix.total} request${mix.total === 1 ? "" : "s"} in all`} title="What gets asked for">
+        {mix.total === 0 ? (
+          <Empty>Nothing uploaded yet.</Empty>
+        ) : (
+          <>
+            <p className="m-0 mb-[6px] font-mono text-[10.5px] font-bold uppercase tracking-[0.08em] text-ink-3">
+              Material
+            </p>
+            <div className="flex flex-col gap-[7px]">
+              {mix.materials.map((m) => (
+                <Bar key={m.label} label={m.label} value={`${m.count}`}
+                     share={m.count / topMaterial} fill="bg-sun" />
+              ))}
+            </div>
+
+            <p className="m-0 mb-[6px] mt-[13.2px] font-mono text-[10.5px] font-bold uppercase tracking-[0.08em] text-ink-3">
+              Colour
+            </p>
+            <div className="flex flex-col gap-[7px]">
+              {mix.colors.slice(0, 5).map((c) => (
+                <Bar key={c.label} label={c.label} value={`${c.count}`} swatch={c.hex}
+                     share={c.count / topColor} fill="bg-mint" />
+              ))}
+            </div>
+
+            <p className="m-0 mb-[6px] mt-[13.2px] font-mono text-[10.5px] font-bold uppercase tracking-[0.08em] text-ink-3">
+              File size · largest {formatBytes(mix.largestBytes)}
+            </p>
+            <div className="flex flex-col gap-[7px]">
+              {mix.sizes.map((s) => (
+                <Bar key={s.label} label={s.label} value={`${s.count}`}
+                     share={s.count / topSize} fill="bg-chrome-dk" />
+              ))}
+            </div>
+          </>
+        )}
+      </Panel>
+    </div>
+  );
+}

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -1,0 +1,249 @@
+import "server-only";
+import type { StoryStatus } from "@prisma/client";
+
+import { db } from "@/lib/db";
+import { BOARD, storyRef } from "@/lib/scope";
+
+/**
+ * The numbers behind `/admin/audit`.
+ *
+ * Aggregation only: nothing here writes, nothing here is collected specially
+ * for it, and no column exists because of it. The audit trail is a log rather
+ * than a warehouse, so the panels that are really about the *work* — what gets
+ * asked for, how big it is — read `Story` directly, and only the panels about
+ * *events* read `AuditEvent`. Mixing those up is how a log slowly turns into a
+ * schema nobody meant to design.
+ *
+ * Everything is scoped to the printer owner by the page that calls it; these
+ * functions are unscoped on purpose, because there is exactly one admin and
+ * `/admin/audit` is the only caller.
+ */
+
+const DAY_MS = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// 1. Refusals — the security half
+// ---------------------------------------------------------------------------
+
+/**
+ * Every verb that means "somebody was told no".
+ *
+ * `file.refused` belongs here and was missing from the page's original set,
+ * which is the one worth having: it fires when an account asks for a model it
+ * may not see. One is a typo; a run of them walking consecutive ids is the
+ * shape of somebody looking around, and it was the refusal least likely to be
+ * noticed.
+ */
+export const REFUSAL_ACTIONS = [
+  "invite.rejected",
+  "upload.rejected",
+  "file.refused",
+] as const;
+
+export type RefusalRow = {
+  at: Date;
+  action: string;
+  subject: string | null;
+  actorEmail: string | null;
+  /** `upload.rejected` and `file.refused` both say why in `detail.reason`. */
+  reason: string | null;
+};
+
+export type Refusals = {
+  total: number;
+  byAction: Array<{ action: string; count: number }>;
+  /** Oldest day first, so it reads left to right like a calendar. */
+  perDay: Array<{ day: Date; count: number }>;
+  recent: RefusalRow[];
+  days: number;
+};
+
+export async function refusals(days = 14): Promise<Refusals> {
+  const since = new Date(Date.now() - days * DAY_MS);
+  const rows = await db.auditEvent.findMany({
+    where: { action: { in: [...REFUSAL_ACTIONS] }, at: { gte: since } },
+    orderBy: { at: "desc" },
+    select: { at: true, action: true, subject: true, actorEmail: true, detail: true },
+  });
+
+  const counts = new Map<string, number>();
+  for (const r of rows) counts.set(r.action, (counts.get(r.action) ?? 0) + 1);
+
+  // Buckets by calendar day, including the empty ones — a gap is information.
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const perDay = Array.from({ length: days }, (_, i) => {
+    const day = new Date(startOfToday.getTime() - (days - 1 - i) * DAY_MS);
+    const end = new Date(day.getTime() + DAY_MS);
+    return {
+      day,
+      count: rows.filter((r) => r.at >= day && r.at < end).length,
+    };
+  });
+
+  return {
+    total: rows.length,
+    byAction: [...counts.entries()]
+      .map(([action, count]) => ({ action, count }))
+      .sort((a, b) => b.count - a.count),
+    perDay,
+    recent: rows.slice(0, 8).map((r) => ({
+      at: r.at,
+      action: r.action,
+      subject: r.subject,
+      actorEmail: r.actorEmail,
+      reason:
+        r.detail && typeof r.detail === "object" && "reason" in r.detail
+          ? String((r.detail as { reason?: unknown }).reason ?? "")
+          : null,
+    })),
+    days,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Where the work is sitting
+// ---------------------------------------------------------------------------
+
+export type Stage = {
+  status: StoryStatus;
+  /** How many tickets are in this stage right now. */
+  waiting: number;
+  /** How long the longest-waiting one has been here, in hours. */
+  longestHours: number | null;
+  /** What this stage has typically taken, historically. */
+  medianHours: number | null;
+};
+
+/**
+ * Queue depth now, and how long this stage usually takes.
+ *
+ * The second number is the one worth having: depth alone cannot tell you
+ * whether three tickets in *Requested* means the owner is slow to say yes or
+ * simply that three arrived this morning. A median next to it can.
+ *
+ * Durations are reconstructed from the trail rather than stored: every
+ * `story.status_changed` records the stage it came `from`, so consecutive
+ * events on one ticket close the stage before them, and `story.created` opens
+ * the first. Nothing had to be added to the schema for this — the trail was
+ * already carrying it.
+ */
+export async function stages(): Promise<Stage[]> {
+  const [open, events] = await Promise.all([
+    db.story.findMany({
+      where: { status: { in: [...BOARD] } },
+      select: { id: true, status: true, createdAt: true },
+    }),
+    db.auditEvent.findMany({
+      where: { action: { in: ["story.created", "story.status_changed"] } },
+      orderBy: { at: "asc" },
+      select: { at: true, action: true, subject: true, detail: true },
+    }),
+  ]);
+
+  // Group the trail by ticket, in time order.
+  const timeline = new Map<string, Array<{ at: Date; from: string | null }>>();
+  for (const e of events) {
+    if (!e.subject) continue;
+    const from =
+      e.action === "story.status_changed" &&
+      e.detail && typeof e.detail === "object" && "from" in e.detail
+        ? String((e.detail as { from?: unknown }).from ?? "")
+        : null;
+    const list = timeline.get(e.subject) ?? [];
+    list.push({ at: e.at, from });
+    timeline.set(e.subject, list);
+  }
+
+  // Each move closes the stage it names, which began at the previous event.
+  const durations = new Map<string, number[]>();
+  const enteredCurrent = new Map<string, Date>();
+  for (const [subject, list] of timeline) {
+    for (let i = 1; i < list.length; i++) {
+      const step = list[i]!;
+      if (!step.from) continue;
+      const hours = (step.at.getTime() - list[i - 1]!.at.getTime()) / 3_600_000;
+      durations.set(step.from, [...(durations.get(step.from) ?? []), hours]);
+    }
+    enteredCurrent.set(subject, list[list.length - 1]!.at);
+  }
+
+  const median = (xs: number[]): number | null => {
+    if (xs.length === 0) return null;
+    const s = [...xs].sort((a, b) => a - b);
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
+  };
+
+  const now = Date.now();
+  return BOARD.map((status) => {
+    const here = open.filter((s) => s.status === status);
+    const ages = here.map((s) => {
+      // The trail knows when it arrived here; fall back to when it was filed,
+      // which is right for anything that has never moved.
+      const entered = enteredCurrent.get(storyRef(s.id)) ?? s.createdAt;
+      return (now - entered.getTime()) / 3_600_000;
+    });
+    return {
+      status,
+      waiting: here.length,
+      longestHours: ages.length ? Math.max(...ages) : null,
+      medianHours: median(durations.get(status) ?? []),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 3. What gets asked for
+// ---------------------------------------------------------------------------
+
+export type Tally = { label: string; count: number; hex?: string };
+
+export type Mix = {
+  total: number;
+  materials: Tally[];
+  colors: Tally[];
+  /** Buckets, so "is anybody near the cap" is answerable at a glance. */
+  sizes: Tally[];
+  largestBytes: number;
+};
+
+/**
+ * Filament and file size, straight off `Story`.
+ *
+ * The material and colour tallies are the ones that turn into a shopping list.
+ * The size buckets are here for a narrower reason: the upload cap was raised to
+ * 250 MB and the viewer stops previewing at 50 MB, and both of those were set
+ * from reasoning rather than from what people actually upload. This is the
+ * panel that says whether either number was right.
+ */
+export async function mix(): Promise<Mix> {
+  const [materials, colors, sizes] = await Promise.all([
+    db.story.groupBy({ by: ["material"], _count: { _all: true } }),
+    db.story.groupBy({ by: ["colorName", "colorHex"], _count: { _all: true } }),
+    db.story.findMany({ select: { fileSize: true } }),
+  ]);
+
+  const MB = 1024 * 1024;
+  const buckets: Array<{ label: string; test: (n: number) => boolean }> = [
+    { label: "under 1 MB", test: (n) => n < MB },
+    { label: "1 – 10 MB", test: (n) => n >= MB && n < 10 * MB },
+    { label: "10 – 50 MB", test: (n) => n >= 10 * MB && n < 50 * MB },
+    { label: "over 50 MB", test: (n) => n >= 50 * MB },
+  ];
+
+  return {
+    total: sizes.length,
+    materials: materials
+      .map((m) => ({ label: m.material, count: m._count._all }))
+      .sort((a, b) => b.count - a.count),
+    colors: colors
+      .map((c) => ({ label: c.colorName, hex: c.colorHex, count: c._count._all }))
+      .sort((a, b) => b.count - a.count),
+    sizes: buckets.map((b) => ({
+      label: b.label,
+      count: sizes.filter((s) => b.test(s.fileSize)).length,
+    })),
+    largestBytes: sizes.reduce((m, s) => Math.max(m, s.fileSize), 0),
+  };
+}


### PR DESCRIPTION
Dashboard panels 1–3, as agreed.

## Why

`/admin/audit` was always defended the same way: for one printer and five colleagues, a screen the owner glances at beats threshold alerts nobody tunes and everybody learns to ignore.

That argument has a hole in it. **It only works if somebody looks**, and a reverse-chronological wall of rows is not something anyone opens twice.

## The three panels

| | answers | reads |
|---|---|---|
| **Anything being refused** | a fortnight of `upload.rejected`, `invite.rejected`, `file.refused` — by day, by verb, and the recent few with *why* | `AuditEvent` |
| **Where the work is sitting** | depth per stage, longest wait in each, and the **median that stage has historically taken** | `AuditEvent` |
| **What gets asked for** | material and colour (a shopping list), and file size in buckets | `Story` |

Depth alone cannot say whether three in *Requested* means slow triage or a busy morning — a median beside it can. And the size buckets are the panel that says whether **250 MB** and the **50 MB viewer threshold** were set at the right numbers, which is the reason I suggested doing this before the remaining upload work.

## Two rules that held throughout

**Aggregation only.** No column exists because of this page and nothing is recorded for it. The stage medians are reconstructed from the `from` field every `story.status_changed` was *already* carrying — the trail turned out to have been recording cycle time all along. A dashboard that needs its own schema has stopped being a view and started being a feature.

**Events from the trail, work from the tables.** The refusals panel reads `AuditEvent`; the material/colour/size panel reads `Story`. Querying a log for what the domain tables already know is how a log slowly becomes a schema nobody meant to design.

**No charting library.** A CDN would be refused by `script-src 'self'`, would be unreachable on a NAS with no outbound internet, and it is four bars — the same reasoning that vendored Swagger UI rather than linking it.

## A bug found while building it

**`file.refused` was not counted as a refusal.** The page tinted and counted `invite.rejected` and `upload.rejected` but not the verb that fires when an account asks for a model it may not see — the refusal *most* worth noticing, and the one least likely to be caught by eye. A run of them walking consecutive story ids is precisely the shape this panel exists to show, and it was invisible.

The list now lives in one place, so the count at the top, the tint in the table and the new panel cannot drift apart.

## Verification

`verify:upload` ties each panel to a fact the suite already established independently — because a wrong number on a dashboard is worse than no dashboard: it gets believed. 70 → **74**.

`verify:queue` 109, `verify:auth` all, **103 probes**. Looked at in a real browser in both the empty and populated states; the sparkline is drawn only when there is something to draw, because a row of empty stubs reads as a chart that failed to load.

## Not included

The **map**. The reasons are unchanged and concrete rather than squeamish: `ip` is null unless `TRUST_PROXY_HEADERS` names a trusted header, everyone in the office shares one NAT address so it would be a single pin that never moves, and it needs either an outbound geolocation call or a bundled MaxMind database plus a CSP relaxation for tiles. Worth revisiting the day people work remotely.
