### PR TITLE
Bring the docs level with what has actually shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,13 @@ that: there is no multi-tenancy, no billing, and no queue theory.
 - **Open a model straight in PrusaSlicer** — one click on a ticket hands the
   model to a slicer running on your own machine. A small helper the printer
   owner installs once does the fetch, because PrusaSlicer's own deep link
-  refuses any host but Printables. See **[Open in PrusaSlicer](docs/prusaslicer.md)**.
+  refuses any host but Printables. The link carries its own short-lived
+  credential, so nothing secret sits in the helper's config.
+  See **[Open in PrusaSlicer](docs/prusaslicer.md)**.
+- **Or just take the file** — a plain download on every ticket, for a machine
+  without the helper, a phone, or a slicer that is not PrusaSlicer. Same
+  permissions as the ticket, and recorded when the bytes go to somebody other
+  than the person who uploaded them.
 
 ## Requirements
 
@@ -377,10 +383,22 @@ has no outbound internet, set `HIBP_DISABLED=true` — and only then.
 Invite-only enforced in one hook across every authentication method. Passwords
 are ≥10 characters and refused if they appear in a known breach corpus.
 Authorisation answers **404, not 403**, for a resource you may not see — a 403
-confirms it exists. Session cookies are `HttpOnly`, `SameSite=Lax` and
-`__Secure-` prefixed, with cookie caching deliberately off so sign-out is
-immediate. CSP carries a per-request nonce. Every access and content change is
-audited.
+confirms it exists. CSP carries a per-request nonce. Every access and content
+change is audited.
+
+Session cookies are `HttpOnly`, `SameSite=Lax` and `__Secure-` prefixed, with
+cookie caching deliberately off so sign-out is immediate. A session is worth
+**twenty idle minutes**, not a month: the window used to renew itself on every
+visit, which meant a captured cookie on a shared desk was good more or less
+indefinitely. Twenty minutes is only humane because passkeys are here, and
+signing back in is a touch.
+
+Shortening it limits how long a stolen cookie is useful but not whether it is
+useful *now*, so the four actions that outlive a session — inviting somebody,
+re-sending an invitation, minting a password-reset link, revoking or restoring
+access — ask for the passkey or the password again if the current sign-in is
+more than five minutes old. That is the one control on the list a copied cookie
+cannot satisfy.
 
 The full assessment, including what was found and fixed and what is knowingly
 accepted, is in [docs/security-audit.md](docs/security-audit.md). To report

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ npm run verify:frr            # the feature-request track (file, triage, the flo
 npm run verify:benefits       # the owner-managed benefits (tip) catalogue
 npm run verify:api            # the JSON API, the OpenAPI document and the console
 npm run verify:passkey        # WebAuthn ceremonies in a real browser
-npm run probe:security        # 91 OWASP-mapped security probes
+npm run probe:security        # 103 OWASP-mapped security probes
 ```
 
 ## Verifying it

--- a/docs/feature-requests.md
+++ b/docs/feature-requests.md
@@ -23,10 +23,15 @@ notifications and audit trail a print goes through. It lives at **`/frr`**.
 
 ## For the owner
 
-- **`/frr/queue`** — triage. *Waiting on you* (still `Requested`) comes first,
-  ordered high-priority first; everything in flight is a list with one control
-  each. The same **filter bar** (priority / status / category) narrows the
-  view. Owner-only — a client gets a 404, exactly like the print queue.
+- **`/frr/queue`** — triage, reached by the **Triage** button on `/frr`.
+  *Waiting on you* (still `Requested`) comes first, ordered high-priority
+  first; everything in flight is a list with one control each. The same
+  **filter bar** (priority / status / category) narrows the view. Owner-only —
+  a client gets a 404, exactly like the print queue.
+
+  The nav points at the board rather than here, for both roles: the board is
+  the shared view of everything asked for, and triage is a step off it. That
+  mirrors the print track, where *The rail* and *The pass* sit side by side.
 - Move a request one step at a time: **Requested → Accepted → In progress →
   Shipped → Done**, or **Decline** it (terminal, and only from `Requested`).
   Every move notifies the requester and writes an audit row.


### PR DESCRIPTION
Documentation only. Three claims on `main` that merged work had left behind.

| file | was | now |
|---|---|---|
| `docs/development.md` | *"91 OWASP-mapped security probes"* | **103** |
| `README.md` — features | PrusaSlicer bridge only | plain **Download** bullet added beside it |
| `README.md` — Security | cookie flags only | **20-minute session** and **re-auth on access-moving actions** |
| `docs/feature-requests.md` | `/frr/queue` described with no route in | says it is reached by the **Triage** button |

## Why these three

**The probe count** is stated in three files and this was the one nobody updated — it has been 103 since the session work and the slicer link credential each added their own.

**The download** shipped beside the PrusaSlicer bridge but never reached the feature list, which is where someone learns what the app does. Anyone reading it would not have known a plain download existed. The slicer bullet also now says the link carries its own credential, since *"a small helper the printer owner installs once"* no longer implies a token on disk.

**The Security section** predated the largest security change it has to summarise. It described cookie flags and said nothing about the window coming down from a renewing month to twenty idle minutes, or about the four access-moving actions asking for the passkey or password again. Both are documented in the audit and in `docs/authentication.md` — the summary a person reads *first* had neither.

## Deliberately left alone

Everything else that still names thirty days or `PPP_TOKEN`:

- `docs/prusaslicer.md` — the *"if you set this up before"* migration note
- `docs/authentication.md` — *"It used to be thirty days"*, which is history and reads correctly
- `CHANGELOG.md` — the record
- `SECURITY.md` — an unrelated 30-day response window

## Not in scope

`#45` and `#46` carry their own doc changes on their branches (the 250 MB cap, the viewer threshold, the proxy `client_max_body_size` note, the dashboard). This PR only fixes what is already untrue on `main`.

`check:links` and `check:secrets` clean; no code touched.
